### PR TITLE
refactor: remove webview store panel removal

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -240,6 +240,8 @@ This file is the high-level index for the per-feature plan structure in
   document-based panel lookup path is removed from both store and callers.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
+- WebviewMediator cleanup now removes store entries by URI directly, allowing
+  WebviewStore to drop its last panel-based reverse-lookup helper.
 - repeatable web-extension verification exists via `npm run test:web`.
 
 ### Next Priority Tasks

--- a/src/extension/webview/WebviewMediator.ts
+++ b/src/extension/webview/WebviewMediator.ts
@@ -6,7 +6,7 @@ import { mountViewerPanel } from "./mountViewerPanel";
 
 type WebviewMediatorStore = Pick<
   WebviewStore,
-  "allPanels" | "dispose" | "panelByUri" | "removeByPanel"
+  "allPanels" | "dispose" | "panelByUri" | "removeByUri"
 >;
 
 type DocumentChangeHandler = (
@@ -100,7 +100,7 @@ export class WebviewMediator implements vscode.Disposable {
     if (panel === undefined) {
       return;
     }
-    this.removeAndDisposePanel(panel);
+    this.removeAndDisposePanel(document.uri, panel);
   }
 
   private onDidRenameFiles(event: vscode.FileRenameEvent): void {
@@ -112,7 +112,7 @@ export class WebviewMediator implements vscode.Disposable {
       );
       const panel = this.#store.panelByUri(file.oldUri);
       if (panel !== undefined) {
-        this.removeAndDisposePanel(panel);
+        this.removeAndDisposePanel(file.oldUri, panel);
       }
     });
   }
@@ -125,8 +125,11 @@ export class WebviewMediator implements vscode.Disposable {
     });
   }
 
-  private removeAndDisposePanel(panel: vscode.WebviewPanel): void {
-    this.#store.removeByPanel(panel);
+  private removeAndDisposePanel(
+    uri: vscode.Uri,
+    panel: vscode.WebviewPanel,
+  ): void {
+    this.#store.removeByUri(uri);
     panel.dispose();
   }
 }

--- a/src/extension/webview/WebviewStore.ts
+++ b/src/extension/webview/WebviewStore.ts
@@ -31,17 +31,6 @@ export class WebviewStore implements vscode.Disposable {
     this.prettyPrint();
   }
 
-  removeByPanel(panel: vscode.WebviewPanel): void {
-    console.log(
-      `invoke WebviewStore.removeByPanel. (${this.#viewType}, ${panel.title})`,
-    );
-    const key = this.keyByPanel(panel);
-    if (key) {
-      this.deleteByKey(key);
-    }
-    this.prettyPrint();
-  }
-
   panelByUri(uri: vscode.Uri): vscode.WebviewPanel | undefined {
     console.log(
       `invoke WebviewStore.panelByUri. (${this.#viewType}, ${uri.toString()})`,
@@ -73,14 +62,5 @@ export class WebviewStore implements vscode.Disposable {
 
   private keyByUri(uri: vscode.Uri): string {
     return uri.toString();
-  }
-
-  private keyByPanel(panel: vscode.WebviewPanel): string | undefined {
-    for (const [key, value] of this.#mapPanel.entries()) {
-      if (value === panel) {
-        return key;
-      }
-    }
-    return undefined;
   }
 }

--- a/src/test/suite/webviewMediator.test.ts
+++ b/src/test/suite/webviewMediator.test.ts
@@ -8,7 +8,7 @@ type Listener<T> = (event: T) => void;
 
 suite("WebviewMediator", () => {
   test("routes close, rename, and theme events through focused handlers", () => {
-    const removedByPanel: string[] = [];
+    const removedByUri: string[] = [];
     const mounted: string[] = [];
     const changed: string[] = [];
     let storeDisposed = false;
@@ -52,8 +52,8 @@ suite("WebviewMediator", () => {
             ? panel
             : undefined;
         },
-        removeByPanel(receivedPanel) {
-          removedByPanel.push(receivedPanel.title);
+        removeByUri(receivedUri) {
+          removedByUri.push(receivedUri.toString());
         },
         allPanels: new Set([panel]),
         dispose() {
@@ -95,7 +95,10 @@ suite("WebviewMediator", () => {
     mediator.dispose();
 
     assert.deepStrictEqual(changed, ["file:///sample.ajs"]);
-    assert.deepStrictEqual(removedByPanel, ["sample", "sample"]);
+    assert.deepStrictEqual(removedByUri, [
+      "file:///sample.ajs",
+      "file:///sample.ajs",
+    ]);
     assert.deepStrictEqual(mounted, ["ajsbutler.testViewer"]);
     assert.strictEqual(panelDisposed, true);
     assert.strictEqual(storeDisposed, true);

--- a/src/test/suite/webviewStore.test.ts
+++ b/src/test/suite/webviewStore.test.ts
@@ -36,7 +36,7 @@ suite("WebviewStore", () => {
     store.removeByUri(document1.uri);
     assert.strictEqual(store.panelByUri(document1.uri), undefined);
 
-    store.removeByPanel(panel2);
+    store.removeByUri(document2.uri);
     assert.strictEqual(store.panelByUri(document2.uri), undefined);
 
     store.add(document1.uri, panel1);


### PR DESCRIPTION
## Summary
- remove panel-based WebviewStore cleanup and reverse lookup
- let WebviewMediator remove store entries by URI directly for close and rename flows
- update tests and plans for the narrower store contract

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build