### PR TITLE
refactor: decouple webview store types

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -238,6 +238,9 @@ This file is the high-level index for the per-feature plan structure in
   parallel document map no longer served any live lookup path.
 - WebviewStore callers now resolve panels by URI only, so the last
   document-based panel lookup path is removed from both store and callers.
+- viewer factory, mediator, and message-routing contracts now describe the
+  minimal store surface locally instead of importing `WebviewStore` just to
+  slice its type with `Pick`.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
 - WebviewMediator cleanup now removes store entries by URI directly, allowing

--- a/src/extension/webview/ViewerFactory.ts
+++ b/src/extension/webview/ViewerFactory.ts
@@ -5,13 +5,13 @@ import {
   createViewerMessageHandler,
   registerViewerPanelDispose,
 } from "./viewerMessageRouting";
-import { WebviewStore } from "./WebviewStore";
 import { MyExtension } from "../MyExtension";
 
-type ViewerFactoryStore = Pick<
-  WebviewStore,
-  "add" | "panelByUri" | "removeByUri"
->;
+type ViewerFactoryStore = {
+  add(uri: vscode.Uri, panel: vscode.WebviewPanel): void;
+  panelByUri(uri: vscode.Uri): vscode.WebviewPanel | undefined;
+  removeByUri(uri: vscode.Uri): void;
+};
 
 type ViewerFactoryDeps = {
   createWebviewPanel: typeof vscode.window.createWebviewPanel;

--- a/src/extension/webview/WebviewMediator.ts
+++ b/src/extension/webview/WebviewMediator.ts
@@ -1,13 +1,14 @@
 import * as vscode from "vscode";
-import { WebviewStore } from "./WebviewStore";
 import { MyExtension } from "../MyExtension";
 import { LANGUAGE_ID } from "../constant";
 import { mountViewerPanel } from "./mountViewerPanel";
 
-type WebviewMediatorStore = Pick<
-  WebviewStore,
-  "allPanels" | "dispose" | "panelByUri" | "removeByUri"
->;
+type WebviewMediatorStore = {
+  readonly allPanels: ReadonlySet<vscode.WebviewPanel>;
+  dispose(): void;
+  panelByUri(uri: vscode.Uri): vscode.WebviewPanel | undefined;
+  removeByUri(uri: vscode.Uri): void;
+};
 
 type DocumentChangeHandler = (
   document: vscode.TextDocument,

--- a/src/extension/webview/viewerMessageRouting.ts
+++ b/src/extension/webview/viewerMessageRouting.ts
@@ -8,7 +8,6 @@ import {
   type ResourceEventType,
   type WebviewEventType,
 } from "../../shared/webviewEvents";
-import { WebviewStore } from "./WebviewStore";
 
 type ViewerMessageRoutingDeps = {
   document: vscode.TextDocument;
@@ -66,7 +65,9 @@ type ViewerPanelDisposeDeps = {
   uri: vscode.Uri;
   panel: vscode.WebviewPanel;
   viewType: string;
-  store: Pick<WebviewStore, "removeByUri">;
+  store: {
+    removeByUri(uri: vscode.Uri): void;
+  };
   receiveMessageDispose: Pick<vscode.Disposable, "dispose">;
 };
 


### PR DESCRIPTION
## Summary
- replace WebviewStore Pick types with local viewer-side contracts
- keep ViewerFactory, WebviewMediator, and message routing focused on the store surface they actually use
- record the contract narrowing in plans

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build