### PR TITLE
refactor: remove viewer factory viewType api

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -241,6 +241,9 @@ This file is the high-level index for the per-feature plan structure in
 - viewer factory, mediator, and message-routing contracts now describe the
   minimal store surface locally instead of importing `WebviewStore` just to
   slice its type with `Pick`.
+- preview command wiring now owns `viewType` explicitly, so `ViewerFactory`
+  no longer exposes it as part of its public API just to support command
+  registration, mounting, and telemetry naming.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
 - WebviewMediator cleanup now removes store entries by URI directly, allowing

--- a/src/extension/bootstrap/viewerWiring.ts
+++ b/src/extension/bootstrap/viewerWiring.ts
@@ -43,7 +43,7 @@ const createViewerBundle = (
     saveHandler,
   );
 
-  return [mediator, registerPreviewCommand(factory, myExtension)];
+  return [mediator, registerPreviewCommand(viewType, factory, myExtension)];
 };
 
 export const createViewerSubscriptions = (

--- a/src/extension/commands/openPreviewCommand.ts
+++ b/src/extension/commands/openPreviewCommand.ts
@@ -3,7 +3,7 @@ import { MyExtension } from "../MyExtension";
 import { ViewerFactory } from "../webview/ViewerFactory";
 import { mountViewerPanel } from "../webview/mountViewerPanel";
 
-type PreviewPanelFactory = Pick<ViewerFactory, "viewType" | "getPanel">;
+type PreviewPanelFactory = Pick<ViewerFactory, "getPanel">;
 
 type OpenPreviewCommandDependencies = {
   getActiveEditor: () => vscode.TextEditor | undefined;
@@ -13,6 +13,7 @@ type OpenPreviewCommandDependencies = {
 };
 
 type ExecuteOpenPreviewCommandArgs = {
+  viewType: string;
   panelFactory: PreviewPanelFactory;
   deps: OpenPreviewCommandDependencies;
 };
@@ -31,10 +32,10 @@ const createDependencies = (
 });
 
 export const executeOpenPreviewCommand = ({
+  viewType,
   panelFactory,
   deps,
 }: ExecuteOpenPreviewCommandArgs): void => {
-  const viewType = panelFactory.viewType;
   const activeEditor = deps.getActiveEditor();
   if (!activeEditor) {
     void deps.showErrorMessage("No active editor found to open.");
@@ -52,10 +53,12 @@ export const executeOpenPreviewCommand = ({
 };
 
 export const openPreviewCommand = (
+  viewType: string,
   panelFactory: PreviewPanelFactory,
   myExtension: MyExtension,
 ): void => {
   executeOpenPreviewCommand({
+    viewType,
     panelFactory,
     deps: createDependencies(myExtension),
   });

--- a/src/extension/commands/registerPreviewCommand.ts
+++ b/src/extension/commands/registerPreviewCommand.ts
@@ -4,12 +4,12 @@ import { MyExtension } from "../MyExtension";
 import { openPreviewCommand } from "./openPreviewCommand";
 
 export const registerPreviewCommand = (
+  viewType: string,
   panelFactory: ViewerFactory,
   myExtension: MyExtension,
 ): vscode.Disposable => {
-  const viewType = panelFactory.viewType;
   console.log(`invoke registerPreview. (${viewType})`);
   return vscode.commands.registerCommand(`open.${viewType}`, () => {
-    openPreviewCommand(panelFactory, myExtension);
+    openPreviewCommand(viewType, panelFactory, myExtension);
   });
 };

--- a/src/extension/webview/ViewerFactory.ts
+++ b/src/extension/webview/ViewerFactory.ts
@@ -31,8 +31,8 @@ type ViewerReadyHandler = (
  * It ensures that only one panel exists for a given URI, reusing existing panels when possible.
  */
 export class ViewerFactory {
-  readonly viewType: string;
   #store: ViewerFactoryStore;
+  #viewType: string;
   #myExtension: MyExtension;
   #onReady: ViewerReadyHandler;
   #onSave?: (content: string) => Promise<void>;
@@ -46,7 +46,7 @@ export class ViewerFactory {
     onSave?: (content: string) => Promise<void>,
     deps: ViewerFactoryDeps = defaultDeps,
   ) {
-    this.viewType = viewType;
+    this.#viewType = viewType;
     this.#myExtension = myExtension;
     this.#store = store;
     this.#onReady = onReady;
@@ -59,7 +59,7 @@ export class ViewerFactory {
    */
   public getPanel(document: vscode.TextDocument) {
     console.log(
-      `invoke PanelFactory.getPanel. (${this.viewType}, ${document.uri.toString()})`,
+      `invoke PanelFactory.getPanel. (${this.#viewType}, ${document.uri.toString()})`,
     );
 
     const existingPanel = this.#store.panelByUri(document.uri);
@@ -98,7 +98,7 @@ export class ViewerFactory {
     registerViewerPanelDispose({
       uri: document.uri,
       panel,
-      viewType: this.viewType,
+      viewType: this.#viewType,
       store: this.#store,
       receiveMessageDispose,
     });
@@ -117,7 +117,7 @@ export class ViewerFactory {
     document: vscode.TextDocument,
   ): vscode.WebviewPanel {
     const panel = this.#deps.createWebviewPanel(
-      this.viewType,
+      this.#viewType,
       path.basename(document.fileName),
       vscode.ViewColumn.Beside,
       {

--- a/src/test/suite/openPreviewCommand.test.ts
+++ b/src/test/suite/openPreviewCommand.test.ts
@@ -8,8 +8,8 @@ suite("Open Preview Command", () => {
     let tracked = false;
 
     executeOpenPreviewCommand({
+      viewType: "ajsbutler.tableViewer",
       panelFactory: {
-        viewType: "ajsbutler.tableViewer",
         getPanel: () => {
           throw new Error("panel should not be created");
         },
@@ -47,8 +47,8 @@ suite("Open Preview Command", () => {
     const activeEditor = { document };
 
     executeOpenPreviewCommand({
+      viewType: "ajsbutler.flowViewer",
       panelFactory: {
-        viewType: "ajsbutler.flowViewer",
         getPanel: (receivedDocument) => {
           assert.strictEqual(receivedDocument, document);
           return panel as never;


### PR DESCRIPTION
## Summary
- stop exposing viewType on ViewerFactory
- pass the preview command viewType explicitly from viewer wiring
- keep ViewerFactory focused on panel creation rather than command naming

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build