### PR TITLE
refactor: decouple preview command types

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -244,6 +244,9 @@ This file is the high-level index for the per-feature plan structure in
 - preview command wiring now owns `viewType` explicitly, so `ViewerFactory`
   no longer exposes it as part of its public API just to support command
   registration, mounting, and telemetry naming.
+- preview command registration now depends only on a local `getPanel(...)`
+  contract, so command wiring no longer imports the concrete `ViewerFactory`
+  type just to invoke the shared preview-open flow.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
 - WebviewMediator cleanup now removes store entries by URI directly, allowing

--- a/src/extension/commands/openPreviewCommand.ts
+++ b/src/extension/commands/openPreviewCommand.ts
@@ -1,9 +1,10 @@
 import * as vscode from "vscode";
 import { MyExtension } from "../MyExtension";
-import { ViewerFactory } from "../webview/ViewerFactory";
 import { mountViewerPanel } from "../webview/mountViewerPanel";
 
-type PreviewPanelFactory = Pick<ViewerFactory, "getPanel">;
+export type PreviewPanelFactory = {
+  getPanel(document: vscode.TextDocument): vscode.WebviewPanel;
+};
 
 type OpenPreviewCommandDependencies = {
   getActiveEditor: () => vscode.TextEditor | undefined;

--- a/src/extension/commands/registerPreviewCommand.ts
+++ b/src/extension/commands/registerPreviewCommand.ts
@@ -1,11 +1,13 @@
 import * as vscode from "vscode";
-import { ViewerFactory } from "../webview/ViewerFactory";
 import { MyExtension } from "../MyExtension";
-import { openPreviewCommand } from "./openPreviewCommand";
+import {
+  openPreviewCommand,
+  type PreviewPanelFactory,
+} from "./openPreviewCommand";
 
 export const registerPreviewCommand = (
   viewType: string,
-  panelFactory: ViewerFactory,
+  panelFactory: PreviewPanelFactory,
   myExtension: MyExtension,
 ): vscode.Disposable => {
   console.log(`invoke registerPreview. (${viewType})`);


### PR DESCRIPTION
## Summary
- stop importing ViewerFactory into preview command wiring
- move the preview panel factory contract into the command module
- keep command wiring focused on the getPanel surface it actually needs

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build