### PR TITLE
refactor: decouple preview registration

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -247,6 +247,9 @@ This file is the high-level index for the per-feature plan structure in
 - preview command registration now depends only on a local `getPanel(...)`
   contract, so command wiring no longer imports the concrete `ViewerFactory`
   type just to invoke the shared preview-open flow.
+- preview command registration now accepts a plain execute callback, so the
+  registration helper no longer depends on `MyExtension` or preview-open
+  wiring details beyond the command id it publishes.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
 - WebviewMediator cleanup now removes store entries by URI directly, allowing

--- a/src/extension/bootstrap/viewerWiring.ts
+++ b/src/extension/bootstrap/viewerWiring.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { MyExtension } from "../MyExtension";
 import { registerPreviewCommand } from "../commands/registerPreviewCommand";
+import { openPreviewCommand } from "../commands/openPreviewCommand";
 import { ViewerFactory } from "../webview/ViewerFactory";
 import { WebviewMediator } from "../webview/WebviewMediator";
 import {
@@ -43,7 +44,12 @@ const createViewerBundle = (
     saveHandler,
   );
 
-  return [mediator, registerPreviewCommand(viewType, factory, myExtension)];
+  return [
+    mediator,
+    registerPreviewCommand(viewType, () => {
+      openPreviewCommand(viewType, factory, myExtension);
+    }),
+  ];
 };
 
 export const createViewerSubscriptions = (

--- a/src/extension/commands/registerPreviewCommand.ts
+++ b/src/extension/commands/registerPreviewCommand.ts
@@ -1,17 +1,9 @@
 import * as vscode from "vscode";
-import { MyExtension } from "../MyExtension";
-import {
-  openPreviewCommand,
-  type PreviewPanelFactory,
-} from "./openPreviewCommand";
 
 export const registerPreviewCommand = (
   viewType: string,
-  panelFactory: PreviewPanelFactory,
-  myExtension: MyExtension,
+  execute: () => void,
 ): vscode.Disposable => {
   console.log(`invoke registerPreview. (${viewType})`);
-  return vscode.commands.registerCommand(`open.${viewType}`, () => {
-    openPreviewCommand(viewType, panelFactory, myExtension);
-  });
+  return vscode.commands.registerCommand(`open.${viewType}`, execute);
 };

--- a/src/test/suite/registerPreviewCommand.test.ts
+++ b/src/test/suite/registerPreviewCommand.test.ts
@@ -1,0 +1,39 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { registerPreviewCommand } from "../../extension/commands/registerPreviewCommand";
+
+suite("Register Preview Command", () => {
+  test("registers the open command for the given view type", async () => {
+    let registeredCommandId: string | undefined;
+    let execute: (() => void) | undefined;
+
+    const originalRegisterCommand = vscode.commands.registerCommand;
+    (vscode.commands
+      .registerCommand as typeof vscode.commands.registerCommand) = ((
+      commandId: string,
+      callback: () => void,
+    ) => {
+      registeredCommandId = commandId;
+      execute = callback;
+      return { dispose() {} };
+    }) as typeof vscode.commands.registerCommand;
+
+    try {
+      const disposable = registerPreviewCommand("ajsbutler.tableViewer", () => {
+        registeredCommandId = `${registeredCommandId}:executed`;
+      });
+
+      assert.strictEqual(registeredCommandId, "open.ajsbutler.tableViewer");
+      execute?.();
+      assert.strictEqual(
+        registeredCommandId,
+        "open.ajsbutler.tableViewer:executed",
+      );
+      disposable.dispose();
+    } finally {
+      (vscode.commands
+        .registerCommand as typeof vscode.commands.registerCommand) =
+        originalRegisterCommand;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- make preview command registration accept a plain execute callback
- move preview-open wiring back to viewer bootstrap where MyExtension is already available
- add focused coverage for command registration and invocation

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build