### PR TITLE
refactor: decouple open preview deps

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -250,6 +250,9 @@ This file is the high-level index for the per-feature plan structure in
 - preview command registration now accepts a plain execute callback, so the
   registration helper no longer depends on `MyExtension` or preview-open
   wiring details beyond the command id it publishes.
+- preview-open execution now depends on explicit command dependencies instead
+  of `MyExtension`, so viewer bootstrap owns the extension-context and
+  telemetry wiring while the command module stays focused on execution flow.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
 - WebviewMediator cleanup now removes store entries by URI directly, allowing

--- a/src/extension/bootstrap/viewerWiring.ts
+++ b/src/extension/bootstrap/viewerWiring.ts
@@ -1,7 +1,10 @@
 import * as vscode from "vscode";
 import { MyExtension } from "../MyExtension";
 import { registerPreviewCommand } from "../commands/registerPreviewCommand";
-import { openPreviewCommand } from "../commands/openPreviewCommand";
+import {
+  createOpenPreviewCommandDependencies,
+  openPreviewCommand,
+} from "../commands/openPreviewCommand";
 import { ViewerFactory } from "../webview/ViewerFactory";
 import { WebviewMediator } from "../webview/WebviewMediator";
 import {
@@ -43,11 +46,17 @@ const createViewerBundle = (
     readyAjsDocument,
     saveHandler,
   );
+  const previewDeps = createOpenPreviewCommandDependencies(
+    myExtension.context,
+    (eventViewType, properties) => {
+      myExtension.telemetry.trackEvent(eventViewType, properties);
+    },
+  );
 
   return [
     mediator,
     registerPreviewCommand(viewType, () => {
-      openPreviewCommand(viewType, factory, myExtension);
+      openPreviewCommand(viewType, factory, previewDeps);
     }),
   ];
 };

--- a/src/extension/commands/openPreviewCommand.ts
+++ b/src/extension/commands/openPreviewCommand.ts
@@ -1,12 +1,11 @@
 import * as vscode from "vscode";
-import { MyExtension } from "../MyExtension";
 import { mountViewerPanel } from "../webview/mountViewerPanel";
 
 export type PreviewPanelFactory = {
   getPanel(document: vscode.TextDocument): vscode.WebviewPanel;
 };
 
-type OpenPreviewCommandDependencies = {
+export type OpenPreviewCommandDependencies = {
   getActiveEditor: () => vscode.TextEditor | undefined;
   showErrorMessage: (message: string) => Thenable<string | undefined>;
   mountPanel: (panel: vscode.WebviewPanel, viewType: string) => void;
@@ -18,19 +17,6 @@ type ExecuteOpenPreviewCommandArgs = {
   panelFactory: PreviewPanelFactory;
   deps: OpenPreviewCommandDependencies;
 };
-
-const createDependencies = (
-  myExtension: MyExtension,
-): OpenPreviewCommandDependencies => ({
-  getActiveEditor: () => vscode.window.activeTextEditor,
-  showErrorMessage: (message) => vscode.window.showErrorMessage(message),
-  mountPanel: (panel, viewType) => {
-    mountViewerPanel(myExtension.context, panel, viewType);
-  },
-  trackEvent: (viewType, properties) => {
-    myExtension.telemetry.trackEvent(viewType, properties);
-  },
-});
 
 export const executeOpenPreviewCommand = ({
   viewType,
@@ -56,11 +42,23 @@ export const executeOpenPreviewCommand = ({
 export const openPreviewCommand = (
   viewType: string,
   panelFactory: PreviewPanelFactory,
-  myExtension: MyExtension,
+  deps: OpenPreviewCommandDependencies,
 ): void => {
   executeOpenPreviewCommand({
     viewType,
     panelFactory,
-    deps: createDependencies(myExtension),
+    deps,
   });
 };
+
+export const createOpenPreviewCommandDependencies = (
+  context: vscode.ExtensionContext,
+  trackEvent: (viewType: string, properties: Record<string, string>) => void,
+): OpenPreviewCommandDependencies => ({
+  getActiveEditor: () => vscode.window.activeTextEditor,
+  showErrorMessage: (message) => vscode.window.showErrorMessage(message),
+  mountPanel: (panel, viewType) => {
+    mountViewerPanel(context, panel, viewType);
+  },
+  trackEvent,
+});


### PR DESCRIPTION
## Summary
- stop passing MyExtension into openPreviewCommand
- build preview command dependencies from viewer bootstrap instead
- keep the command module focused on execution flow and explicit dependencies

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build