### PR TITLE
refactor: share preview command deps

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -253,6 +253,9 @@ This file is the high-level index for the per-feature plan structure in
 - preview-open execution now depends on explicit command dependencies instead
   of `MyExtension`, so viewer bootstrap owns the extension-context and
   telemetry wiring while the command module stays focused on execution flow.
+- viewer wiring now creates preview command dependencies once per extension
+  runtime instead of rebuilding the same context and telemetry closures for
+  each viewer entry.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
 - WebviewMediator cleanup now removes store entries by URI directly, allowing

--- a/src/extension/bootstrap/viewerWiring.ts
+++ b/src/extension/bootstrap/viewerWiring.ts
@@ -30,6 +30,7 @@ const viewerConfigs: ViewerConfig[] = [
 
 const createViewerBundle = (
   myExtension: MyExtension,
+  previewDeps: ReturnType<typeof createOpenPreviewCommandDependencies>,
   { viewType, saveHandler }: ViewerConfig,
 ): vscode.Disposable[] => {
   const store = new WebviewStore(viewType);
@@ -46,12 +47,6 @@ const createViewerBundle = (
     readyAjsDocument,
     saveHandler,
   );
-  const previewDeps = createOpenPreviewCommandDependencies(
-    myExtension.context,
-    (eventViewType, properties) => {
-      myExtension.telemetry.trackEvent(eventViewType, properties);
-    },
-  );
 
   return [
     mediator,
@@ -63,5 +58,15 @@ const createViewerBundle = (
 
 export const createViewerSubscriptions = (
   myExtension: MyExtension,
-): vscode.Disposable[] =>
-  viewerConfigs.flatMap((config) => createViewerBundle(myExtension, config));
+): vscode.Disposable[] => {
+  const previewDeps = createOpenPreviewCommandDependencies(
+    myExtension.context,
+    (eventViewType, properties) => {
+      myExtension.telemetry.trackEvent(eventViewType, properties);
+    },
+  );
+
+  return viewerConfigs.flatMap((config) =>
+    createViewerBundle(myExtension, previewDeps, config),
+  );
+};


### PR DESCRIPTION
## Summary
- create preview command dependencies once per extension runtime
- reuse the same preview dependency set across viewer entries
- keep viewer wiring symmetric while removing repeated closure construction

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build