### PR TITLE
refactor: move preview deps to viewer wiring

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -256,6 +256,9 @@ This file is the high-level index for the per-feature plan structure in
 - viewer wiring now creates preview command dependencies once per extension
   runtime instead of rebuilding the same context and telemetry closures for
   each viewer entry.
+- preview command execution now exports only runtime-agnostic command logic,
+  while viewer wiring owns the VS Code-specific dependency construction used
+  to mount panels and emit preview telemetry.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
 - WebviewMediator cleanup now removes store entries by URI directly, allowing

--- a/src/extension/bootstrap/viewerWiring.ts
+++ b/src/extension/bootstrap/viewerWiring.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { MyExtension } from "../MyExtension";
 import { registerPreviewCommand } from "../commands/registerPreviewCommand";
 import {
-  createOpenPreviewCommandDependencies,
+  type OpenPreviewCommandDependencies,
   openPreviewCommand,
 } from "../commands/openPreviewCommand";
 import { ViewerFactory } from "../webview/ViewerFactory";
@@ -16,6 +16,7 @@ import {
   debouncedAjsDocumentChangeFn,
   readyAjsDocument,
 } from "../webview/ajsDocument";
+import { mountViewerPanel } from "../webview/mountViewerPanel";
 import { saveText } from "../webview/messageHandlers";
 
 type ViewerConfig = {
@@ -28,9 +29,22 @@ const viewerConfigs: ViewerConfig[] = [
   { viewType: AJS_FLOW_VIEWER_TYPE },
 ];
 
+const createPreviewCommandDependencies = (
+  myExtension: MyExtension,
+): OpenPreviewCommandDependencies => ({
+  getActiveEditor: () => vscode.window.activeTextEditor,
+  showErrorMessage: (message) => vscode.window.showErrorMessage(message),
+  mountPanel: (panel, viewType) => {
+    mountViewerPanel(myExtension.context, panel, viewType);
+  },
+  trackEvent: (viewType, properties) => {
+    myExtension.telemetry.trackEvent(viewType, properties);
+  },
+});
+
 const createViewerBundle = (
   myExtension: MyExtension,
-  previewDeps: ReturnType<typeof createOpenPreviewCommandDependencies>,
+  previewDeps: OpenPreviewCommandDependencies,
   { viewType, saveHandler }: ViewerConfig,
 ): vscode.Disposable[] => {
   const store = new WebviewStore(viewType);
@@ -59,12 +73,7 @@ const createViewerBundle = (
 export const createViewerSubscriptions = (
   myExtension: MyExtension,
 ): vscode.Disposable[] => {
-  const previewDeps = createOpenPreviewCommandDependencies(
-    myExtension.context,
-    (eventViewType, properties) => {
-      myExtension.telemetry.trackEvent(eventViewType, properties);
-    },
-  );
+  const previewDeps = createPreviewCommandDependencies(myExtension);
 
   return viewerConfigs.flatMap((config) =>
     createViewerBundle(myExtension, previewDeps, config),

--- a/src/extension/commands/openPreviewCommand.ts
+++ b/src/extension/commands/openPreviewCommand.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { mountViewerPanel } from "../webview/mountViewerPanel";
 
 export type PreviewPanelFactory = {
   getPanel(document: vscode.TextDocument): vscode.WebviewPanel;
@@ -50,15 +49,3 @@ export const openPreviewCommand = (
     deps,
   });
 };
-
-export const createOpenPreviewCommandDependencies = (
-  context: vscode.ExtensionContext,
-  trackEvent: (viewType: string, properties: Record<string, string>) => void,
-): OpenPreviewCommandDependencies => ({
-  getActiveEditor: () => vscode.window.activeTextEditor,
-  showErrorMessage: (message) => vscode.window.showErrorMessage(message),
-  mountPanel: (panel, viewType) => {
-    mountViewerPanel(context, panel, viewType);
-  },
-  trackEvent,
-});


### PR DESCRIPTION
## Summary
- keep openPreviewCommand focused on runtime-agnostic execution logic
- move VS Code-specific preview dependency construction into viewer wiring
- keep preview dependency sharing at the bootstrap layer

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build