### PR TITLE
refactor: remove thin open preview wrapper

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -259,6 +259,9 @@ This file is the high-level index for the per-feature plan structure in
 - preview command execution now exports only runtime-agnostic command logic,
   while viewer wiring owns the VS Code-specific dependency construction used
   to mount panels and emit preview telemetry.
+- viewer wiring now calls `executeOpenPreviewCommand(...)` directly, so the
+  command module no longer keeps a one-line `openPreviewCommand(...)` wrapper
+  around the same execution arguments.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
 - WebviewMediator cleanup now removes store entries by URI directly, allowing

--- a/src/extension/bootstrap/viewerWiring.ts
+++ b/src/extension/bootstrap/viewerWiring.ts
@@ -3,7 +3,7 @@ import { MyExtension } from "../MyExtension";
 import { registerPreviewCommand } from "../commands/registerPreviewCommand";
 import {
   type OpenPreviewCommandDependencies,
-  openPreviewCommand,
+  executeOpenPreviewCommand,
 } from "../commands/openPreviewCommand";
 import { ViewerFactory } from "../webview/ViewerFactory";
 import { WebviewMediator } from "../webview/WebviewMediator";
@@ -65,7 +65,11 @@ const createViewerBundle = (
   return [
     mediator,
     registerPreviewCommand(viewType, () => {
-      openPreviewCommand(viewType, factory, previewDeps);
+      executeOpenPreviewCommand({
+        viewType,
+        panelFactory: factory,
+        deps: previewDeps,
+      });
     }),
   ];
 };

--- a/src/extension/commands/openPreviewCommand.ts
+++ b/src/extension/commands/openPreviewCommand.ts
@@ -37,15 +37,3 @@ export const executeOpenPreviewCommand = ({
     development: String(DEVELOPMENT),
   });
 };
-
-export const openPreviewCommand = (
-  viewType: string,
-  panelFactory: PreviewPanelFactory,
-  deps: OpenPreviewCommandDependencies,
-): void => {
-  executeOpenPreviewCommand({
-    viewType,
-    panelFactory,
-    deps,
-  });
-};


### PR DESCRIPTION
## Summary
- remove the one-line openPreviewCommand wrapper
- call executeOpenPreviewCommand directly from viewer wiring
- keep the command module focused on the actual execution entrypoint

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build