### PR TITLE
refactor: remove local register preview helper

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -265,6 +265,9 @@ This file is the high-level index for the per-feature plan structure in
 - viewer wiring now inlines the preview command registration helper, removing
   the last one-line `registerPreviewCommand(...)` wrapper from the command
   layer and keeping the bootstrap wiring in one local flow.
+- viewer wiring no longer keeps a second local `registerPreview(...)` helper
+  now that preview command registration happens only once per viewer entry and
+  reads clearly inline at the command registration site.
 - WebviewStore registration now also takes a URI directly, so its public
   contract is fully aligned with the URI-keyed internal model.
 - WebviewMediator cleanup now removes store entries by URI directly, allowing

--- a/src/extension/bootstrap/viewerWiring.ts
+++ b/src/extension/bootstrap/viewerWiring.ts
@@ -41,14 +41,6 @@ const createPreviewCommandDependencies = (
   },
 });
 
-const registerPreview = (
-  viewType: string,
-  execute: () => void,
-): vscode.Disposable => {
-  console.log(`invoke registerPreview. (${viewType})`);
-  return vscode.commands.registerCommand(`open.${viewType}`, execute);
-};
-
 const createViewerBundle = (
   myExtension: MyExtension,
   previewDeps: OpenPreviewCommandDependencies,
@@ -71,7 +63,8 @@ const createViewerBundle = (
 
   return [
     mediator,
-    registerPreview(viewType, () => {
+    vscode.commands.registerCommand(`open.${viewType}`, () => {
+      console.log(`invoke registerPreview. (${viewType})`);
       executeOpenPreviewCommand({
         viewType,
         panelFactory: factory,


### PR DESCRIPTION
## Summary
- remove the last local registerPreview helper from viewer wiring
- register preview commands directly at the single call site
- keep the bootstrap flow local while dropping another one-use wrapper

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build