### PR TITLE
docs: align docs-only verification rules

### DIFF
--- a/.codex/skills/sdd-change/SKILL.md
+++ b/.codex/skills/sdd-change/SKILL.md
@@ -9,7 +9,8 @@ Prepare or update SDD artifacts before implementing a non-trivial repository cha
 1. read `AGENTS.md`
 2. read `package.json`
 3. read the relevant files in `docs/specs/`
-4. update or create the matching use-case spec in `docs/use-cases/`
+4. update or create the matching use-case spec in
+   `docs/requirements/use-cases/`
 5. update `PLANS.md` with assumptions, scope, and acceptance criteria
 6. summarize compatibility and layering risks before editing runtime code
 
@@ -19,3 +20,5 @@ Prepare or update SDD artifacts before implementing a non-trivial repository cha
 - preserve desktop and web extension behavior
 - prefer small vertical slices over broad rewrites
 - document assumptions instead of hiding them
+- use a `docs/...` branch name only when the slice stays within the docs-only
+  file set used by `.github/workflows/verify.yml`

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -24,11 +24,13 @@ jobs:
             docs:
               - 'docs/**'
               - 'README.md'
+              - '.codex/**/*.md'
               - '.github/**/*.md'
             non_docs:
               - '**'
               - '!docs/**'
               - '!README.md'
+              - '!.codex/**/*.md'
               - '!.github/**/*.md'
 
   decide:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,16 @@ For non-trivial changes, follow this order:
 
 If the requested change is ambiguous, prefer documenting assumptions explicitly in `PLANS.md` instead of making hidden assumptions.
 
+## Branch Naming
+
+- Use a dedicated git branch for each slice.
+- Reserve `docs/...` branch names for docs-only changes.
+- Treat "docs-only" the same way as the `Verify` workflow:
+  only `docs/**`, `README.md`, `.codex/**/*.md`, and `.github/**/*.md` may
+  change.
+- If a branch named `docs/...` needs any non-doc change, rename it or start a
+  non-doc branch before continuing so verification expectations stay honest.
+
 ## Coding Rules
 
 - Use TypeScript.
@@ -88,6 +98,8 @@ If the requested change is ambiguous, prefer documenting assumptions explicitly 
 ## Testing Policy
 
 Before finishing a task, run the most relevant checks available.
+
+For docs-only changes, markdown lint is sufficient.
 
 Minimum expectation for meaningful code changes:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ This repository is incrementally adopting Specification-Driven Development
 - Branch-level planning is tracked in `docs/specs/plans.md`.
 - `PLANS.md` is the root index that points to the active SDD documents.
 - Codex-specific repository guidance lives in `AGENTS.md`.
+- Docs-only work should use a `docs/...` branch name and stay within the
+  docs-only file set used by `.github/workflows/verify.yml`:
+  `docs/**`, `README.md`, `.codex/**/*.md`, and `.github/**/*.md`.
 
 Recent refactoring work introduced:
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -26,6 +26,7 @@ repository.
 For non-trivial changes:
 
 1. create a dedicated git branch before implementation work starts
+   and use `docs/...` only for docs-only slices
 2. update or create the relevant use-case spec in
    `docs/requirements/use-cases/` and/or
    `docs/specs/features/<feature>/SPECS.md`
@@ -51,10 +52,30 @@ For non-trivial changes:
 For docs-only changes:
 
 - `npm run build` is not required
-- prefer markdown-focused validation such as `npm run lint:md`
-- `npm run qlty` is still recommended when docs formatting or repository-wide
-  quality rules may be affected
+- run markdown-focused validation such as `npm run lint:md`
 - repository `Verify` workflow should not be relied on as a required gate
+
+## Branch Naming
+
+Use branch names to signal verification intent clearly:
+
+- `docs/...`
+  Reserve for docs-only slices.
+- non-`docs/...`
+  Use for any slice that changes runtime code, tests, config, or other
+  non-doc files.
+
+Match the branch name to the `Verify` workflow's docs-only rule.
+In `.github/workflows/verify.yml`, a PR is treated as docs-only only when the
+changed files stay within:
+
+- `docs/**`
+- `README.md`
+- `.codex/**/*.md`
+- `.github/**/*.md`
+
+If a `docs/...` branch needs any file outside that set, rename the branch or
+start a new non-doc branch before continuing.
 
 ## When To Use `docs/requirements/use-cases/`
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -32,14 +32,18 @@ For non-trivial changes:
 3. update or create corresponding plans in
    `docs/specs/features/<feature>/PLANS.md`
 4. track execution tasks in `docs/specs/features/<feature>/TASKS.md`
+   and update that file in the same commit whenever a task is completed,
+   reframed, or dropped
 5. document assumptions explicitly
 6. implement in small vertical slices
-7. refresh `docs/specs/plans.md` if the active slice or branch priorities
-   change materially
-8. before `git push`, run local validation serially in this order for code
+7. refresh `docs/specs/plans.md` in the same commit if the active slice or
+   branch priorities change materially
+8. refresh `docs/specs/roadmap.md` in the same commit if a completed slice
+   changes repository-level ordering, remaining debt, or deferred work
+9. before `git push`, run local validation serially in this order for code
    changes: `npm run qlty`, `npm test`, `npm run test:web`, `npm run build`
-9. run any additional task-specific checks before finishing
-10. avoid anemic domain models: extract only cross-unit or cross-layer
+10. run any additional task-specific checks before finishing
+11. avoid anemic domain models: extract only cross-unit or cross-layer
     semantics into helpers/interfaces, and keep entity identity plus
     unit-local behavior in the entity when that behavior is part of the
     JP1/AJS concept itself
@@ -71,6 +75,24 @@ Poor fit:
 - file-by-file execution checklists
 
 Those belong under `docs/specs/`.
+
+## Sync Cadence
+
+Treat the following docs as required sync artifacts, not optional catch-up
+notes:
+
+- `docs/specs/features/<feature>/TASKS.md`
+  Update immediately when one task or follow-up is completed, re-scoped, or
+  intentionally dropped.
+- `docs/specs/plans.md`
+  Update when that task completion changes the branch summary or next priority.
+- `docs/specs/roadmap.md`
+  Update when that completion changes repository-level sequence, remaining
+  debt, or deferred work.
+
+Prefer the smallest useful cadence:
+one completed task or one resolved follow-up is enough reason to sync the
+docs in the same commit.
 
 ## Document Roles
 

--- a/docs/specs/features/build-flow-graph/PLANS.md
+++ b/docs/specs/features/build-flow-graph/PLANS.md
@@ -20,6 +20,6 @@ Deliver the feature for use case: UC: Build Flow Graph.
 
 ## Validation
 
-- npm test
-- npm run lint:md
-- npm run qlty
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/build-flow-graph/TASKS.md
+++ b/docs/specs/features/build-flow-graph/TASKS.md
@@ -1,5 +1,12 @@
 # TASKS: build-flow-graph
 
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
 ## Completed
 
 - [x] Review use case: docs/requirements/use-cases/uc-build-flow-graph.md
@@ -12,4 +19,4 @@
 
 - [x] Remove residual `UnitEntity` reconstruction from flow presentation
 - [ ] Record a current manual smoke-test result for desktop and web viewers in docs
-- [ ] Keep architecture and roadmap docs aligned with the migrated state
+- [x] Keep architecture and roadmap docs aligned with the migrated state

--- a/docs/specs/features/build-unit-list-view/PLANS.md
+++ b/docs/specs/features/build-unit-list-view/PLANS.md
@@ -20,6 +20,6 @@ Deliver the feature for use case: UC: Build Unit List View.
 
 ## Validation
 
-- npm test
-- npm run lint:md
-- npm run qlty
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/build-unit-list-view/TASKS.md
+++ b/docs/specs/features/build-unit-list-view/TASKS.md
@@ -1,5 +1,12 @@
 # TASKS: build-unit-list-view
 
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
 ## Completed
 
 - [x] Review use case: docs/requirements/use-cases/uc-build-unit-list-view.md

--- a/docs/specs/features/build-unit-list/PLANS.md
+++ b/docs/specs/features/build-unit-list/PLANS.md
@@ -20,6 +20,6 @@ Deliver the feature for use case: UC: Build Unit List.
 
 ## Validation
 
-- npm test
-- npm run lint:md
-- npm run qlty
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/build-unit-list/TASKS.md
+++ b/docs/specs/features/build-unit-list/TASKS.md
@@ -1,5 +1,12 @@
 # TASKS: build-unit-list
 
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
 ## Completed
 
 - [x] Review use case: docs/requirements/use-cases/uc-build-unit-list.md

--- a/docs/specs/features/export-unit-list-csv/PLANS.md
+++ b/docs/specs/features/export-unit-list-csv/PLANS.md
@@ -20,6 +20,6 @@ Deliver the feature for use case: UC: Export Unit List CSV.
 
 ## Validation
 
-- npm test
-- npm run lint:md
-- npm run qlty
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/export-unit-list-csv/TASKS.md
+++ b/docs/specs/features/export-unit-list-csv/TASKS.md
@@ -1,5 +1,12 @@
 # TASKS: export-unit-list-csv
 
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
 ## Completed
 
 - [x] Review use case: docs/requirements/use-cases/uc-export-unit-list-csv.md

--- a/docs/specs/features/normalize-ajs-document/PLANS.md
+++ b/docs/specs/features/normalize-ajs-document/PLANS.md
@@ -20,7 +20,6 @@ Deliver the feature for use case: UC: Normalize AJS Document.
 
 ## Validation
 
-- npm test
-- npm run lint:md
-- npm run qlty
-- npm run build
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/normalize-ajs-document/TASKS.md
+++ b/docs/specs/features/normalize-ajs-document/TASKS.md
@@ -1,5 +1,12 @@
 # TASKS: normalize-ajs-document
 
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
 ## Completed
 
 - [x] Review use case: docs/requirements/use-cases/uc-normalize-ajs-document.md
@@ -15,7 +22,7 @@
 - [ ] Prefer fixture-backed normalization coverage for remaining edge cases such
       as encoding-sensitive documents and larger definitions, instead of
       creating new abstractions without repeated consumers
-- [ ] Keep adapter-boundary docs aligned when a semantic intentionally remains
+- [x] Keep adapter-boundary docs aligned when a semantic intentionally remains
       wrapper-local or application-local, so future slices do not re-open
       already settled extraction decisions
 - [x] Expose normalized helpers for parent, ancestor, and root jobnet lookup

--- a/docs/specs/features/provide-editor-feedback/PLANS.md
+++ b/docs/specs/features/provide-editor-feedback/PLANS.md
@@ -20,6 +20,6 @@ Deliver the feature for use case: UC: Provide Editor Feedback.
 
 ## Validation
 
-- npm test
-- npm run lint:md
-- npm run qlty
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/provide-editor-feedback/TASKS.md
+++ b/docs/specs/features/provide-editor-feedback/TASKS.md
@@ -1,5 +1,12 @@
 # TASKS: provide-editor-feedback
 
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
 ## Completed
 
 - [x] Review use case: docs/requirements/use-cases/uc-provide-editor-feedback.md

--- a/docs/specs/features/record-telemetry/PLANS.md
+++ b/docs/specs/features/record-telemetry/PLANS.md
@@ -20,6 +20,6 @@ Deliver the feature for use case: UC: Record Telemetry.
 
 ## Validation
 
-- npm test
-- npm run lint:md
-- npm run qlty
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/record-telemetry/TASKS.md
+++ b/docs/specs/features/record-telemetry/TASKS.md
@@ -1,5 +1,12 @@
 # TASKS: record-telemetry
 
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
 ## Completed
 
 - [x] Review use case: docs/requirements/use-cases/uc-record-telemetry.md

--- a/docs/specs/features/show-unit-definition/PLANS.md
+++ b/docs/specs/features/show-unit-definition/PLANS.md
@@ -20,6 +20,6 @@ Deliver the feature for use case: UC: Show Unit Definition.
 
 ## Validation
 
-- npm test
-- npm run lint:md
-- npm run qlty
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/show-unit-definition/TASKS.md
+++ b/docs/specs/features/show-unit-definition/TASKS.md
@@ -1,5 +1,12 @@
 # TASKS: show-unit-definition
 
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
 ## Completed
 
 - [x] Review use case: docs/requirements/use-cases/uc-show-unit-definition.md

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -105,15 +105,19 @@ model.
    - `SPECS.md` for implementation requirements
    - `PLANS.md` for planning and milestones
    - `TASKS.md` for execution items
-5. Fill in assumptions explicitly when requirements are ambiguous.
-6. Implement only after acceptance criteria are clear.
-7. Refresh `docs/specs/plans.md` when the active slice or branch-level
-   priorities change materially.
-8. Before `git push`, run local validation serially in this order for code
-   changes: `npm run qlty`, `npm test`, `npm run test:web`, `npm run build`.
-9. Run any additional task-specific checks after that serial baseline when
-   needed.
-10. Summarize compatibility risks and follow-up work.
+5. Update the owning `TASKS.md` in the same commit whenever one task or
+   follow-up is completed, re-scoped, or intentionally dropped.
+6. Fill in assumptions explicitly when requirements are ambiguous.
+7. Implement only after acceptance criteria are clear.
+8. Refresh `docs/specs/plans.md` in the same commit when the active slice or
+   branch-level priorities change materially.
+9. Refresh `docs/specs/roadmap.md` in the same commit when a completed slice
+   changes repository-level ordering, remaining debt, or deferred work.
+10. Before `git push`, run local validation serially in this order for code
+    changes: `npm run qlty`, `npm test`, `npm run test:web`, `npm run build`.
+11. Run any additional task-specific checks after that serial baseline when
+    needed.
+12. Summarize compatibility risks and follow-up work.
 
 Docs-only exception:
 
@@ -161,6 +165,9 @@ Use-case note:
   validation instead and do not treat repository `Verify` as a required gate.
 - Keep `Completed In This Branch` concise enough to function as a planning
   summary rather than a chronological changelog.
+- Treat `docs/specs/features/<feature>/TASKS.md`, `docs/specs/plans.md`, and
+  `docs/specs/roadmap.md` as sync targets that should be updated at the time a
+  task outcome becomes known, not in a later cleanup pass.
 
 ### Design
 
@@ -211,35 +218,29 @@ Use-case note:
 
 ### Task
 
-Refresh the branch-level SDD instructions so the active plan, completed work
-summary, and roadmap reflect the current post-refactor state.
+Audit feature-local SDD task files and add a same-commit sync rule for task,
+plan, and roadmap updates.
 
 ### Why
 
-The branch has accumulated many small refactor slices across wrapper
-semantics, normalized AJS mapping, activation/bootstrap, and webview wiring.
-The existing plan file read like a running changelog and still carried an
-outdated current task, which made it harder to choose the next slice
-deliberately.
+The branch-level docs are now in better shape, but the feature-local
+`TASKS.md` files still contain stale follow-up notes and no explicit rule
+about when to sync task, plan, and roadmap documents. Without a tighter
+cadence, the repo drifts back toward catch-up documentation.
 
 ### Scope
 
-- update the root `PLANS.md` index so it points at the active SDD sources more
-  clearly
-- compress `docs/specs/plans.md` branch status into grouped branch-level
-  outcomes
-- replace the stale current task with an SDD-maintenance task that matches the
-  present branch state
-- tighten next-priority guidance so roadmap and plan files point to the same
-  remaining concerns
-- update `docs/specs/roadmap.md` so completed slices and next work reflect the
-  latest extension/bootstrap and webview refactors
+- audit `docs/specs/features/*/TASKS.md` against the current merged state
+- remove or reclassify follow-up notes that are already satisfied
+- add a shared operating rule that task completion should trigger same-commit
+  updates to feature tasks and, when applicable, branch plans and roadmap docs
+- keep the rule visible in both central SDD guidance and feature task files
 
 ### Non-Goals
 
 - changing runtime code behavior
-- changing parser, normalized-model, flow, list, or CSV outputs
-- introducing a new architectural policy that contradicts `AGENTS.md`
+- reopening already-settled wrapper-capability decisions
+- adding automation tooling beyond explicit repository guidance
 - touching unrelated local modifications outside the SDD docs
 
 ### Constraints
@@ -253,24 +254,26 @@ deliberately.
 
 #### Use case
 
-Repository-level SDD workflow maintenance.
+Repository-level SDD workflow maintenance and feature-task sync discipline.
 
 #### Layers affected
 
-- docs: root planning index, branch-level plan summary, roadmap guidance
+- docs: central SDD workflow guidance, branch-level plan summary, roadmap
+  guidance, feature task files
 
 #### Key decisions
 
-- Treat `docs/specs/plans.md` as a planning summary, not a branch changelog.
-- Keep roadmap and current-task wording synchronized with the latest merged
-  refactor themes.
+- Treat `TASKS.md`, `plans.md`, and `roadmap.md` as same-commit sync targets
+  once a task outcome becomes known.
+- Remove obviously stale follow-up items instead of carrying them as passive
+  reminders forever.
 
 ### Acceptance Criteria
 
-- [ ] branch status is readable as grouped outcomes rather than a long
-      chronological list
-- [ ] current task reflects the real documentation-maintenance slice
-- [ ] roadmap and next-priority tasks point at the same remaining concerns
+- [ ] feature-local task files no longer carry obviously stale follow-up notes
+- [ ] central SDD docs define when task, plan, and roadmap files must be
+      updated together
+- [ ] feature task files carry a visible sync rule
 - [ ] docs-only validation passes
 
 ### Test Plan
@@ -280,11 +283,11 @@ Repository-level SDD workflow maintenance.
 
 ### Risks
 
-- the grouped summary could omit useful detail if compressed too aggressively
-- roadmap language could drift again if future slices are not reflected here
+- the sync rule could be too heavy if written like a bureaucratic checklist
+- some feature follow-up items may look stale without being fully closed in
+  code, so each removal must stay conservative
 
 ### Rollback Plan
 
-- restore the previous detailed branch log if the grouped summary proves too
-  lossy for planning
-- move any missing implementation detail into feature-local SDD files instead
+- restore removed follow-up notes if a task was closed prematurely
+- narrow the sync rule wording if it proves too rigid in practice

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -97,6 +97,9 @@ model.
 ## Default Workflow
 
 1. Create a dedicated git branch before implementation work starts.
+   Use `docs/...` only when the slice changes files that `Verify` treats as
+   docs-only: `docs/**`, `README.md`, `.codex/**/*.md`, and
+   `.github/**/*.md`.
 2. Read the relevant documents in `docs/specs/`.
 3. Update or create the related use-case spec in
    `docs/requirements/use-cases/`.
@@ -122,7 +125,7 @@ model.
 Docs-only exception:
 
 - `npm run build` is not required
-- prefer `npm run lint:md` as the main validation step
+- `npm run lint:md` is sufficient
 - do not require the repository `Verify` workflow for docs-only slices
 
 Use-case note:
@@ -159,10 +162,13 @@ Use-case note:
   semantics into helpers/interfaces, and keep entity identity plus
   unit-local JP1/AJS behavior in the entity when it is part of that concept.
 - Start implementation from a dedicated git branch, not directly on `main`.
+- Reserve `docs/...` branch names for slices that stay within the docs-only
+  file set used by `.github/workflows/verify.yml`:
+  `docs/**`, `README.md`, `.codex/**/*.md`, and `.github/**/*.md`.
 - Do not `git push` until `npm run qlty`, `npm test`, `npm run test:web`,
   and `npm run build` have all passed locally in that order for code changes.
-- For docs-only changes, `npm run build` is not required; use markdown-focused
-  validation instead and do not treat repository `Verify` as a required gate.
+- For docs-only changes, markdown lint is sufficient and repository `Verify`
+  is not a required gate.
 - Keep `Completed In This Branch` concise enough to function as a planning
   summary rather than a chronological changelog.
 - Treat `docs/specs/features/<feature>/TASKS.md`, `docs/specs/plans.md`, and
@@ -194,8 +200,8 @@ Use-case note:
 - [ ] tests updated
 - [ ] `git push` happens only after local `npm run qlty`, `npm test`,
       `npm run test:web`, and `npm run build` pass for code changes
-- [ ] docs-only slices may use `npm run lint:md` instead of `npm run build`
-      and may skip repository `Verify`
+- [ ] docs-only slices use `npm run lint:md` and do not rely on repository
+      `Verify` as a required gate
 - [ ] desktop behavior preserved
 - [ ] web behavior preserved if affected
 
@@ -218,30 +224,33 @@ Use-case note:
 
 ### Task
 
-Audit feature-local SDD task files and add a same-commit sync rule for task,
-plan, and roadmap updates.
+Align docs-only verification rules, branch naming rules, and stale use-case
+paths with the actual `Verify` workflow behavior.
 
 ### Why
 
-The branch-level docs are now in better shape, but the feature-local
-`TASKS.md` files still contain stale follow-up notes and no explicit rule
-about when to sync task, plan, and roadmap documents. Without a tighter
-cadence, the repo drifts back toward catch-up documentation.
+The repo now has explicit docs-only branch naming guidance, but the
+implementation and documents drifted in two places:
+the `Verify` workflow did not yet treat `.codex/**/*.md` as docs-only, and
+some docs still implied broader docs-only validation or referenced the old
+use-case path.
 
 ### Scope
 
-- audit `docs/specs/features/*/TASKS.md` against the current merged state
-- remove or reclassify follow-up notes that are already satisfied
-- add a shared operating rule that task completion should trigger same-commit
-  updates to feature tasks and, when applicable, branch plans and roadmap docs
-- keep the rule visible in both central SDD guidance and feature task files
+- update `.github/workflows/verify.yml` so docs-only detection includes
+  `.codex/**/*.md`
+- align central docs and repo guidance with that docs-only file set
+- correct stale `docs/use-cases/` references to
+  `docs/requirements/use-cases/`
+- align docs-only validation wording so markdown lint is the required check
+  for docs-only slices
 
 ### Non-Goals
 
 - changing runtime code behavior
-- reopening already-settled wrapper-capability decisions
+- changing parser, flow, list, CSV, diagnostics, hover, or telemetry behavior
 - adding automation tooling beyond explicit repository guidance
-- touching unrelated local modifications outside the SDD docs
+- touching unrelated local modifications outside the docs and verify workflow
 
 ### Constraints
 
@@ -254,40 +263,42 @@ cadence, the repo drifts back toward catch-up documentation.
 
 #### Use case
 
-Repository-level SDD workflow maintenance and feature-task sync discipline.
+Repository-level SDD workflow maintenance and verification-rule alignment.
 
 #### Layers affected
 
-- docs: central SDD workflow guidance, branch-level plan summary, roadmap
-  guidance, feature task files
+- docs: central SDD workflow guidance, root guidance, skill guidance
+- workflow: docs-only verification filter
 
 #### Key decisions
 
-- Treat `TASKS.md`, `plans.md`, and `roadmap.md` as same-commit sync targets
-  once a task outcome becomes known.
-- Remove obviously stale follow-up items instead of carrying them as passive
-  reminders forever.
+- Treat `.codex/**/*.md` as docs-only for verification because those files are
+  documentation, not runtime code.
+- Keep docs-only required validation minimal: markdown lint only.
 
 ### Acceptance Criteria
 
-- [ ] feature-local task files no longer carry obviously stale follow-up notes
-- [ ] central SDD docs define when task, plan, and roadmap files must be
-      updated together
-- [ ] feature task files carry a visible sync rule
-- [ ] docs-only validation passes
+- [ ] `Verify` docs-only detection includes `.codex/**/*.md`
+- [ ] central docs describe the same docs-only file set and branch naming rule
+- [ ] stale use-case path references are removed
+- [ ] docs-only validation wording is consistent
 
 ### Test Plan
 
-- run `npm run lint:md`
 - run `npm run qlty`
+- run `npm test`
+- run `npm run test:web`
+- run `npm run build`
 
 ### Risks
 
-- the sync rule could be too heavy if written like a bureaucratic checklist
-- some feature follow-up items may look stale without being fully closed in
-  code, so each removal must stay conservative
+- docs and workflow rules could drift again if the docs-only file set changes
+  in the workflow but not in the docs
+- expanding docs-only too broadly could hide non-doc changes, so the rule
+  stays scoped to `.codex/**/*.md`
 
 ### Rollback Plan
 
-- restore removed follow-up notes if a task was closed prematurely
-- narrow the sync rule wording if it proves too rigid in practice
+- revert the workflow filter and matching docs changes together
+- narrow the docs-only file set if future `.codex` content stops being purely
+  documentation

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -53,4 +53,7 @@
 - tests cover the behavior being preserved
 - compatibility impact is stated for desktop and web
 - remaining debt is listed instead of hidden
-- branch-level docs are updated when the slice changes roadmap priorities
+- feature `TASKS.md` is updated in the same commit that closes, reframes, or
+  drops a task
+- branch-level docs are updated in the same commit when the slice changes
+  roadmap priorities


### PR DESCRIPTION
## Summary
- align the Verify docs-only filter with repository docs conventions by including .codex markdown files
- document the docs-only branch naming and validation rules consistently across repo guidance
- fix stale use-case path references and align feature plan validation wording

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build
