### PR TITLE
refactor: narrow viewer wiring seams

### DIFF
--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -224,64 +224,62 @@ Use-case note:
 
 ### Task
 
-Align docs-only verification rules, branch naming rules, and stale use-case
-paths with the actual `Verify` workflow behavior.
+Narrow the remaining viewer wiring seam so webview adapters stop depending on
+the full `MyExtension` runtime when they only need telemetry or extension
+context.
 
 ### Why
 
-The repo now has explicit docs-only branch naming guidance, but the
-implementation and documents drifted in two places:
-the `Verify` workflow did not yet treat `.codex/**/*.md` as docs-only, and
-some docs still implied broader docs-only validation or referenced the old
-use-case path.
+`viewerWiring.ts` is already much smaller than before, but the remaining
+factory and mediator setup still pass the full `MyExtension` object into
+webview adapters. That keeps the adapter boundary broader than necessary and
+makes the remaining seam less explicit than it should be.
 
 ### Scope
 
-- update `.github/workflows/verify.yml` so docs-only detection includes
-  `.codex/**/*.md`
-- align central docs and repo guidance with that docs-only file set
-- correct stale `docs/use-cases/` references to
-  `docs/requirements/use-cases/`
-- align docs-only validation wording so markdown lint is the required check
-  for docs-only slices
+- narrow `ViewerFactory` to depend on telemetry instead of `MyExtension`
+- narrow `WebviewMediator` to depend on extension context instead of
+  `MyExtension`
+- keep `createViewerSubscriptions(...)` as the composition point that still
+  owns the full runtime
+- update focused regression tests for factory and mediator construction
 
 ### Non-Goals
 
-- changing runtime code behavior
-- changing parser, flow, list, CSV, diagnostics, hover, or telemetry behavior
-- adding automation tooling beyond explicit repository guidance
-- touching unrelated local modifications outside the docs and verify workflow
+- changing viewer behavior, command ids, or mount timing
+- introducing a new helper file when local wiring remains readable
+- changing parser, list, flow, CSV, diagnostics, hover, or telemetry payloads
 
 ### Constraints
 
-- Keep the docs aligned with actual merged code, not with an aspirational but
-  stale intermediate state.
-- Do not edit unrelated local worktree changes.
-- For docs-only updates, prefer docs-focused validation and skip build.
+- Keep desktop and web extension behavior unchanged.
+- Do not widen webview adapter responsibilities while narrowing constructor
+  dependencies.
+- Keep the slice small and adapter-focused.
 
 ### Design
 
 #### Use case
 
-Repository-level SDD workflow maintenance and verification-rule alignment.
+Remaining activation and webview boundary cleanup.
 
 #### Layers affected
 
-- docs: central SDD workflow guidance, root guidance, skill guidance
-- workflow: docs-only verification filter
+- extension/bootstrap: viewer composition
+- extension/webview: factory and mediator constructor seams
+- tests: viewer factory and mediator regression coverage
 
 #### Key decisions
 
-- Treat `.codex/**/*.md` as docs-only for verification because those files are
-  documentation, not runtime code.
-- Keep docs-only required validation minimal: markdown lint only.
+- `viewerWiring.ts` remains the composition root for the full runtime.
+- Viewer adapters receive only the dependency surface they actually consume.
 
 ### Acceptance Criteria
 
-- [ ] `Verify` docs-only detection includes `.codex/**/*.md`
-- [ ] central docs describe the same docs-only file set and branch naming rule
-- [ ] stale use-case path references are removed
-- [ ] docs-only validation wording is consistent
+- [ ] `ViewerFactory` no longer depends on `MyExtension`
+- [ ] `WebviewMediator` no longer depends on `MyExtension`
+- [ ] `viewerWiring.ts` still owns the full runtime composition
+- [ ] focused regression tests cover the narrowed seams
 
 ### Test Plan
 
@@ -292,13 +290,13 @@ Repository-level SDD workflow maintenance and verification-rule alignment.
 
 ### Risks
 
-- docs and workflow rules could drift again if the docs-only file set changes
-  in the workflow but not in the docs
-- expanding docs-only too broadly could hide non-doc changes, so the rule
-  stays scoped to `.codex/**/*.md`
+- the slice could become a broader bootstrap refactor if too many adapters are
+  touched at once
+- test doubles could hide an accidental runtime dependency if constructor
+  seams are not updated consistently
 
 ### Rollback Plan
 
-- revert the workflow filter and matching docs changes together
-- narrow the docs-only file set if future `.codex` content stops being purely
-  documentation
+- revert the constructor narrowing and keep `MyExtension` flowing through the
+  viewer adapters
+- keep any future seam change separate from this small adapter cleanup

--- a/src/extension/bootstrap/viewerWiring.ts
+++ b/src/extension/bootstrap/viewerWiring.ts
@@ -48,14 +48,14 @@ const createViewerBundle = (
 ): vscode.Disposable[] => {
   const store = new WebviewStore(viewType);
   const mediator = new WebviewMediator(
-    myExtension,
+    myExtension.context,
     viewType,
     store,
     debouncedAjsDocumentChangeFn(300),
   );
   const factory = new ViewerFactory(
     viewType,
-    myExtension,
+    myExtension.telemetry,
     store,
     readyAjsDocument,
     saveHandler,

--- a/src/extension/webview/ViewerFactory.ts
+++ b/src/extension/webview/ViewerFactory.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
 import * as path from "path";
+import type { TelemetryPort } from "../../application/telemetry/TelemetryPort";
 import { postResourceMessage, reportWebviewOperation } from "./messageHandlers";
 import {
   createViewerMessageHandler,
   registerViewerPanelDispose,
 } from "./viewerMessageRouting";
-import { MyExtension } from "../MyExtension";
 
 type ViewerFactoryStore = {
   add(uri: vscode.Uri, panel: vscode.WebviewPanel): void;
@@ -33,21 +33,21 @@ type ViewerReadyHandler = (
 export class ViewerFactory {
   #store: ViewerFactoryStore;
   #viewType: string;
-  #myExtension: MyExtension;
+  #telemetry: TelemetryPort;
   #onReady: ViewerReadyHandler;
   #onSave?: (content: string) => Promise<void>;
   #deps: ViewerFactoryDeps;
 
   public constructor(
     viewType: string,
-    myExtension: MyExtension,
+    telemetry: TelemetryPort,
     store: ViewerFactoryStore,
     onReady: ViewerReadyHandler,
     onSave?: (content: string) => Promise<void>,
     deps: ViewerFactoryDeps = defaultDeps,
   ) {
     this.#viewType = viewType;
-    this.#myExtension = myExtension;
+    this.#telemetry = telemetry;
     this.#store = store;
     this.#onReady = onReady;
     this.#onSave = onSave;
@@ -82,7 +82,7 @@ export class ViewerFactory {
     const onDidReceiveMessage = createViewerMessageHandler({
       document,
       panel,
-      telemetry: this.#myExtension.telemetry,
+      telemetry: this.#telemetry,
       onReady,
       onResource: (event, receivedPanel) => {
         console.log("invoke ViewerFactory.onDidReceiveMessage.", event);

--- a/src/extension/webview/WebviewMediator.ts
+++ b/src/extension/webview/WebviewMediator.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { MyExtension } from "../MyExtension";
 import { LANGUAGE_ID } from "../constant";
 import { mountViewerPanel } from "./mountViewerPanel";
 
@@ -33,14 +32,14 @@ const defaultDeps: WebviewMediatorDeps = {
 
 export class WebviewMediator implements vscode.Disposable {
   #viewType: string;
-  #myExtension: MyExtension;
+  #context: vscode.ExtensionContext;
   #store: WebviewMediatorStore;
   #change: DocumentChangeHandler;
   #deps: WebviewMediatorDeps;
   #subscriptions: vscode.Disposable;
 
   constructor(
-    myExtension: MyExtension,
+    context: vscode.ExtensionContext,
     viewType: string,
     store: WebviewMediatorStore,
     change: DocumentChangeHandler,
@@ -49,7 +48,7 @@ export class WebviewMediator implements vscode.Disposable {
     console.log(`invoke WebviewMediator.constructor. (${viewType})`);
 
     this.#viewType = viewType;
-    this.#myExtension = myExtension;
+    this.#context = context;
     this.#store = store;
     this.#change = change;
     this.#deps = deps;
@@ -120,9 +119,8 @@ export class WebviewMediator implements vscode.Disposable {
 
   private onDidChangeActiveColorTheme(event: vscode.ColorTheme): void {
     console.log("invoke WebviewMediator.onDidChangeActiveColorTheme.", event);
-    const context = this.#myExtension.context;
     this.#store.allPanels.forEach((panel) => {
-      this.#deps.mountPanel(context, panel, this.#viewType);
+      this.#deps.mountPanel(this.#context, panel, this.#viewType);
     });
   }
 

--- a/src/test/suite/viewerFactory.test.ts
+++ b/src/test/suite/viewerFactory.test.ts
@@ -1,7 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import type { TelemetryPort } from "../../application/telemetry/TelemetryPort";
-import { MyExtension } from "../../extension/MyExtension";
 import { ViewerFactory } from "../../extension/webview/ViewerFactory";
 import { OPERATION, READY, RESOURCE, SAVE } from "../../shared/webviewEvents";
 
@@ -26,10 +25,7 @@ suite("ViewerFactory", () => {
 
     const factory = new ViewerFactory(
       "ajsbutler.testViewer",
-      MyExtension.init(
-        { subscriptions: [] } as unknown as vscode.ExtensionContext,
-        telemetry,
-      ),
+      telemetry,
       {
         panelByUri() {
           return existingPanel;
@@ -79,10 +75,7 @@ suite("ViewerFactory", () => {
 
     const factory = new ViewerFactory(
       "ajsbutler.testViewer",
-      MyExtension.init(
-        { subscriptions: [] } as unknown as vscode.ExtensionContext,
-        telemetry,
-      ),
+      telemetry,
       {
         panelByUri() {
           return undefined;
@@ -161,10 +154,7 @@ suite("ViewerFactory", () => {
 
     const factory = new ViewerFactory(
       "ajsbutler.testViewer",
-      MyExtension.init(
-        { subscriptions: [] } as unknown as vscode.ExtensionContext,
-        telemetry,
-      ),
+      telemetry,
       {
         removeByUri(uri) {
           removed.push(uri.toString());

--- a/src/test/suite/webviewMediator.test.ts
+++ b/src/test/suite/webviewMediator.test.ts
@@ -1,7 +1,5 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { TelemetryPort } from "../../application/telemetry/TelemetryPort";
-import { MyExtension } from "../../extension/MyExtension";
 import { WebviewMediator } from "../../extension/webview/WebviewMediator";
 
 type Listener<T> = (event: T) => void;
@@ -21,14 +19,9 @@ suite("WebviewMediator", () => {
     let onRenameFiles: Listener<vscode.FileRenameEvent> | undefined;
     let onChangeTheme: Listener<vscode.ColorTheme> | undefined;
 
-    const telemetry: TelemetryPort = {
-      trackEvent() {},
-      dispose() {},
-    };
-    const extension = MyExtension.init(
-      { subscriptions: [] } as unknown as vscode.ExtensionContext,
-      telemetry,
-    );
+    const context = {
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
     const document = {
       languageId: "jp1ajs",
       uri: { toString: () => "file:///sample.ajs" },
@@ -44,7 +37,7 @@ suite("WebviewMediator", () => {
     } as unknown as vscode.WebviewPanel;
 
     const mediator = new WebviewMediator(
-      extension,
+      context,
       "ajsbutler.testViewer",
       {
         panelByUri(receivedUri) {


### PR DESCRIPTION
## Summary
- narrow ViewerFactory to the telemetry dependency it actually uses
- narrow WebviewMediator to the extension context it actually uses
- keep viewerWiring as the full runtime composition point and update focused tests

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build
