### PR TITLE
docs: audit feature sdd task lists

### DIFF
--- a/docs/specs/features/build-unit-list/TASKS.md
+++ b/docs/specs/features/build-unit-list/TASKS.md
@@ -18,4 +18,9 @@
 ## Remaining Follow-up
 
 - [ ] Decide whether filtering/search should become a separate application use case
-- [ ] Keep fixture guidance and manual verification notes current
+
+## Notes
+
+- Fixture guidance and manual verification notes are maintenance concerns.
+  Keep them current when that evidence changes, but do not track them as an
+  always-open slice task.

--- a/docs/specs/features/normalize-ajs-document/TASKS.md
+++ b/docs/specs/features/normalize-ajs-document/TASKS.md
@@ -17,11 +17,6 @@
 
 ## Remaining Follow-up
 
-- [ ] Revisit normalized-model extraction only when a wrapper rule is both
-      broadly reusable and still duplicated outside the owning wrapper
-- [ ] Prefer fixture-backed normalization coverage for remaining edge cases such
-      as encoding-sensitive documents and larger definitions, instead of
-      creating new abstractions without repeated consumers
 - [x] Keep adapter-boundary docs aligned when a semantic intentionally remains
       wrapper-local or application-local, so future slices do not re-open
       already settled extraction decisions
@@ -147,3 +142,11 @@
 - [x] Document which semantics intentionally remain in application view adapters
 - [x] Document the current capability/shared/local wrapper semantics matrix so
       future refactors use the same extraction criteria
+
+## Notes
+
+- Revisit normalized-model extraction only when a wrapper rule is both broadly
+  reusable and still duplicated outside the owning wrapper.
+- Prefer fixture-backed normalization coverage for remaining edge cases such as
+  encoding-sensitive documents and larger definitions, instead of creating new
+  abstractions without repeated consumers.

--- a/docs/specs/features/provide-editor-feedback/TASKS.md
+++ b/docs/specs/features/provide-editor-feedback/TASKS.md
@@ -18,4 +18,9 @@
 ## Remaining Follow-up
 
 - [ ] Record a current manual smoke-test result for diagnostics and hover behavior
-- [ ] Continue reducing activation/bootstrap concentration around registration wiring
+
+## Notes
+
+- Remaining activation/bootstrap concentration around registration wiring is
+  tracked as branch-level architecture work in `docs/specs/plans.md`, not as a
+  feature-local follow-up for editor feedback alone.

--- a/docs/specs/features/record-telemetry/TASKS.md
+++ b/docs/specs/features/record-telemetry/TASKS.md
@@ -18,4 +18,8 @@
 ## Remaining Follow-up
 
 - [ ] Continue verifying browser-hosted telemetry behavior and fallback handling
-- [ ] Keep privacy constraints explicit in follow-on telemetry changes
+
+## Notes
+
+- Privacy constraints are ongoing policy, not a standing open slice task.
+  Keep them explicit in follow-on telemetry work per `AGENTS.md`.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -45,6 +45,9 @@ structure in `docs/specs/features/<feature>/`.
   table and flow viewers consume the same normalized
   `absolutePath -> UnitDefinitionDialogDto` mapping path instead of
   rebuilding equivalent dialog DTO maps separately.
+- Feature-local `TASKS.md` files now distinguish actionable follow-up debt
+  from standing policy or maintenance notes, so open task lists stay aligned
+  with real remaining work.
 
 ### How To Maintain This Section
 
@@ -65,12 +68,12 @@ structure in `docs/specs/features/<feature>/`.
 2. Close the remaining activation and webview concentration by deciding which
    pieces should stay as local wiring in `viewerWiring.ts` and which deserve
    a stable application or infrastructure boundary.
-3. Audit feature-local SDD files under `docs/specs/features/` and remove stale
-   tasks that no longer match what has already merged to `main`.
-4. Keep wrapper refactoring selective:
+3. Keep wrapper refactoring selective:
    extract only semantics that are cross-unit or shared with normalization,
    and keep unit-local JP1/AJS rules on the owning wrapper when abstraction
    would be artificial.
+4. Verify browser-hosted telemetry behavior and fallback handling so the
+   telemetry follow-up does not remain purely assumption-based.
 5. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, or shared adapters change.
 
@@ -231,79 +234,74 @@ Use-case note:
 
 ### Task
 
-Close the remaining `show-unit-definition` follow-up by removing duplicated
-viewer-local dialog DTO reconstruction and updating the synced SDD docs.
+Audit feature-local SDD task lists and remove stale open items that are really
+standing policy notes or maintenance guidance.
 
 ### Why
 
-The feature already moved away from wrapper-backed dialog state, but the table
-and flow viewers still each built their own path-to-dialog DTO map. That keeps
-the same application-facing behavior duplicated in presentation and makes the
-remaining follow-up harder to verify and close cleanly.
+Several feature `TASKS.md` files still mixed concrete follow-up work with
+evergreen policies such as privacy constraints, extraction guardrails, or
+maintenance reminders. That makes the open task lists noisier than they should
+be and weakens the value of `TASKS.md` as an execution tracker.
 
 ### Scope
 
-- extract a shared normalized-unit mapping helper for unit-definition DTOs
-- switch table and flow viewers to that shared helper
-- extend focused regression coverage for the shared mapping path
-- sync feature and branch-level SDD docs with the closed follow-up
+- review remaining unchecked items across feature `TASKS.md` files
+- keep concrete follow-up work as open tasks
+- move standing guidance into `Notes` where the item is not an actionable
+  slice
+- sync branch-level plans and roadmap after the audit
 
 ### Non-Goals
 
-- changing dialog content, command ids, or open/close behavior
-- adding a new wrapper abstraction or reintroducing `UnitEntity`
-- claiming interactive smoke coverage that was not actually run
+- changing product behavior or code
+- closing legitimate manual smoke or browser-verification debt without
+  evidence
+- rewriting feature history into a changelog
 
 ### Constraints
 
-- Keep desktop and web extension behavior unchanged.
-- Keep the slice small and feature-focused.
-- Use the normalized AJS model as the only input to dialog DTO construction.
+- Keep the slice docs-only.
+- Preserve a clear separation between actionable follow-up debt and policy.
+- Do not remove open tasks that still correspond to real unresolved work.
 
 ### Design
 
 #### Use case
 
-`ShowUnitDefinition` follow-up cleanup.
+Feature-local SDD maintenance.
 
 #### Layers affected
 
-- application: unit-definition DTO mapping
-- presentation: table and flow viewer consumption
-- tests: unit-definition mapping regression coverage
-- docs/specs: feature tasks and branch-level planning sync
+- docs/specs/features: task-list cleanup
+- docs/specs: branch-level planning sync
 
 #### Key decisions
 
-- Table and flow should share one `absolutePath -> UnitDefinitionDialogDto`
-  mapping helper instead of rebuilding equivalent maps locally.
-- Interactive smoke verification remains open until it is run in an actual
-  VS Code environment and recorded in docs.
+- Open tasks should represent concrete remaining work, not standing policy.
+- Evergreen guidance should move to `Notes` instead of remaining indefinitely
+  under `## Remaining Follow-up`.
 
 ### Acceptance Criteria
 
-- [x] table and flow both consume a shared normalized DTO mapping path
-- [x] tests cover nested unit mapping without requiring wrapper instances
-- [x] `docs/specs/features/show-unit-definition/TASKS.md` reflects the closed
-      code follow-up and the remaining manual smoke debt
+- [x] feature task lists keep real unresolved work as open items
+- [x] standing policy or maintenance guidance is moved out of open task lists
+- [x] `docs/specs/plans.md` and `docs/specs/roadmap.md` reflect the post-audit
+      priorities
 
 ### Test Plan
 
-- run `npm run qlty`
-- run `npm test`
-- run `npm run test:web`
-- run `npm run build`
+- run `npm run lint:md`
 
 ### Risks
 
-- viewer behavior could drift if the shared mapping changes path keys or raw
-  parameter formatting
-- docs could imply manual verification is complete when only automated
-  regression coverage was added
+- a real unresolved follow-up could be misclassified as mere guidance
+- branch-level priorities could drift if the roadmap is not updated with the
+  audit outcome
 
 ### Rollback Plan
 
-- revert the shared mapping helper and restore the prior viewer-local map
-  construction
-- keep manual smoke verification as a separate follow-up if interactive
-  validation cannot be run in this environment
+- restore any removed open task if later inspection shows it still represents
+  real unresolved work
+- keep the audit slice docs-only and defer any code follow-up to a separate
+  branch

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -32,10 +32,10 @@
 2. Keep wrapper-domain cleanup selective:
    move only cross-unit or normalization-shared semantics into helpers, and
    avoid abstracting unit-local JP1/AJS rules prematurely.
-3. Bring feature-local SDD files back in sync with the current merged state so
-   task lists stop describing already-finished slices.
-4. Record current manual smoke-test results for completed viewer-facing slices
+3. Record current manual smoke-test results for completed viewer-facing slices
    so remaining verification debt is explicit instead of implicit.
+4. Verify browser-hosted telemetry behavior and fallback handling instead of
+   leaving that follow-up as a standing assumption.
 5. Keep validating desktop and web extension compatibility while managing
    bundle-size and shared-runtime risk.
 
@@ -59,3 +59,5 @@
   drops a task
 - branch-level docs are updated in the same commit when the slice changes
   roadmap priorities
+- open task lists prefer actionable remaining work over evergreen policy or
+  maintenance reminders


### PR DESCRIPTION
## Summary
- remove stale always-open items from feature TASKS files when they are really standing policy or maintenance notes
- keep only actionable remaining work unchecked across feature task lists
- sync branch-level plans and roadmap after the audit

## Validation
- npm run lint:md