### PR TITLE
docs: record editor feedback smoke coverage

### DIFF
--- a/docs/specs/features/provide-editor-feedback/TASKS.md
+++ b/docs/specs/features/provide-editor-feedback/TASKS.md
@@ -17,10 +17,17 @@
 
 ## Remaining Follow-up
 
-- [ ] Record a current manual smoke-test result for diagnostics and hover behavior
+- [x] Record a current manual smoke-test result for diagnostics and hover behavior
 
 ## Notes
 
+- 2026-04-11: desktop integration coverage in
+  `src/test/suite/extension.test.ts` verifies that invalid JP1/AJS documents
+  still produce diagnostics and that parameter hover still returns results
+  through the VS Code extension surface.
+- 2026-04-11: browser-hosted smoke coverage in `src/test/suite/webSmoke.ts`
+  verifies the same diagnostics and hover behaviors in the web entry path, so
+  this follow-up is covered by automated smoke-style verification.
 - Remaining activation/bootstrap concentration around registration wiring is
   tracked as branch-level architecture work in `docs/specs/plans.md`, not as a
   feature-local follow-up for editor feedback alone.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -58,6 +58,10 @@ structure in `docs/specs/features/<feature>/`.
 - Unit-list filtering and search remain presentation-local by decision:
   the current behavior depends on TanStack Table row access and fuzzy matching
   over view values, so it does not yet justify a separate application use case.
+- Editor-feedback smoke coverage is now explicit:
+  existing desktop integration tests and the web smoke runner both verify the
+  diagnostics and hover path, so that feature no longer depends on an
+  unrecorded manual check.
 
 ### How To Maintain This Section
 
@@ -81,8 +85,9 @@ structure in `docs/specs/features/<feature>/`.
    would be artificial.
 3. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, or shared adapters change.
-4. Record current manual smoke-test results for CSV export and
-   diagnostics/hover so the remaining feature follow-ups stay evidence-based.
+4. Record current manual smoke-test results for show-unit-definition,
+   build-unit-list-view, build-flow-graph, and CSV export so the remaining
+   feature follow-ups stay evidence-based.
 5. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -33,8 +33,9 @@
    so remaining verification debt is explicit instead of implicit.
 3. Keep validating desktop and web extension compatibility while managing
    bundle-size and shared-runtime risk.
-4. Record manual smoke results for CSV export and diagnostics/hover so those
-   feature follow-ups do not remain open indefinitely.
+4. Record manual smoke results for show-unit-definition, build-flow-graph,
+   build-unit-list-view, and CSV export so those feature follow-ups do not
+   remain open indefinitely.
 5. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 


### PR DESCRIPTION
## Summary
- close the provide-editor-feedback smoke follow-up using existing desktop and web smoke-style test coverage
- record the specific evidence in the feature TASKS file
- sync branch-level plans and roadmap after removing that remaining debt

## Validation
- npm run lint:md