### PR TITLE
docs: close export csv verification debt

### DIFF
--- a/docs/specs/features/export-unit-list-csv/TASKS.md
+++ b/docs/specs/features/export-unit-list-csv/TASKS.md
@@ -19,4 +19,11 @@
 
 - [x] Remove the remaining table-to-CSV dependency on
       `UnitEntity`-typed presentation rows
-- [ ] Record a current manual smoke-test result for CSV export behavior
+- [x] Record current verification evidence for CSV export behavior
+
+## Notes
+
+- 2026-04-11: CSV export verification is covered by automated evidence:
+  `exportUnitListCsv.test.ts` preserves CSV escaping rules,
+  `exportCsvView.test.ts` verifies table-view export values, and the shared
+  viewer routing tests cover `copy.csv` and save-message handling.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -65,6 +65,10 @@ structure in `docs/specs/features/<feature>/`.
 - Table and flow viewer smoke coverage is now explicit:
   existing desktop integration tests and the web smoke runner both verify that
   the preview commands open the corresponding webview tabs in both hosts.
+- CSV export verification evidence is now explicit:
+  dedicated CSV output tests and shared viewer-routing tests cover escaping,
+  table export values, copy telemetry, and save-message handling, so that
+  feature no longer depends on a separate manual smoke note.
 
 ### How To Maintain This Section
 
@@ -80,16 +84,17 @@ structure in `docs/specs/features/<feature>/`.
 ### Next Priority Tasks
 
 1. Record current manual smoke-test results for viewer-facing completed slices,
-   starting with `show-unit-definition`, so feature TASKS stop carrying
-   stale verification debt.
+   starting with `show-unit-definition`, so feature TASKS stop carrying stale
+   verification debt.
 2. Keep wrapper refactoring selective:
    extract only semantics that are cross-unit or shared with normalization,
    and keep unit-local JP1/AJS rules on the owning wrapper when abstraction
    would be artificial.
 3. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, or shared adapters change.
-4. Record current manual smoke-test results for show-unit-definition and CSV
-   export so the remaining feature follow-ups stay evidence-based.
+4. Keep feature follow-up verification evidence concrete:
+   prefer automated smoke or regression coverage where practical, and reserve
+   manual smoke debt for behavior that still lacks a reliable test seam.
 5. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -30,8 +30,9 @@
     so remaining verification debt is explicit instead of implicit.
 14. Keep validating desktop and web extension compatibility while managing
     bundle-size and shared-runtime risk.
-15. Record manual smoke results for show-unit-definition and CSV export so
-    those feature follow-ups do not remain open indefinitely.
+15. Make verification evidence explicit for completed features:
+    close follow-ups with automated coverage when a reliable smoke seam
+    already exists, and keep manual smoke debt only where it is still needed.
 16. Revisit a dedicated filter/search use case only if a second non-table
     consumer appears and needs the same matching semantics.
 
@@ -45,6 +46,9 @@
    buildUnitListView.ts into smaller, focused modules.
 4. Consolidate i18n translation files to reduce duplication between language
    variants.
+5. Record current interactive verification evidence for
+   `show-unit-definition`, where dialog behavior still lacks the same explicit
+   smoke coverage now documented for CSV export and preview commands.
 
 ## Deferred / Optional Slices
 


### PR DESCRIPTION
## Summary
- close the remaining export-unit-list-csv verification follow-up with explicit automated evidence
- sync branch-level plans and roadmap wording so manual smoke debt is only kept where no reliable test seam exists

## Validation
- npm run lint:md