### PR TITLE
refactor: extract unit list view helpers

### DIFF
--- a/docs/specs/features/build-unit-list-view/TASKS.md
+++ b/docs/specs/features/build-unit-list-view/TASKS.md
@@ -34,3 +34,7 @@
   verifies that the same table viewer command path executes in the web entry
   flow without failing, so this follow-up is covered by automated smoke-style
   verification.
+- 2026-04-12: internal calendar, priority, and schedule-value parsing helpers
+  can be extracted independently from `buildUnitListView.ts` without changing
+  the `UnitListRowView` contract, so future complexity-reduction slices should
+  prefer helper extraction over another broad rewrite.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -89,10 +89,13 @@ structure in `docs/specs/features/<feature>/`.
    would be artificial.
 2. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, or shared adapters change.
-3. Keep feature follow-up verification evidence concrete:
+3. Reduce `buildUnitListView.ts` incrementally:
+   extract calendar, priority, and schedule parsing helpers into focused
+   modules while preserving the existing `UnitListRowView` contract and tests.
+4. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-4. Revisit a dedicated filter/search use case only if a second non-table
+5. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 
 ## Wrapper Semantics Matrix

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -40,15 +40,13 @@
 
 1. Refactor unit model classes to reduce code duplication across similar unit
    types.
-2. Break down high-complexity functions in application layer (e.g.,
-   buildUnitListView, parameterHelpers, unitPriorityHelpers).
+2. Break down high-complexity functions in the application layer, starting
+   with focused helper extraction from `buildUnitListView.ts` instead of
+   another broad rewrite.
 3. Extract common logic from large files like ParameterFactory.ts and
    buildUnitListView.ts into smaller, focused modules.
 4. Consolidate i18n translation files to reduce duplication between language
    variants.
-5. Record current interactive verification evidence for
-   `show-unit-definition`, where dialog behavior still lacks the same explicit
-   smoke coverage now documented for CSV export and preview commands.
 
 ## Deferred / Optional Slices
 

--- a/src/application/unit-list/buildUnitListView.ts
+++ b/src/application/unit-list/buildUnitListView.ts
@@ -4,13 +4,24 @@ import {
   AjsRelationType,
   AjsUnit,
   AjsUnitType,
-  findAjsUnitParameter,
   findAjsUnitParameterValue,
   findAjsUnitParameterValues,
   findParentAjsUnit,
   flattenAjsUnits,
 } from "../../domain/models/ajs/AjsDocument";
-import { WeekSymbol, isWeekSymbol } from "../../domain/values/AjsType";
+import {
+  buildCalendarWeekView,
+  getPriorityForUnitTypes,
+  isNonWeekCalendarValue,
+  parseCftd,
+  parseCy,
+  parseLnParentRule,
+  parseSd,
+  parseSh,
+  parseShd,
+  parseTimeValue,
+  parseWc,
+} from "./unitListViewHelpers";
 
 export type UnitListGroup1View = {
   name: string;
@@ -255,169 +266,6 @@ export type UnitListRowView = {
   group8: UnitListGroup8View;
   group9: UnitListGroup9View;
 };
-
-const weekSymbols: WeekSymbol[] = ["su", "mo", "tu", "we", "th", "fr", "sa"];
-
-const getCalendarWeekSymbol = (value: string): WeekSymbol | undefined => {
-  const parsedValue = value.split(":")[0];
-  return isWeekSymbol(parsedValue) ? parsedValue : undefined;
-};
-
-const buildCalendarWeekView = (
-  openValues: string[],
-  closeValues: string[],
-): Record<WeekSymbol, boolean | undefined> =>
-  Object.fromEntries(
-    weekSymbols.map((weekSymbol) => [
-      weekSymbol,
-      openValues.some((value) => getCalendarWeekSymbol(value) === weekSymbol)
-        ? true
-        : closeValues.some(
-              (value) => getCalendarWeekSymbol(value) === weekSymbol,
-            )
-          ? false
-          : undefined,
-    ]),
-  ) as Record<WeekSymbol, boolean | undefined>;
-
-const isNonWeekCalendarValue = (value: string): boolean =>
-  getCalendarWeekSymbol(value) === undefined;
-
-const toNiPriority = (value: string): number => {
-  const nice = Number(value);
-  if (nice > 10) {
-    return 5;
-  }
-  if (nice > 0) {
-    return 4;
-  }
-  if (nice === 0) {
-    return 3;
-  }
-  if (nice > -11) {
-    return 2;
-  }
-  return 1;
-};
-
-const getPriorityForUnitTypes = (
-  document: AjsDocument,
-  unit: AjsUnit,
-  priorityById: Map<string, number>,
-  targetUnitTypes: readonly AjsUnitType[],
-): number | undefined => {
-  const cachedPriority = priorityById.get(unit.id);
-  if (cachedPriority !== undefined) {
-    return cachedPriority;
-  }
-  if (!targetUnitTypes.includes(unit.unitType)) {
-    return undefined;
-  }
-
-  const pr = findAjsUnitParameter(unit, "pr");
-  const ni = findAjsUnitParameter(unit, "ni");
-
-  const prPriority =
-    pr && pr.value !== undefined && pr.value !== ""
-      ? Number(pr.value)
-      : undefined;
-  const niPriority = ni ? toNiPriority(ni.value) : undefined;
-
-  if (prPriority !== undefined && niPriority !== undefined) {
-    const priority =
-      (pr.position ?? -1) > (ni.position ?? -1) ? prPriority : niPriority;
-    priorityById.set(unit.id, priority);
-    return priority;
-  }
-  if (prPriority !== undefined) {
-    priorityById.set(unit.id, prPriority);
-    return prPriority;
-  }
-  if (niPriority !== undefined) {
-    priorityById.set(unit.id, niPriority);
-    return niPriority;
-  }
-
-  const parent = findParentAjsUnit(document, unit);
-  if (parent && (parent.unitType === "n" || parent.unitType === "rn")) {
-    const parentPriority = getPriorityForUnitTypes(
-      document,
-      parent,
-      priorityById,
-      ["n", "rn"],
-    );
-    if (parentPriority !== undefined) {
-      priorityById.set(unit.id, parentPriority);
-      return parentPriority;
-    }
-  }
-  priorityById.set(unit.id, 1);
-  return 1;
-};
-
-const parseRulePrefix = (value: string): { rule?: string; body: string } => {
-  const matched = /^(\d{1,3}),(.*)$/.exec(value);
-  return matched ? { rule: matched[1], body: matched[2] } : { body: value };
-};
-
-const parseLnParentRule = (value: string): string =>
-  parseRulePrefix(value).body;
-
-const parseSd = (
-  value: string,
-): { type: string; yearMonth: string; day: string } => {
-  const matched =
-    /^((\d{1,3}),)?((\d{4}\/)?\d{2}\/)?(([+*@])?\d{2}|([+*@])?b(-\d{2})?|\+?(su|mo|tu|we|th|fr|sa)(:(\d|b))?|en|ud)/.exec(
-      value,
-    );
-  const yearMonth = matched?.[3]?.slice(0, -1) ?? "";
-  const dayValue = matched?.[5] ?? "";
-  const type =
-    dayValue === "en" || dayValue === "ud"
-      ? dayValue
-      : dayValue.startsWith("+")
-        ? "+"
-        : dayValue.startsWith("*")
-          ? "*"
-          : dayValue.startsWith("@")
-            ? "@"
-            : "";
-  const day =
-    dayValue && dayValue !== "en" && dayValue !== "ud"
-      ? dayValue.replace(/^[+*@]/, "")
-      : "";
-  return { type, yearMonth, day };
-};
-
-const parseTimeValue = (value: string, fallback = ""): string =>
-  /^((\d{1,3}),)?(no|([+]?)\d{2}:\d{2}|([MCU])?\d{1,4}|un)?/.exec(value)?.[3] ??
-  fallback;
-
-const parseCy = (value: string): string =>
-  /^((\d{1,3}),)?\(((\d{1,3}),([ymwd]))\)/.exec(value)?.[3] ?? "";
-
-const parseSh = (value: string): string =>
-  /^((\d{1,3}),)?(be|af|ca|no)/.exec(value)?.[3] ?? "";
-
-const parseShd = (value: string): string =>
-  /^((\d{1,3}),)?(\d{1,3})/.exec(value)?.[3] ?? "2";
-
-const parseCftd = (
-  value: string,
-): { scheduleByDaysFromStart: string; maxShiftableDays: string } => {
-  const matched =
-    /^((\d{1,3}),)?(no|be|af|db|da)((,(\d{1,2}))(,(\d{1,2}))?)?/.exec(value);
-  const type = matched?.[3] ?? "no";
-  return {
-    scheduleByDaysFromStart:
-      type === "no" ? "no" : `${type},${matched?.[6] ?? "1"}`,
-    maxShiftableDays:
-      type && ["no", "db", "da"].includes(type) ? "" : (matched?.[8] ?? "10"),
-  };
-};
-
-const parseWc = (value: string): string =>
-  /^((\d{1,3}),)?(.+)/.exec(value)?.[3] ?? "1";
 
 export const buildUnitListView = (document: AjsDocument): UnitListRowView[] => {
   const units = flattenAjsUnits(document.rootUnits);

--- a/src/application/unit-list/unitListViewHelpers.ts
+++ b/src/application/unit-list/unitListViewHelpers.ts
@@ -1,0 +1,171 @@
+import {
+  AjsDocument,
+  AjsUnit,
+  AjsUnitType,
+  findAjsUnitParameter,
+  findParentAjsUnit,
+} from "../../domain/models/ajs/AjsDocument";
+import { WeekSymbol, isWeekSymbol } from "../../domain/values/AjsType";
+
+const weekSymbols: WeekSymbol[] = ["su", "mo", "tu", "we", "th", "fr", "sa"];
+
+const getCalendarWeekSymbol = (value: string): WeekSymbol | undefined => {
+  const parsedValue = value.split(":")[0];
+  return isWeekSymbol(parsedValue) ? parsedValue : undefined;
+};
+
+export const buildCalendarWeekView = (
+  openValues: string[],
+  closeValues: string[],
+): Record<WeekSymbol, boolean | undefined> =>
+  Object.fromEntries(
+    weekSymbols.map((weekSymbol) => [
+      weekSymbol,
+      openValues.some((value) => getCalendarWeekSymbol(value) === weekSymbol)
+        ? true
+        : closeValues.some(
+              (value) => getCalendarWeekSymbol(value) === weekSymbol,
+            )
+          ? false
+          : undefined,
+    ]),
+  ) as Record<WeekSymbol, boolean | undefined>;
+
+export const isNonWeekCalendarValue = (value: string): boolean =>
+  getCalendarWeekSymbol(value) === undefined;
+
+const toNiPriority = (value: string): number => {
+  const nice = Number(value);
+  if (nice > 10) {
+    return 5;
+  }
+  if (nice > 0) {
+    return 4;
+  }
+  if (nice === 0) {
+    return 3;
+  }
+  if (nice > -11) {
+    return 2;
+  }
+  return 1;
+};
+
+export const getPriorityForUnitTypes = (
+  document: AjsDocument,
+  unit: AjsUnit,
+  priorityById: Map<string, number>,
+  targetUnitTypes: readonly AjsUnitType[],
+): number | undefined => {
+  const cachedPriority = priorityById.get(unit.id);
+  if (cachedPriority !== undefined) {
+    return cachedPriority;
+  }
+  if (!targetUnitTypes.includes(unit.unitType)) {
+    return undefined;
+  }
+
+  const pr = findAjsUnitParameter(unit, "pr");
+  const ni = findAjsUnitParameter(unit, "ni");
+
+  const prPriority =
+    pr && pr.value !== undefined && pr.value !== ""
+      ? Number(pr.value)
+      : undefined;
+  const niPriority = ni ? toNiPriority(ni.value) : undefined;
+
+  if (prPriority !== undefined && niPriority !== undefined) {
+    const priority =
+      (pr.position ?? -1) > (ni.position ?? -1) ? prPriority : niPriority;
+    priorityById.set(unit.id, priority);
+    return priority;
+  }
+  if (prPriority !== undefined) {
+    priorityById.set(unit.id, prPriority);
+    return prPriority;
+  }
+  if (niPriority !== undefined) {
+    priorityById.set(unit.id, niPriority);
+    return niPriority;
+  }
+
+  const parent = findParentAjsUnit(document, unit);
+  if (parent && (parent.unitType === "n" || parent.unitType === "rn")) {
+    const parentPriority = getPriorityForUnitTypes(
+      document,
+      parent,
+      priorityById,
+      ["n", "rn"],
+    );
+    if (parentPriority !== undefined) {
+      priorityById.set(unit.id, parentPriority);
+      return parentPriority;
+    }
+  }
+  priorityById.set(unit.id, 1);
+  return 1;
+};
+
+const parseRulePrefix = (value: string): { rule?: string; body: string } => {
+  const matched = /^(\d{1,3}),(.*)$/.exec(value);
+  return matched ? { rule: matched[1], body: matched[2] } : { body: value };
+};
+
+export const parseLnParentRule = (value: string): string =>
+  parseRulePrefix(value).body;
+
+export const parseSd = (
+  value: string,
+): { type: string; yearMonth: string; day: string } => {
+  const matched =
+    /^((\d{1,3}),)?((\d{4}\/)?\d{2}\/)?(([+*@])?\d{2}|([+*@])?b(-\d{2})?|\+?(su|mo|tu|we|th|fr|sa)(:(\d|b))?|en|ud)/.exec(
+      value,
+    );
+  const yearMonth = matched?.[3]?.slice(0, -1) ?? "";
+  const dayValue = matched?.[5] ?? "";
+  const type =
+    dayValue === "en" || dayValue === "ud"
+      ? dayValue
+      : dayValue.startsWith("+")
+        ? "+"
+        : dayValue.startsWith("*")
+          ? "*"
+          : dayValue.startsWith("@")
+            ? "@"
+            : "";
+  const day =
+    dayValue && dayValue !== "en" && dayValue !== "ud"
+      ? dayValue.replace(/^[+*@]/, "")
+      : "";
+  return { type, yearMonth, day };
+};
+
+export const parseTimeValue = (value: string, fallback = ""): string =>
+  /^((\d{1,3}),)?(no|([+]?)\d{2}:\d{2}|([MCU])?\d{1,4}|un)?/.exec(value)?.[3] ??
+  fallback;
+
+export const parseCy = (value: string): string =>
+  /^((\d{1,3}),)?\(((\d{1,3}),([ymwd]))\)/.exec(value)?.[3] ?? "";
+
+export const parseSh = (value: string): string =>
+  /^((\d{1,3}),)?(be|af|ca|no)/.exec(value)?.[3] ?? "";
+
+export const parseShd = (value: string): string =>
+  /^((\d{1,3}),)?(\d{1,3})/.exec(value)?.[3] ?? "2";
+
+export const parseCftd = (
+  value: string,
+): { scheduleByDaysFromStart: string; maxShiftableDays: string } => {
+  const matched =
+    /^((\d{1,3}),)?(no|be|af|db|da)((,(\d{1,2}))(,(\d{1,2}))?)?/.exec(value);
+  const type = matched?.[3] ?? "no";
+  return {
+    scheduleByDaysFromStart:
+      type === "no" ? "no" : `${type},${matched?.[6] ?? "1"}`,
+    maxShiftableDays:
+      type && ["no", "db", "da"].includes(type) ? "" : (matched?.[8] ?? "10"),
+  };
+};
+
+export const parseWc = (value: string): string =>
+  /^((\d{1,3}),)?(.+)/.exec(value)?.[3] ?? "1";

--- a/src/test/suite/unitListViewHelpers.test.ts
+++ b/src/test/suite/unitListViewHelpers.test.ts
@@ -1,0 +1,133 @@
+import * as assert from "assert";
+import { AjsDocument, AjsUnit } from "../../domain/models/ajs/AjsDocument";
+import {
+  buildCalendarWeekView,
+  getPriorityForUnitTypes,
+  isNonWeekCalendarValue,
+  parseCftd,
+  parseCy,
+  parseLnParentRule,
+  parseSd,
+  parseSh,
+  parseShd,
+  parseTimeValue,
+  parseWc,
+} from "../../application/unit-list/unitListViewHelpers";
+
+const createUnit = (overrides: Partial<AjsUnit> = {}): AjsUnit => ({
+  id: "u1",
+  name: "unit",
+  unitAttribute: "unit,,jp1admin,",
+  permission: "jp1admin",
+  jp1Username: "jp1admin",
+  jp1ResourceGroup: undefined,
+  unitType: "j",
+  groupType: undefined,
+  comment: undefined,
+  absolutePath: "/root/unit",
+  depth: 1,
+  parentId: "root",
+  isRoot: false,
+  isRecovery: false,
+  isRootJobnet: false,
+  hasSchedule: false,
+  hasWaitedFor: false,
+  layout: { h: 80, v: 48 },
+  parameters: [],
+  relations: [],
+  children: [],
+  ...overrides,
+});
+
+suite("Unit List View helpers", () => {
+  test("maps calendar week flags and non-week values separately", () => {
+    const weekView = buildCalendarWeekView(
+      ["mo:1", "2024/01/01"],
+      ["tu:2", "2024/01/02"],
+    );
+
+    assert.strictEqual(weekView.mo, true);
+    assert.strictEqual(weekView.tu, false);
+    assert.strictEqual(weekView.we, undefined);
+    assert.strictEqual(isNonWeekCalendarValue("2024/01/01"), true);
+    assert.strictEqual(isNonWeekCalendarValue("mo:1"), false);
+  });
+
+  test("resolves priority from ni, pr precedence, and parent inheritance", () => {
+    const root = createUnit({
+      id: "root",
+      name: "root",
+      absolutePath: "/root",
+      depth: 0,
+      parentId: undefined,
+      unitType: "n",
+      isRoot: true,
+      isRootJobnet: true,
+      parameters: [
+        { key: "ni", value: "5", position: 1 },
+        { key: "pr", value: "4", position: 2 },
+      ],
+    });
+    const child = createUnit({
+      id: "child",
+      absolutePath: "/root/child",
+      unitType: "j",
+      parameters: [],
+    });
+    const qjob = createUnit({
+      id: "qjob",
+      absolutePath: "/root/qjob",
+      unitType: "qj",
+      parameters: [{ key: "ni", value: "0", position: 1 }],
+    });
+    root.children = [child, qjob];
+
+    const document: AjsDocument = {
+      rootUnits: [root],
+      warnings: [],
+    };
+
+    assert.strictEqual(
+      getPriorityForUnitTypes(document, root, new Map(), ["n", "rn"]),
+      4,
+    );
+    assert.strictEqual(
+      getPriorityForUnitTypes(document, child, new Map(), ["j", "rj"]),
+      4,
+    );
+    assert.strictEqual(
+      getPriorityForUnitTypes(document, qjob, new Map(), [
+        "j",
+        "rj",
+        "pj",
+        "rp",
+        "qj",
+        "rq",
+      ]),
+      3,
+    );
+  });
+
+  test("parses schedule-related parameter fragments consistently", () => {
+    assert.deepStrictEqual(parseSd("2024/12/+31"), {
+      type: "+",
+      yearMonth: "2024/12",
+      day: "31",
+    });
+    assert.deepStrictEqual(parseSd("2,en"), {
+      type: "en",
+      yearMonth: "",
+      day: "",
+    });
+    assert.strictEqual(parseLnParentRule("2,parent-rule"), "parent-rule");
+    assert.strictEqual(parseTimeValue("09:30", "+00:00"), "09:30");
+    assert.strictEqual(parseCy("(3,d)"), "3,d");
+    assert.strictEqual(parseSh("be"), "be");
+    assert.strictEqual(parseShd("5"), "5");
+    assert.deepStrictEqual(parseCftd("be,3,9"), {
+      scheduleByDaysFromStart: "be,3",
+      maxShiftableDays: "9",
+    });
+    assert.strictEqual(parseWc("4"), "4");
+  });
+});


### PR DESCRIPTION
## Summary
- extract calendar, priority, and schedule parsing helpers from buildUnitListView.ts
- add focused unit tests for the extracted helper behavior
- sync build-unit-list-view TASKS, plans, and roadmap with the new slice and remove the stale show-unit-definition roadmap item

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build