### PR TITLE
docs: plan parameter factory decomposition

### DIFF
--- a/docs/specs/features/decompose-parameter-factory/PLANS.md
+++ b/docs/specs/features/decompose-parameter-factory/PLANS.md
@@ -1,0 +1,46 @@
+# PLANS: decompose-parameter-factory
+
+## Objective
+
+Make `ParameterFactory.ts` reviewable and lower-risk by decomposing it into
+focused builder modules while preserving behavior.
+
+## Scope
+
+- `src/domain/models/parameters/ParameterFactory.ts`
+- new internal builder modules under `src/domain/models/parameters/`
+- focused tests for extracted builder families
+- sync updates to `docs/specs/plans.md` and `docs/specs/roadmap.md`
+
+## Risks To Control
+
+- Silent parameter-default drift
+- Accidental reordering of rule-based arrays
+- Breaking root-jobnet-only defaults
+- Over-extraction that only moves code without clarifying ownership
+
+## Slice Strategy
+
+1. Document the target decomposition and slice order
+2. Extract one builder family at a time behind the existing `ParamFactory`
+   facade
+3. Add or update focused tests for that family
+4. Run the full serial validation baseline
+5. Re-sync feature `TASKS.md`, branch `plans.md`, and `roadmap.md`
+
+## Proposed Slice Order
+
+1. Optional scalar builders
+2. Optional array builders
+3. Inherited builders
+4. SD-aligned builders
+5. Root-jobnet-aware builders
+6. Transfer-operation builders
+7. Final pass to keep `ParamFactory.ts` as a thin facade only if that still
+   reads better than direct exports
+
+## Validation
+
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/decompose-parameter-factory/SPECS.md
+++ b/docs/specs/features/decompose-parameter-factory/SPECS.md
@@ -1,0 +1,50 @@
+# SPECS: decompose-parameter-factory
+
+## Purpose
+
+Reduce the structural risk of `src/domain/models/parameters/ParameterFactory.ts`
+without changing JP1/AJS parameter behavior.
+
+## Origin
+
+This is a behavior-preserving refactor slice under the existing normalized
+parameter and wrapper work, not a new end-user use case.
+
+## Acceptance Criteria
+
+- `ParameterFactory` behavior is unchanged for desktop and web extension paths.
+- Public callers can keep importing `ParamFactory` from the current location.
+- Parameter construction rules remain aligned with the existing helper layer in
+  `src/domain/models/parameters/parameterHelpers.ts`.
+- Tests cover each extracted parameter-builder family before or during
+  migration.
+- The refactor proceeds in small slices; no broad rewrite lands in one change.
+
+## Implementation Notes
+
+- Prefer extracting coherent builder families over splitting by arbitrary line
+  count.
+- Keep `ParamFactory` as the stable facade while internal builder
+  implementations move to focused modules.
+- Start with the lowest-risk families that already delegate almost entirely to
+  existing helper functions.
+- Avoid moving JP1/AJS semantics out of the current helper layer unless the
+  same rule is still duplicated after decomposition.
+- Do not combine this refactor with new parameter behavior, wrapper semantics,
+  or VS Code adapter changes.
+
+## Candidate Builder Families
+
+1. Optional scalar builders with or without `DEFAULTS.*`
+2. Optional array builders
+3. Inherited scalar and array builders
+4. SD-aligned rule builders
+5. Root-jobnet-aware builders
+6. Transfer-operation `top1` to `top4` builders
+
+## Initial Non-Goals
+
+- Replacing `ParamFactory` with a different public API
+- Reworking `parameterHelpers.ts` semantics in the same slice
+- Changing wrapper class ownership or parameter naming
+- Raising VS Code compatibility requirements

--- a/docs/specs/features/decompose-parameter-factory/TASKS.md
+++ b/docs/specs/features/decompose-parameter-factory/TASKS.md
@@ -1,0 +1,34 @@
+# TASKS: decompose-parameter-factory
+
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
+## Completed
+
+- [x] Define the feature boundary and decomposition goal before code changes
+- [x] Identify builder families and an initial extraction order
+
+## Planned Slices
+
+- [ ] Extract optional scalar builders into a focused internal module
+- [ ] Extract optional array builders into a focused internal module
+- [ ] Extract inherited builders into a focused internal module
+- [ ] Extract SD-aligned builders into a focused internal module
+- [ ] Extract root-jobnet-aware builders into a focused internal module
+- [ ] Extract transfer-operation `top1` to `top4` builders into a focused
+      internal module
+- [ ] Decide whether the end state should keep `ParamFactory` as a thin facade
+      or collapse to direct exports
+
+## Notes
+
+- 2026-04-12: `ParameterFactory.ts` is still the largest handwritten source
+  file in the repository at roughly 2300 lines, so decomposition should be
+  tracked as its own feature rather than treated as an incidental cleanup.
+- 2026-04-12: the safest first slices are the families that already delegate
+  almost entirely to `parameterHelpers.ts`; they can reduce file size without
+  reopening parameter semantics.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -92,10 +92,13 @@ structure in `docs/specs/features/<feature>/`.
 3. Reduce `buildUnitListView.ts` incrementally:
    extract calendar, priority, and schedule parsing helpers into focused
    modules while preserving the existing `UnitListRowView` contract and tests.
-4. Keep feature follow-up verification evidence concrete:
+4. Decompose `ParameterFactory.ts` as a dedicated feature:
+   extract coherent builder families behind the existing facade instead of
+   attempting another large refactor in one pass.
+5. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-5. Revisit a dedicated filter/search use case only if a second non-table
+6. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 
 ## Wrapper Semantics Matrix

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -43,8 +43,8 @@
 2. Break down high-complexity functions in the application layer, starting
    with focused helper extraction from `buildUnitListView.ts` instead of
    another broad rewrite.
-3. Extract common logic from large files like ParameterFactory.ts and
-   buildUnitListView.ts into smaller, focused modules.
+3. Decompose `ParameterFactory.ts` by coherent builder families while keeping
+   `ParamFactory` as the stable facade during migration.
 4. Consolidate i18n translation files to reduce duplication between language
    variants.
 


### PR DESCRIPTION
## Summary
- add a dedicated feature plan for ParameterFactory decomposition before implementation
- define builder-family based slice boundaries and migration order
- sync branch plans and roadmap so the next implementation slices have an explicit target

## Validation
- npm run lint:md