### PR TITLE
refactor: extract optional array parameter builders

### DIFF
--- a/docs/specs/features/decompose-parameter-factory/PLANS.md
+++ b/docs/specs/features/decompose-parameter-factory/PLANS.md
@@ -35,12 +35,18 @@ focused builder modules while preserving behavior.
 - 2026-04-12: `ParamFactory` now delegates that family through a thin facade.
 - 2026-04-12: focused regression tests were added for explicit value,
   defaulted value, and the legacy `wth` to `wt` mapping.
+- 2026-04-12: optional array builders were extracted to
+  `optionalArrayParameterBuilders.ts`.
+- 2026-04-12: `ParamFactory` now delegates optional array builders through the
+  same facade style, with focused regression tests for explicit and missing
+  array values.
 
 ## Proposed Slice Order
 
 1. Optional scalar builders
    Status: completed on 2026-04-12
 2. Optional array builders
+   Status: completed on 2026-04-12
 3. Inherited builders
 4. SD-aligned builders
 5. Root-jobnet-aware builders

--- a/docs/specs/features/decompose-parameter-factory/TASKS.md
+++ b/docs/specs/features/decompose-parameter-factory/TASKS.md
@@ -15,7 +15,7 @@
 ## Planned Slices
 
 - [x] Extract optional scalar builders into a focused internal module
-- [ ] Extract optional array builders into a focused internal module
+- [x] Extract optional array builders into a focused internal module
 - [ ] Extract inherited builders into a focused internal module
 - [ ] Extract SD-aligned builders into a focused internal module
 - [ ] Extract root-jobnet-aware builders into a focused internal module
@@ -35,3 +35,7 @@
 - 2026-04-12: optional scalar builders now live in
   `optionalScalarParameterBuilders.ts`, with `ParamFactory` preserved as the
   public facade for that family.
+- 2026-04-12: optional array builders now live in
+  `optionalArrayParameterBuilders.ts`, with `ParamFactory` still exposing the
+  public entry points for `ar`, `el`, `env`, `eun`, `jpoif`, `mladr`,
+  `mlsbj`, and `mltxt`.

--- a/src/domain/models/parameters/ParameterFactory.ts
+++ b/src/domain/models/parameters/ParameterFactory.ts
@@ -1,18 +1,10 @@
 import {
-  Ar,
   Cftd,
   Cl,
   Cy,
-  El,
-  Env,
-  Eun,
   Ey,
-  Jpoif,
   Ln,
   Md,
-  Mladr,
-  Mlsbj,
-  Mltxt,
   Ncex,
   Ncl,
   Ncs,
@@ -40,12 +32,12 @@ import { J } from "../units/J";
 import { N } from "../units/N";
 import { UnitEntity } from "../units/UnitEntity";
 import { DEFAULTS } from "./Defaults";
+import { optionalArrayParameterBuilders } from "./optionalArrayParameterBuilders";
 import { optionalScalarParameterBuilders } from "./optionalScalarParameterBuilders";
 import {
   buildSdAlignedDefaultRuleParameters,
   buildSdAlignedEmptyRuleParameters,
   buildDefaultableParameter,
-  buildOptionalParameterArray,
   buildRootJobnetParameter,
   buildRootJobnetRuleParameters,
   buildRequiredParameter,
@@ -59,15 +51,7 @@ import {
 export class ParamFactory {
   static ab = optionalScalarParameterBuilders.ab;
   static abr = optionalScalarParameterBuilders.abr;
-  static ar(unit: UnitEntity) {
-    return buildOptionalParameterArray(
-      {
-        unit: unit,
-        parameter: "ar",
-      },
-      (param) => new Ar(param),
-    );
-  }
+  static ar = optionalArrayParameterBuilders.ar;
   static cd = optionalScalarParameterBuilders.cd;
   static cftd(unit: UnitEntity) {
     return buildSdAlignedDefaultRuleParameters(
@@ -121,37 +105,13 @@ export class ParamFactory {
   static ejt = optionalScalarParameterBuilders.ejt;
   static eju = optionalScalarParameterBuilders.eju;
   static ejv = optionalScalarParameterBuilders.ejv;
-  static el(unit: UnitEntity) {
-    return buildOptionalParameterArray(
-      {
-        unit: unit,
-        parameter: "el",
-      },
-      (param) => new El(param),
-    );
-  }
-  static env(unit: UnitEntity) {
-    return buildOptionalParameterArray(
-      {
-        unit: unit,
-        parameter: "env",
-      },
-      (param) => new Env(param),
-    );
-  }
+  static el = optionalArrayParameterBuilders.el;
+  static env = optionalArrayParameterBuilders.env;
   static etm = optionalScalarParameterBuilders.etm;
   static etn = optionalScalarParameterBuilders.etn;
   static ets = optionalScalarParameterBuilders.ets;
   static eu = optionalScalarParameterBuilders.eu;
-  static eun(unit: UnitEntity) {
-    return buildOptionalParameterArray(
-      {
-        unit: unit,
-        parameter: "eun",
-      },
-      (param) => new Eun(param),
-    );
-  }
+  static eun = optionalArrayParameterBuilders.eun;
   static ev = optionalScalarParameterBuilders.ev;
   static evdet = optionalScalarParameterBuilders.evdet;
   static evesc = optionalScalarParameterBuilders.evesc;
@@ -207,15 +167,7 @@ export class ParamFactory {
   static jc = optionalScalarParameterBuilders.jc;
   static jd = optionalScalarParameterBuilders.jd;
   static jdf = optionalScalarParameterBuilders.jdf;
-  static jpoif(unit: UnitEntity) {
-    return buildOptionalParameterArray(
-      {
-        unit: unit,
-        parameter: "jpoif",
-      },
-      (param) => new Jpoif(param),
-    );
-  }
+  static jpoif = optionalArrayParameterBuilders.jpoif;
   static jty = optionalScalarParameterBuilders.jty;
   static lfcre = optionalScalarParameterBuilders.lfcre;
   static lfdft = optionalScalarParameterBuilders.lfdft;
@@ -248,41 +200,17 @@ export class ParamFactory {
     );
   }
   static mh = optionalScalarParameterBuilders.mh;
-  static mladr(unit: UnitEntity) {
-    return buildOptionalParameterArray(
-      {
-        unit: unit,
-        parameter: "mladr",
-      },
-      (param) => new Mladr(param),
-    );
-  }
+  static mladr = optionalArrayParameterBuilders.mladr;
   static mlafl = optionalScalarParameterBuilders.mlafl;
   static mlatf = optionalScalarParameterBuilders.mlatf;
   static mlftx = optionalScalarParameterBuilders.mlftx;
   static mllst = optionalScalarParameterBuilders.mllst;
   static mlprf = optionalScalarParameterBuilders.mlprf;
   static mlsav = optionalScalarParameterBuilders.mlsav;
-  static mlsbj(unit: UnitEntity) {
-    return buildOptionalParameterArray(
-      {
-        unit: unit,
-        parameter: "mlsbj",
-      },
-      (param) => new Mlsbj(param),
-    );
-  }
+  static mlsbj = optionalArrayParameterBuilders.mlsbj;
   static mlsfd = optionalScalarParameterBuilders.mlsfd;
   static mlstx = optionalScalarParameterBuilders.mlstx;
-  static mltxt(unit: UnitEntity) {
-    return buildOptionalParameterArray(
-      {
-        unit: unit,
-        parameter: "mltxt",
-      },
-      (param) => new Mltxt(param),
-    );
-  }
+  static mltxt = optionalArrayParameterBuilders.mltxt;
   static mm = optionalScalarParameterBuilders.mm;
   static mp = optionalScalarParameterBuilders.mp;
   static mqcor = optionalScalarParameterBuilders.mqcor;

--- a/src/domain/models/parameters/optionalArrayParameterBuilders.ts
+++ b/src/domain/models/parameters/optionalArrayParameterBuilders.ts
@@ -1,0 +1,29 @@
+import { Ar, El, Env, Eun, Jpoif, Mladr, Mlsbj, Mltxt } from "../parameters";
+import { UnitEntity } from "../units/UnitEntity";
+import { buildOptionalParameterArray } from "./parameterHelpers";
+import { ParamInternal } from "./parameter.types";
+
+const createOptionalArrayBuilder = <T, P extends ParamInternal["parameter"]>(
+  parameter: P,
+  mapParam: (param: ParamInternal) => T,
+) => {
+  return (unit: UnitEntity): Array<T> | undefined =>
+    buildOptionalParameterArray(
+      {
+        unit: unit,
+        parameter: parameter,
+      },
+      mapParam,
+    );
+};
+
+export const optionalArrayParameterBuilders = {
+  ar: createOptionalArrayBuilder("ar", (param) => new Ar(param)),
+  el: createOptionalArrayBuilder("el", (param) => new El(param)),
+  env: createOptionalArrayBuilder("env", (param) => new Env(param)),
+  eun: createOptionalArrayBuilder("eun", (param) => new Eun(param)),
+  jpoif: createOptionalArrayBuilder("jpoif", (param) => new Jpoif(param)),
+  mladr: createOptionalArrayBuilder("mladr", (param) => new Mladr(param)),
+  mlsbj: createOptionalArrayBuilder("mlsbj", (param) => new Mlsbj(param)),
+  mltxt: createOptionalArrayBuilder("mltxt", (param) => new Mltxt(param)),
+} as const;

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -19,8 +19,31 @@ unit=root,,jp1admin,;
 }
 `;
 
+const arrayDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=job1,j,+0+0;
+  unit=job1,,jp1admin,;
+  {
+    ty=j;
+    ar=job2,0;
+    ar=job3,1;
+    jpoif=if-a;
+    jpoif=if-b;
+  }
+}
+`;
+
 const parseJob = (): J => {
   const result = parseAjs(definition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as J;
+};
+
+const parseArrayJob = (): J => {
+  const result = parseAjs(arrayDefinition);
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as J;
@@ -56,5 +79,29 @@ suite("ParameterFactory", () => {
     assert.ok(wth);
     assert.strictEqual(wth?.parameter, "wt");
     assert.strictEqual(wth?.value(), "wait-target");
+  });
+
+  test("returns explicit optional array parameters through the facade", () => {
+    const job = parseArrayJob();
+
+    const ar = ParamFactory.ar(job);
+    const jpoif = ParamFactory.jpoif(job);
+
+    assert.deepStrictEqual(
+      ar?.map((parameter) => parameter.value()),
+      ["job2,0", "job3,1"],
+    );
+    assert.deepStrictEqual(
+      jpoif?.map((parameter) => parameter.value()),
+      ["if-a", "if-b"],
+    );
+  });
+
+  test("returns undefined for missing optional array parameters", () => {
+    const job = parseJob();
+
+    const ar = ParamFactory.ar(job);
+
+    assert.strictEqual(ar, undefined);
   });
 });


### PR DESCRIPTION
## Summary
- extract optional array parameter builders into a focused internal module
- keep ParamFactory as the public facade for that builder family
- add focused regression coverage and sync decompose-parameter-factory docs

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build
- npm run lint:md