### PR TITLE
refactor: extract inherited parameter builders

### DIFF
--- a/docs/specs/features/decompose-parameter-factory/PLANS.md
+++ b/docs/specs/features/decompose-parameter-factory/PLANS.md
@@ -40,6 +40,11 @@ focused builder modules while preserving behavior.
 - 2026-04-12: `ParamFactory` now delegates optional array builders through the
   same facade style, with focused regression tests for explicit and missing
   array values.
+- 2026-04-12: inherited builders were extracted to
+  `inheritedParameterBuilders.ts`.
+- 2026-04-12: `ParamFactory` now delegates inherited scalar and array builders
+  through the same facade style, with focused regression tests for inherited
+  values and inherited flags.
 
 ## Proposed Slice Order
 
@@ -48,6 +53,7 @@ focused builder modules while preserving behavior.
 2. Optional array builders
    Status: completed on 2026-04-12
 3. Inherited builders
+   Status: completed on 2026-04-12
 4. SD-aligned builders
 5. Root-jobnet-aware builders
 6. Transfer-operation builders

--- a/docs/specs/features/decompose-parameter-factory/TASKS.md
+++ b/docs/specs/features/decompose-parameter-factory/TASKS.md
@@ -16,7 +16,7 @@
 
 - [x] Extract optional scalar builders into a focused internal module
 - [x] Extract optional array builders into a focused internal module
-- [ ] Extract inherited builders into a focused internal module
+- [x] Extract inherited builders into a focused internal module
 - [ ] Extract SD-aligned builders into a focused internal module
 - [ ] Extract root-jobnet-aware builders into a focused internal module
 - [ ] Extract transfer-operation `top1` to `top4` builders into a focused
@@ -39,3 +39,6 @@
   `optionalArrayParameterBuilders.ts`, with `ParamFactory` still exposing the
   public entry points for `ar`, `el`, `env`, `eun`, `jpoif`, `mladr`,
   `mlsbj`, and `mltxt`.
+- 2026-04-12: inherited builders now live in
+  `inheritedParameterBuilders.ts`, with `ParamFactory` still exposing the
+  public entry points for `cl`, `md`, `ni`, `op`, `pr`, `sdd`, and `stt`.

--- a/src/domain/models/parameters/ParameterFactory.ts
+++ b/src/domain/models/parameters/ParameterFactory.ts
@@ -1,23 +1,16 @@
 import {
   Cftd,
-  Cl,
   Cy,
   Ey,
   Ln,
-  Md,
   Ncex,
   Ncl,
   Ncs,
-  Ni,
-  Op,
-  Pr,
   Rg,
   Sd,
-  Sdd,
   Sh,
   Shd,
   St,
-  Stt,
   Sy,
   Top1,
   Top2,
@@ -32,6 +25,7 @@ import { J } from "../units/J";
 import { N } from "../units/N";
 import { UnitEntity } from "../units/UnitEntity";
 import { DEFAULTS } from "./Defaults";
+import { inheritedParameterBuilders } from "./inheritedParameterBuilders";
 import { optionalArrayParameterBuilders } from "./optionalArrayParameterBuilders";
 import { optionalScalarParameterBuilders } from "./optionalScalarParameterBuilders";
 import {
@@ -42,8 +36,6 @@ import {
   buildRootJobnetRuleParameters,
   buildRequiredParameter,
   buildTopParameter,
-  buildInheritedParameter,
-  buildInheritedParameterArray,
   buildSortedRuleParameters,
   resolveParameterArray,
 } from "./parameterHelpers";
@@ -65,15 +57,7 @@ export class ParamFactory {
     );
   }
   static cgs = optionalScalarParameterBuilders.cgs;
-  static cl(unit: UnitEntity) {
-    return buildInheritedParameterArray(
-      {
-        unit: unit,
-        parameter: "cl",
-      },
-      (param) => new Cl(param),
-    );
-  }
+  static cl = inheritedParameterBuilders.cl;
   static cm = optionalScalarParameterBuilders.cm;
   static cmaif = optionalScalarParameterBuilders.cmaif;
   static cmsts = optionalScalarParameterBuilders.cmsts;
@@ -189,16 +173,7 @@ export class ParamFactory {
     );
   }
   static mcs = optionalScalarParameterBuilders.mcs;
-  static md(unit: UnitEntity) {
-    return buildInheritedParameter(
-      {
-        unit: unit,
-        parameter: "md",
-        defaultRawValue: DEFAULTS.Md,
-      },
-      (param) => new Md(param),
-    );
-  }
+  static md = inheritedParameterBuilders.md;
   static mh = optionalScalarParameterBuilders.mh;
   static mladr = optionalArrayParameterBuilders.mladr;
   static mlafl = optionalScalarParameterBuilders.mlafl;
@@ -276,16 +251,7 @@ export class ParamFactory {
     );
   }
   static ncsv = optionalScalarParameterBuilders.ncsv;
-  static ni(unit: UnitEntity) {
-    return buildInheritedParameter(
-      {
-        unit: unit,
-        parameter: "ni",
-        defaultRawValue: DEFAULTS.Ni,
-      },
-      (param) => new Ni(param),
-    );
-  }
+  static ni = inheritedParameterBuilders.ni;
   static nmg = optionalScalarParameterBuilders.nmg;
   static ntcls = optionalScalarParameterBuilders.ntcls;
   static ntdis = optionalScalarParameterBuilders.ntdis;
@@ -297,26 +263,9 @@ export class ParamFactory {
   static ntnsr = optionalScalarParameterBuilders.ntnsr;
   static ntolg = optionalScalarParameterBuilders.ntolg;
   static ntsrc = optionalScalarParameterBuilders.ntsrc;
-  static op(unit: UnitEntity) {
-    return buildInheritedParameterArray(
-      {
-        unit: unit,
-        parameter: "op",
-      },
-      (param) => new Op(param),
-    );
-  }
+  static op = inheritedParameterBuilders.op;
   static pfm = optionalScalarParameterBuilders.pfm;
-  static pr(unit: UnitEntity) {
-    return buildInheritedParameter(
-      {
-        unit: unit,
-        parameter: "pr",
-        defaultRawValue: DEFAULTS.Pr,
-      },
-      (param) => new Pr(param),
-    );
-  }
+  static pr = inheritedParameterBuilders.pr;
   static prm = optionalScalarParameterBuilders.prm;
   static pwlf = optionalScalarParameterBuilders.pwlf;
   static pwlt = optionalScalarParameterBuilders.pwlt;
@@ -357,16 +306,7 @@ export class ParamFactory {
       (param) => new Sd(param),
     );
   }
-  static sdd(unit: UnitEntity) {
-    return buildInheritedParameter(
-      {
-        unit: unit,
-        parameter: "sdd",
-        defaultRawValue: DEFAULTS.Sdd,
-      },
-      (param) => new Sdd(param),
-    );
-  }
+  static sdd = inheritedParameterBuilders.sdd;
   static se = optionalScalarParameterBuilders.se;
   static sea = optionalScalarParameterBuilders.sea;
   static sh(unit: UnitEntity) {
@@ -403,16 +343,7 @@ export class ParamFactory {
       (param) => new St(param),
     );
   }
-  static stt(unit: UnitEntity) {
-    return buildInheritedParameter(
-      {
-        unit: unit,
-        parameter: "stt",
-        defaultRawValue: DEFAULTS.Stt,
-      },
-      (param) => new Stt(param),
-    );
-  }
+  static stt = inheritedParameterBuilders.stt;
   static sy(unit: UnitEntity) {
     return buildSdAlignedEmptyRuleParameters(
       {

--- a/src/domain/models/parameters/inheritedParameterBuilders.ts
+++ b/src/domain/models/parameters/inheritedParameterBuilders.ts
@@ -1,0 +1,56 @@
+import { Cl, Md, Ni, Op, Pr, Sdd, Stt } from "../parameters";
+import { UnitEntity } from "../units/UnitEntity";
+import { DEFAULTS } from "./Defaults";
+import {
+  buildInheritedParameter,
+  buildInheritedParameterArray,
+} from "./parameterHelpers";
+import { ParamInternal } from "./parameter.types";
+
+const createInheritedScalarBuilder = <T, P extends ParamInternal["parameter"]>(
+  parameter: P,
+  mapParam: (param: ParamInternal) => T,
+  defaultRawValue?: string,
+) => {
+  return (unit: UnitEntity): T | undefined =>
+    buildInheritedParameter(
+      {
+        unit: unit,
+        parameter: parameter,
+        defaultRawValue: defaultRawValue,
+      },
+      mapParam,
+    );
+};
+
+const createInheritedArrayBuilder = <T, P extends ParamInternal["parameter"]>(
+  parameter: P,
+  mapParam: (param: ParamInternal) => T,
+) => {
+  return (unit: UnitEntity): Array<T> | undefined =>
+    buildInheritedParameterArray(
+      {
+        unit: unit,
+        parameter: parameter,
+      },
+      mapParam,
+    );
+};
+
+export const inheritedParameterBuilders = {
+  cl: createInheritedArrayBuilder("cl", (param) => new Cl(param)),
+  md: createInheritedScalarBuilder("md", (param) => new Md(param), DEFAULTS.Md),
+  ni: createInheritedScalarBuilder("ni", (param) => new Ni(param), DEFAULTS.Ni),
+  op: createInheritedArrayBuilder("op", (param) => new Op(param)),
+  pr: createInheritedScalarBuilder("pr", (param) => new Pr(param), DEFAULTS.Pr),
+  sdd: createInheritedScalarBuilder(
+    "sdd",
+    (param) => new Sdd(param),
+    DEFAULTS.Sdd,
+  ),
+  stt: createInheritedScalarBuilder(
+    "stt",
+    (param) => new Stt(param),
+    DEFAULTS.Stt,
+  ),
+} as const;

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import { ParamFactory } from "../../domain/models/parameters/ParameterFactory";
 import { DEFAULTS } from "../../domain/models/parameters/Defaults";
 import { J } from "../../domain/models/units/J";
+import { N } from "../../domain/models/units/N";
 import { parseAjs } from "../../domain/services/parser/AjsParser";
 import { tyFactory } from "../../domain/utils/TyUtils";
 
@@ -35,6 +36,25 @@ unit=root,,jp1admin,;
 }
 `;
 
+const inheritedDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  cl=mo;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    pr=4;
+    el=subnet,n,+160+0;
+    unit=subnet,,jp1admin,;
+    {
+      ty=n;
+    }
+  }
+}
+`;
+
 const parseJob = (): J => {
   const result = parseAjs(definition);
   assert.deepStrictEqual(result.errors, []);
@@ -47,6 +67,14 @@ const parseArrayJob = (): J => {
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as J;
+};
+
+const parseInheritedJobnet = (): N => {
+  const result = parseAjs(inheritedDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  const jobnet = root.children[0] as N;
+  return jobnet.children[0] as N;
 };
 
 suite("ParameterFactory", () => {
@@ -103,5 +131,27 @@ suite("ParameterFactory", () => {
     const ar = ParamFactory.ar(job);
 
     assert.strictEqual(ar, undefined);
+  });
+
+  test("returns inherited scalar parameters through the facade", () => {
+    const subnet = parseInheritedJobnet();
+
+    const pr = ParamFactory.pr(subnet);
+
+    assert.ok(pr);
+    assert.strictEqual(pr?.value(), "4");
+    assert.strictEqual(pr?.inherited, true);
+  });
+
+  test("returns inherited array parameters through the facade", () => {
+    const subnet = parseInheritedJobnet();
+
+    const cl = ParamFactory.cl(subnet);
+
+    assert.deepStrictEqual(
+      cl?.map((parameter) => parameter.value()),
+      ["mo"],
+    );
+    assert.ok(cl?.every((parameter) => parameter.inherited));
   });
 });


### PR DESCRIPTION
## Summary
- extract inherited parameter builders into a focused internal module
- keep ParamFactory as the public facade for that builder family
- add focused regression coverage and sync decompose-parameter-factory docs

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build
- npm run lint:md