### PR TITLE
refactor: extract rule parameter builders

### DIFF
--- a/docs/specs/features/decompose-parameter-factory/PLANS.md
+++ b/docs/specs/features/decompose-parameter-factory/PLANS.md
@@ -45,6 +45,11 @@ focused builder modules while preserving behavior.
 - 2026-04-12: `ParamFactory` now delegates inherited scalar and array builders
   through the same facade style, with focused regression tests for inherited
   values and inherited flags.
+- 2026-04-12: rule-bearing parameter builders were extracted to
+  `ruleParameterBuilders.ts`.
+- 2026-04-12: this family is defined around `Rule.ts`, including both
+  schedule-rule-aligned parameters and other rule-bearing parameters such as
+  `ln`.
 
 ## Proposed Slice Order
 
@@ -54,7 +59,8 @@ focused builder modules while preserving behavior.
    Status: completed on 2026-04-12
 3. Inherited builders
    Status: completed on 2026-04-12
-4. SD-aligned builders
+4. Rule-bearing parameter builders
+   Status: completed on 2026-04-12
 5. Root-jobnet-aware builders
 6. Transfer-operation builders
 7. Final pass to keep `ParamFactory.ts` as a thin facade only if that still

--- a/docs/specs/features/decompose-parameter-factory/TASKS.md
+++ b/docs/specs/features/decompose-parameter-factory/TASKS.md
@@ -17,7 +17,7 @@
 - [x] Extract optional scalar builders into a focused internal module
 - [x] Extract optional array builders into a focused internal module
 - [x] Extract inherited builders into a focused internal module
-- [ ] Extract SD-aligned builders into a focused internal module
+- [x] Extract rule-bearing parameter builders into a focused internal module
 - [ ] Extract root-jobnet-aware builders into a focused internal module
 - [ ] Extract transfer-operation `top1` to `top4` builders into a focused
       internal module
@@ -42,3 +42,9 @@
 - 2026-04-12: inherited builders now live in
   `inheritedParameterBuilders.ts`, with `ParamFactory` still exposing the
   public entry points for `cl`, `md`, `ni`, `op`, `pr`, `sdd`, and `stt`.
+- 2026-04-12: rule-bearing parameter builders now live in
+  `ruleParameterBuilders.ts`, with `ParamFactory` still exposing the public
+  entry points for `cftd`, `cy`, `ey`, `ln`, `sh`, `shd`, `st`, `sy`, `wc`,
+  and `wt`.
+- 2026-04-12: this family is anchored in `Rule.ts`; the shared concept is
+  parameters that carry a rule number, not the `sd` parameter name by itself.

--- a/src/domain/models/parameters/ParameterFactory.ts
+++ b/src/domain/models/parameters/ParameterFactory.ts
@@ -1,43 +1,29 @@
 import {
-  Cftd,
-  Cy,
-  Ey,
-  Ln,
   Ncex,
   Ncl,
   Ncs,
   Rg,
   Sd,
-  Sh,
-  Shd,
-  St,
-  Sy,
   Top1,
   Top2,
   Top3,
   Top4,
   Ty,
-  Wc,
-  Wt,
 } from "../parameters";
 import { Cj } from "../units/Cj";
 import { J } from "../units/J";
 import { N } from "../units/N";
 import { UnitEntity } from "../units/UnitEntity";
-import { DEFAULTS } from "./Defaults";
 import { inheritedParameterBuilders } from "./inheritedParameterBuilders";
 import { optionalArrayParameterBuilders } from "./optionalArrayParameterBuilders";
 import { optionalScalarParameterBuilders } from "./optionalScalarParameterBuilders";
+import { ruleParameterBuilders } from "./ruleParameterBuilders";
 import {
-  buildSdAlignedDefaultRuleParameters,
-  buildSdAlignedEmptyRuleParameters,
   buildDefaultableParameter,
   buildRootJobnetParameter,
   buildRootJobnetRuleParameters,
   buildRequiredParameter,
   buildTopParameter,
-  buildSortedRuleParameters,
-  resolveParameterArray,
 } from "./parameterHelpers";
 
 export class ParamFactory {
@@ -45,17 +31,7 @@ export class ParamFactory {
   static abr = optionalScalarParameterBuilders.abr;
   static ar = optionalArrayParameterBuilders.ar;
   static cd = optionalScalarParameterBuilders.cd;
-  static cftd(unit: UnitEntity) {
-    return buildSdAlignedDefaultRuleParameters(
-      {
-        unit: unit,
-        parameter: "cftd",
-        defaultRawValue: DEFAULTS.Cftd,
-        buildFallbackRawValue: (rule) => `${rule},${DEFAULTS.Cftd}`,
-      },
-      (param) => new Cftd(param),
-    );
-  }
+  static cftd = ruleParameterBuilders.cftd;
   static cgs = optionalScalarParameterBuilders.cgs;
   static cl = inheritedParameterBuilders.cl;
   static cm = optionalScalarParameterBuilders.cm;
@@ -63,15 +39,7 @@ export class ParamFactory {
   static cmsts = optionalScalarParameterBuilders.cmsts;
   static cond = optionalScalarParameterBuilders.cond;
   static cty = optionalScalarParameterBuilders.cty;
-  static cy(unit: UnitEntity) {
-    return buildSdAlignedEmptyRuleParameters(
-      {
-        unit: unit,
-        parameter: "cy",
-      },
-      (param) => new Cy(param),
-    );
-  }
+  static cy = ruleParameterBuilders.cy;
   static da = optionalScalarParameterBuilders.da;
   static de = optionalScalarParameterBuilders.de;
   static ed = optionalScalarParameterBuilders.ed;
@@ -119,15 +87,7 @@ export class ParamFactory {
   static evwms = optionalScalarParameterBuilders.evwms;
   static evwsv = optionalScalarParameterBuilders.evwsv;
   static ex = optionalScalarParameterBuilders.ex;
-  static ey(unit: UnitEntity) {
-    return buildSdAlignedEmptyRuleParameters(
-      {
-        unit: unit,
-        parameter: "ey",
-      },
-      (param) => new Ey(param),
-    );
-  }
+  static ey = ruleParameterBuilders.ey;
   static f = optionalScalarParameterBuilders.f;
   static fd = optionalScalarParameterBuilders.fd;
   static flco = optionalScalarParameterBuilders.flco;
@@ -163,15 +123,7 @@ export class ParamFactory {
   static lfsiv = optionalScalarParameterBuilders.lfsiv;
   static lfsrc = optionalScalarParameterBuilders.lfsrc;
   static lftpd = optionalScalarParameterBuilders.lftpd;
-  static ln(unit: UnitEntity) {
-    return buildSortedRuleParameters(
-      resolveParameterArray({
-        unit: unit,
-        parameter: "ln",
-      }),
-      (param) => new Ln(param),
-    );
-  }
+  static ln = ruleParameterBuilders.ln;
   static mcs = optionalScalarParameterBuilders.mcs;
   static md = inheritedParameterBuilders.md;
   static mh = optionalScalarParameterBuilders.mh;
@@ -309,50 +261,14 @@ export class ParamFactory {
   static sdd = inheritedParameterBuilders.sdd;
   static se = optionalScalarParameterBuilders.se;
   static sea = optionalScalarParameterBuilders.sea;
-  static sh(unit: UnitEntity) {
-    return buildSdAlignedEmptyRuleParameters(
-      {
-        unit: unit,
-        parameter: "sh",
-      },
-      (param) => new Sh(param),
-    );
-  }
-  static shd(unit: UnitEntity) {
-    return buildSdAlignedDefaultRuleParameters(
-      {
-        unit: unit,
-        parameter: "shd",
-        defaultRawValue: DEFAULTS.Shd,
-        buildFallbackRawValue: (rule) => `${rule},${DEFAULTS.Shd}`,
-      },
-      (param) => new Shd(param),
-    );
-  }
+  static sh = ruleParameterBuilders.sh;
+  static shd = ruleParameterBuilders.shd;
   static si = optionalScalarParameterBuilders.si;
   static so = optionalScalarParameterBuilders.so;
   static soa = optionalScalarParameterBuilders.soa;
-  static st(unit: UnitEntity) {
-    return buildSdAlignedDefaultRuleParameters(
-      {
-        unit: unit,
-        parameter: "st",
-        defaultRawValue: DEFAULTS.St,
-        buildFallbackRawValue: (rule) => `${rule},${DEFAULTS.St}`,
-      },
-      (param) => new St(param),
-    );
-  }
+  static st = ruleParameterBuilders.st;
   static stt = inheritedParameterBuilders.stt;
-  static sy(unit: UnitEntity) {
-    return buildSdAlignedEmptyRuleParameters(
-      {
-        unit: unit,
-        parameter: "sy",
-      },
-      (param) => new Sy(param),
-    );
-  }
+  static sy = ruleParameterBuilders.sy;
   static sz = optionalScalarParameterBuilders.sz;
   static t = optionalScalarParameterBuilders.t;
   static td1 = optionalScalarParameterBuilders.td1;
@@ -419,28 +335,8 @@ export class ParamFactory {
   static uem = optionalScalarParameterBuilders.uem;
   static un = optionalScalarParameterBuilders.un;
   static unit = optionalScalarParameterBuilders.unit;
-  static wc(unit: UnitEntity) {
-    return buildSdAlignedDefaultRuleParameters(
-      {
-        unit: unit,
-        parameter: "wc",
-        defaultRawValue: DEFAULTS.Wc,
-        buildFallbackRawValue: (rule) => `${rule},${DEFAULTS.Wc}`,
-      },
-      (param) => new Wc(param),
-    );
-  }
+  static wc = ruleParameterBuilders.wc;
   static wkp = optionalScalarParameterBuilders.wkp;
-  static wt(unit: UnitEntity) {
-    return buildSdAlignedDefaultRuleParameters(
-      {
-        unit: unit,
-        parameter: "wt",
-        defaultRawValue: DEFAULTS.Wt,
-        buildFallbackRawValue: (rule) => `${rule},${DEFAULTS.Wt}`,
-      },
-      (param) => new Wt(param),
-    );
-  }
+  static wt = ruleParameterBuilders.wt;
   static wth = optionalScalarParameterBuilders.wth;
 }

--- a/src/domain/models/parameters/ruleParameterBuilders.ts
+++ b/src/domain/models/parameters/ruleParameterBuilders.ts
@@ -1,0 +1,100 @@
+import { Cftd, Cy, Ey, Ln, Sh, Shd, St, Sy, Wc, Wt } from "../parameters";
+import { UnitEntity } from "../units/UnitEntity";
+import { DEFAULTS } from "./Defaults";
+import {
+  buildSortedRuleParameters,
+  buildSdAlignedDefaultRuleParameters,
+  buildSdAlignedEmptyRuleParameters,
+  resolveParameterArray,
+} from "./parameterHelpers";
+import { ParamInternal } from "./parameter.types";
+import Rule from "./Rule";
+
+const createScheduleRuleDefaultBuilder = <
+  T extends Rule,
+  P extends ParamInternal["parameter"],
+>(
+  parameter: P,
+  mapParam: (param: ParamInternal) => T,
+  defaultRawValue: string,
+) => {
+  return (unit: UnitEntity): Array<T | null> | undefined =>
+    buildSdAlignedDefaultRuleParameters(
+      {
+        unit: unit,
+        parameter: parameter,
+        defaultRawValue: defaultRawValue,
+        buildFallbackRawValue: (rule) => `${rule},${defaultRawValue}`,
+      },
+      mapParam,
+    );
+};
+
+const createScheduleRuleEmptyBuilder = <
+  T extends Rule,
+  P extends ParamInternal["parameter"],
+>(
+  parameter: P,
+  mapParam: (param: ParamInternal) => T,
+) => {
+  return (unit: UnitEntity): Array<T | null> | undefined =>
+    buildSdAlignedEmptyRuleParameters(
+      {
+        unit: unit,
+        parameter: parameter,
+      },
+      mapParam,
+    );
+};
+
+const createSortedRuleBuilder = <
+  T extends Rule,
+  P extends ParamInternal["parameter"],
+>(
+  parameter: P,
+  mapParam: (param: ParamInternal) => T,
+) => {
+  return (unit: UnitEntity): Array<T> | undefined =>
+    buildSortedRuleParameters(
+      resolveParameterArray({
+        unit: unit,
+        parameter: parameter,
+      }),
+      mapParam,
+    );
+};
+
+// Rule-bearing parameters are primarily meaningful on jobnets (`ty=n`),
+// but the split here is based on parameter structure, not owning unit type.
+export const ruleParameterBuilders = {
+  cftd: createScheduleRuleDefaultBuilder(
+    "cftd",
+    (param) => new Cftd(param),
+    DEFAULTS.Cftd,
+  ),
+  cy: createScheduleRuleEmptyBuilder("cy", (param) => new Cy(param)),
+  ey: createScheduleRuleEmptyBuilder("ey", (param) => new Ey(param)),
+  ln: createSortedRuleBuilder("ln", (param) => new Ln(param)),
+  sh: createScheduleRuleEmptyBuilder("sh", (param) => new Sh(param)),
+  shd: createScheduleRuleDefaultBuilder(
+    "shd",
+    (param) => new Shd(param),
+    DEFAULTS.Shd,
+  ),
+  st: createScheduleRuleDefaultBuilder(
+    "st",
+    (param) => new St(param),
+    DEFAULTS.St,
+  ),
+  sy: createScheduleRuleEmptyBuilder("sy", (param) => new Sy(param)),
+  wc: createScheduleRuleDefaultBuilder(
+    "wc",
+    (param) => new Wc(param),
+    DEFAULTS.Wc,
+  ),
+  wt: createScheduleRuleDefaultBuilder(
+    "wt",
+    (param) => new Wt(param),
+    DEFAULTS.Wt,
+  ),
+} as const;

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -55,6 +55,24 @@ unit=root,,jp1admin,;
 }
 `;
 
+const scheduleDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    rg=3;
+    sd=ud;
+    sd=2,en;
+    wc=2;
+    ln=2;
+    ln=1;
+  }
+}
+`;
+
 const parseJob = (): J => {
   const result = parseAjs(definition);
   assert.deepStrictEqual(result.errors, []);
@@ -75,6 +93,13 @@ const parseInheritedJobnet = (): N => {
   const root = tyFactory(result.rootUnits[0]);
   const jobnet = root.children[0] as N;
   return jobnet.children[0] as N;
+};
+
+const parseScheduleJobnet = (): N => {
+  const result = parseAjs(scheduleDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as N;
 };
 
 suite("ParameterFactory", () => {
@@ -153,5 +178,44 @@ suite("ParameterFactory", () => {
       ["mo"],
     );
     assert.ok(cl?.every((parameter) => parameter.inherited));
+  });
+
+  test("returns schedule-rule parameters with explicit and fallback values", () => {
+    const jobnet = parseScheduleJobnet();
+
+    const wc = ParamFactory.wc(jobnet);
+
+    assert.deepStrictEqual(
+      wc?.map((parameter) => parameter?.value()),
+      ["2", "2,no"],
+    );
+  });
+
+  test("returns schedule-rule default values aligned to sd rules", () => {
+    const jobnet = parseScheduleJobnet();
+
+    const wt = ParamFactory.wt(jobnet);
+
+    assert.deepStrictEqual(
+      wt?.map((parameter) => parameter?.value()),
+      ["no", "2,no"],
+    );
+  });
+
+  test("returns rule-bearing parameters sorted by rule", () => {
+    const jobnet = parseScheduleJobnet();
+
+    const ln = ParamFactory.ln(jobnet);
+
+    assert.deepStrictEqual(
+      ln?.map((parameter) => ({
+        rule: parameter.rule,
+        value: parameter.value(),
+      })),
+      [
+        { rule: 1, value: "1" },
+        { rule: 2, value: "2" },
+      ],
+    );
   });
 });


### PR DESCRIPTION
## Summary
- extract rule-bearing parameter builders into a focused internal module
- keep ParamFactory as the public facade for that builder family
- include ln in the same family and sync feature docs terminology

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build
- npm run lint:md