### PR TITLE
Extract root-jobnet parameter builders

### DIFF
--- a/docs/specs/features/decompose-parameter-factory/PLANS.md
+++ b/docs/specs/features/decompose-parameter-factory/PLANS.md
@@ -48,8 +48,22 @@ focused builder modules while preserving behavior.
 - 2026-04-12: rule-bearing parameter builders were extracted to
   `ruleParameterBuilders.ts`.
 - 2026-04-12: this family is defined around `Rule.ts`, including both
-  schedule-rule-aligned parameters and other rule-bearing parameters such as
-  `ln`.
+  schedule-rule-aligned parameters, root-default-aware rule parameters such as
+  `sd`, and other rule-bearing parameters such as `ln`.
+- 2026-04-12: the `sd` builder naming was clarified so this family no longer
+  implies `sd` is root-jobnet-only; the root-only concern remains limited to
+  its default fallback behavior.
+- 2026-04-12: a broader naming review confirmed that `Rule.ts` and this
+  builder family actually model schedule-rule-bearing parameters, covering
+  `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and `cftd`.
+- 2026-04-12: the branch decision is to defer any broader rename to a
+  dedicated follow-up slice, so this decomposition slice can preserve
+  behavior and avoid mixing extraction with a cross-cutting terminology
+  change.
+- 2026-04-12: root-jobnet-aware builders were extracted to
+  `rootJobnetParameterBuilders.ts`.
+- 2026-04-12: `ParamFactory` now delegates `rg` through a focused module that
+  owns the root-jobnet scalar default concern.
 
 ## Proposed Slice Order
 
@@ -62,8 +76,13 @@ focused builder modules while preserving behavior.
 4. Rule-bearing parameter builders
    Status: completed on 2026-04-12
 5. Root-jobnet-aware builders
+   Status: completed on 2026-04-12
 6. Transfer-operation builders
-7. Final pass to keep `ParamFactory.ts` as a thin facade only if that still
+7. Schedule-rule naming review as a dedicated follow-up slice
+   Status: deferred from the current extraction slice on 2026-04-12
+   Notes: if executed, rename `Rule.ts` and related helpers/builders together
+   so the terminology consistently reflects schedule-rule-bearing parameters.
+8. Final pass to keep `ParamFactory.ts` as a thin facade only if that still
    reads better than direct exports
 
 ## Validation

--- a/docs/specs/features/decompose-parameter-factory/TASKS.md
+++ b/docs/specs/features/decompose-parameter-factory/TASKS.md
@@ -18,9 +18,13 @@
 - [x] Extract optional array builders into a focused internal module
 - [x] Extract inherited builders into a focused internal module
 - [x] Extract rule-bearing parameter builders into a focused internal module
-- [ ] Extract root-jobnet-aware builders into a focused internal module
+- [x] Extract root-jobnet-aware builders into a focused internal module
 - [ ] Extract transfer-operation `top1` to `top4` builders into a focused
       internal module
+- [ ] Revisit `Rule.ts` family naming in a dedicated slice so
+      `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and
+      `cftd` can be renamed together if `schedule rule` terminology is
+      adopted
 - [ ] Decide whether the end state should keep `ParamFactory` as a thin facade
       or collapse to direct exports
 
@@ -44,7 +48,17 @@
   public entry points for `cl`, `md`, `ni`, `op`, `pr`, `sdd`, and `stt`.
 - 2026-04-12: rule-bearing parameter builders now live in
   `ruleParameterBuilders.ts`, with `ParamFactory` still exposing the public
-  entry points for `cftd`, `cy`, `ey`, `ln`, `sh`, `shd`, `st`, `sy`, `wc`,
-  and `wt`.
+  entry points for `cftd`, `cy`, `ey`, `ln`, `sd`, `sh`, `shd`, `st`, `sy`,
+  `wc`, and `wt`.
 - 2026-04-12: this family is anchored in `Rule.ts`; the shared concept is
-  parameters that carry a rule number, not the `sd` parameter name by itself.
+  parameters that carry a rule number, including root-default-aware cases such
+  as `sd`.
+- 2026-04-12: the `sd` builder/helper naming was corrected to describe
+  root-default-aware behavior instead of implying that `sd` itself is limited
+  to the root jobnet.
+- 2026-04-12: the broader naming review concluded that this family is really
+  about schedule-rule-bearing parameters, but that terminology change should
+  happen in its own slice instead of being mixed into the extraction work.
+- 2026-04-12: root-jobnet-aware builders now live in
+  `rootJobnetParameterBuilders.ts`, with `ParamFactory` still exposing the
+  public entry point for `rg`.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -95,10 +95,14 @@ structure in `docs/specs/features/<feature>/`.
 4. Decompose `ParameterFactory.ts` as a dedicated feature:
    extract coherent builder families behind the existing facade instead of
    attempting another large refactor in one pass.
-5. Keep feature follow-up verification evidence concrete:
+5. Keep schedule-rule terminology changes separate from extraction slices:
+   if `Rule.ts` and related helpers are renamed, do it as one focused pass
+   across `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and
+   `cftd` instead of piecemeal renames.
+6. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-6. Revisit a dedicated filter/search use case only if a second non-table
+7. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 
 ## Wrapper Semantics Matrix

--- a/src/domain/models/parameters/ParameterFactory.ts
+++ b/src/domain/models/parameters/ParameterFactory.ts
@@ -1,27 +1,14 @@
-import {
-  Ncex,
-  Ncl,
-  Ncs,
-  Rg,
-  Sd,
-  Top1,
-  Top2,
-  Top3,
-  Top4,
-  Ty,
-} from "../parameters";
+import { Ncex, Ncl, Ncs, Top1, Top2, Top3, Top4, Ty } from "../parameters";
 import { Cj } from "../units/Cj";
 import { J } from "../units/J";
-import { N } from "../units/N";
 import { UnitEntity } from "../units/UnitEntity";
 import { inheritedParameterBuilders } from "./inheritedParameterBuilders";
 import { optionalArrayParameterBuilders } from "./optionalArrayParameterBuilders";
 import { optionalScalarParameterBuilders } from "./optionalScalarParameterBuilders";
+import { rootJobnetParameterBuilders } from "./rootJobnetParameterBuilders";
 import { ruleParameterBuilders } from "./ruleParameterBuilders";
 import {
   buildDefaultableParameter,
-  buildRootJobnetParameter,
-  buildRootJobnetRuleParameters,
   buildRequiredParameter,
   buildTopParameter,
 } from "./parameterHelpers";
@@ -232,32 +219,12 @@ export class ParamFactory {
   static rec = optionalScalarParameterBuilders.rec;
   static rei = optionalScalarParameterBuilders.rei;
   static req = optionalScalarParameterBuilders.req;
-  static rg(unit: N) {
-    return buildRootJobnetParameter(
-      {
-        unit: unit,
-        parameter: "rg",
-        isRootJobnet: unit.isRootJobnet,
-        rootDefaultParameter: "rg",
-      },
-      (param) => new Rg(param),
-    );
-  }
+  static rg = rootJobnetParameterBuilders.rg;
   static rh = optionalScalarParameterBuilders.rh;
   static rje = optionalScalarParameterBuilders.rje;
   static rjs = optionalScalarParameterBuilders.rjs;
   static sc = optionalScalarParameterBuilders.sc;
-  static sd(unit: N) {
-    return buildRootJobnetRuleParameters(
-      {
-        unit: unit,
-        parameter: "sd",
-        isRootJobnet: unit.isRootJobnet,
-        rootDefaultParameter: "sd",
-      },
-      (param) => new Sd(param),
-    );
-  }
+  static sd = ruleParameterBuilders.sd;
   static sdd = inheritedParameterBuilders.sdd;
   static se = optionalScalarParameterBuilders.se;
   static sea = optionalScalarParameterBuilders.sea;

--- a/src/domain/models/parameters/parameterHelpers.ts
+++ b/src/domain/models/parameters/parameterHelpers.ts
@@ -173,7 +173,7 @@ export const buildSdAlignedParameters = <T extends Rule>(
 export const resolveSdParameters = (
   unit: ParamLookupArg["unit"] & { isRoot: boolean },
 ): Array<Sd> | undefined =>
-  buildRootJobnetRuleParameters(
+  buildRootDefaultAwareRuleParameters(
     {
       unit: unit,
       parameter: "sd",
@@ -275,7 +275,7 @@ export const buildRootJobnetParameter = <T>(
     mapParam,
   );
 
-export const buildRootJobnetRuleParameters = <T extends Rule>(
+export const buildRootDefaultAwareRuleParameters = <T extends Rule>(
   arg: Omit<ParamLookupArg, "defaultRawValue" | "inherit"> & {
     isRootJobnet: boolean;
     rootDefaultParameter: keyof typeof rootJobnetDefaultByParameter;

--- a/src/domain/models/parameters/rootJobnetParameterBuilders.ts
+++ b/src/domain/models/parameters/rootJobnetParameterBuilders.ts
@@ -1,0 +1,25 @@
+import { Rg } from "../parameters";
+import { N } from "../units/N";
+import { buildRootJobnetParameter } from "./parameterHelpers";
+import { ParamInternal } from "./parameter.types";
+
+const createRootJobnetScalarBuilder = <T, P extends ParamInternal["parameter"]>(
+  parameter: P,
+  rootDefaultParameter: "rg",
+  mapParam: (param: ParamInternal) => T,
+) => {
+  return (unit: N): T | undefined =>
+    buildRootJobnetParameter(
+      {
+        unit: unit,
+        parameter: parameter,
+        isRootJobnet: unit.isRootJobnet,
+        rootDefaultParameter: rootDefaultParameter,
+      },
+      mapParam,
+    );
+};
+
+export const rootJobnetParameterBuilders = {
+  rg: createRootJobnetScalarBuilder("rg", "rg", (param) => new Rg(param)),
+} as const;

--- a/src/domain/models/parameters/ruleParameterBuilders.ts
+++ b/src/domain/models/parameters/ruleParameterBuilders.ts
@@ -1,7 +1,9 @@
-import { Cftd, Cy, Ey, Ln, Sh, Shd, St, Sy, Wc, Wt } from "../parameters";
+import { Cftd, Cy, Ey, Ln, Sd, Sh, Shd, St, Sy, Wc, Wt } from "../parameters";
+import { N } from "../units/N";
 import { UnitEntity } from "../units/UnitEntity";
 import { DEFAULTS } from "./Defaults";
 import {
+  buildRootDefaultAwareRuleParameters,
   buildSortedRuleParameters,
   buildSdAlignedDefaultRuleParameters,
   buildSdAlignedEmptyRuleParameters,
@@ -64,6 +66,26 @@ const createSortedRuleBuilder = <
     );
 };
 
+const createRootDefaultAwareRuleBuilder = <
+  T extends Rule,
+  P extends ParamInternal["parameter"],
+>(
+  parameter: P,
+  rootDefaultParameter: "sd",
+  mapParam: (param: ParamInternal) => T,
+) => {
+  return (unit: N): Array<T> | undefined =>
+    buildRootDefaultAwareRuleParameters(
+      {
+        unit: unit,
+        parameter: parameter,
+        isRootJobnet: unit.isRootJobnet,
+        rootDefaultParameter: rootDefaultParameter,
+      },
+      mapParam,
+    );
+};
+
 // Rule-bearing parameters are primarily meaningful on jobnets (`ty=n`),
 // but the split here is based on parameter structure, not owning unit type.
 export const ruleParameterBuilders = {
@@ -75,6 +97,7 @@ export const ruleParameterBuilders = {
   cy: createScheduleRuleEmptyBuilder("cy", (param) => new Cy(param)),
   ey: createScheduleRuleEmptyBuilder("ey", (param) => new Ey(param)),
   ln: createSortedRuleBuilder("ln", (param) => new Ln(param)),
+  sd: createRootDefaultAwareRuleBuilder("sd", "sd", (param) => new Sd(param)),
   sh: createScheduleRuleEmptyBuilder("sh", (param) => new Sh(param)),
   shd: createScheduleRuleDefaultBuilder(
     "shd",

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -73,6 +73,18 @@ unit=root,,jp1admin,;
 }
 `;
 
+const rootDefaultDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+  }
+}
+`;
+
 const parseJob = (): J => {
   const result = parseAjs(definition);
   assert.deepStrictEqual(result.errors, []);
@@ -97,6 +109,13 @@ const parseInheritedJobnet = (): N => {
 
 const parseScheduleJobnet = (): N => {
   const result = parseAjs(scheduleDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as N;
+};
+
+const parseRootDefaultJobnet = (): N => {
+  const result = parseAjs(rootDefaultDefinition);
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as N;
@@ -216,6 +235,32 @@ suite("ParameterFactory", () => {
         { rule: 1, value: "1" },
         { rule: 2, value: "2" },
       ],
+    );
+  });
+
+  test("returns explicit root-aware scalar and root-default-aware rule parameters through the facade", () => {
+    const jobnet = parseScheduleJobnet();
+
+    const rg = ParamFactory.rg(jobnet);
+    const sd = ParamFactory.sd(jobnet);
+
+    assert.strictEqual(rg?.value(), "3");
+    assert.deepStrictEqual(
+      sd?.map((parameter) => parameter.value()),
+      ["ud", "2,en"],
+    );
+  });
+
+  test("returns root-jobnet defaults through the facade", () => {
+    const jobnet = parseRootDefaultJobnet();
+
+    const rg = ParamFactory.rg(jobnet);
+    const sd = ParamFactory.sd(jobnet);
+
+    assert.strictEqual(rg?.value(), DEFAULTS.Rg);
+    assert.deepStrictEqual(
+      sd?.map((parameter) => parameter.value()),
+      [DEFAULTS.Sd],
     );
   });
 });

--- a/src/test/suite/parameterHelpers.test.ts
+++ b/src/test/suite/parameterHelpers.test.ts
@@ -14,7 +14,7 @@ import {
   buildOptionalParameter,
   buildRequiredParameter,
   buildRootJobnetParameter,
-  buildRootJobnetRuleParameters,
+  buildRootDefaultAwareRuleParameters,
   buildSdAlignedDefaultRuleParameters,
   buildSdAlignedEmptyRuleParameters,
   buildSdAlignedParameters,
@@ -299,7 +299,7 @@ suite("Parameter helpers", () => {
     assert.deepStrictEqual(inheritedCloseDates, ["mo"]);
   });
 
-  test("builds root-jobnet-aware scalar and rule-array parameters", () => {
+  test("builds root-jobnet-aware scalars and root-default-aware rule arrays", () => {
     const rootJobnet = parseRootDefaultJobnet();
     const { subnet } = parseJobnets();
 
@@ -325,7 +325,7 @@ suite("Parameter helpers", () => {
     );
     assert.strictEqual(inheritedRg, "3");
 
-    const rootSd = buildRootJobnetRuleParameters(
+    const rootSd = buildRootDefaultAwareRuleParameters(
       {
         unit: rootJobnet,
         parameter: "sd",
@@ -513,7 +513,7 @@ suite("Parameter helpers", () => {
     );
   });
 
-  test("resolves sd parameters through shared root-jobnet-aware helper logic", () => {
+  test("resolves sd parameters through shared root-default-aware helper logic", () => {
     const rootJobnet = parseRootDefaultJobnet();
     const { jobnet } = parseJobnets();
 


### PR DESCRIPTION
## Summary
- extract the root-jobnet-aware `rg` builder into a dedicated module and route `ParamFactory` through builder families
- move `sd` into the rule-parameter builder family with focused regression coverage for explicit and root-default behavior
- record the follow-up decision to handle any broader schedule-rule naming review in a separate slice

## Testing
- npm run qlty
- npm test
- npm run test:web
- npm run build