### PR TITLE
refactor: extract transfer operation parameter builders

### DIFF
--- a/docs/specs/features/decompose-parameter-factory/PLANS.md
+++ b/docs/specs/features/decompose-parameter-factory/PLANS.md
@@ -64,6 +64,11 @@ focused builder modules while preserving behavior.
   `rootJobnetParameterBuilders.ts`.
 - 2026-04-12: `ParamFactory` now delegates `rg` through a focused module that
   owns the root-jobnet scalar default concern.
+- 2026-04-12: transfer-operation builders were extracted to
+  `transferOperationParameterBuilders.ts`.
+- 2026-04-12: `ParamFactory` now delegates `top1`, `top2`, `top3`, and `top4`
+  through a focused module, while the shared fallback behavior remains in
+  `parameterHelpers.ts`.
 
 ## Proposed Slice Order
 
@@ -78,6 +83,7 @@ focused builder modules while preserving behavior.
 5. Root-jobnet-aware builders
    Status: completed on 2026-04-12
 6. Transfer-operation builders
+   Status: completed on 2026-04-12
 7. Schedule-rule naming review as a dedicated follow-up slice
    Status: deferred from the current extraction slice on 2026-04-12
    Notes: if executed, rename `Rule.ts` and related helpers/builders together

--- a/docs/specs/features/decompose-parameter-factory/TASKS.md
+++ b/docs/specs/features/decompose-parameter-factory/TASKS.md
@@ -19,7 +19,7 @@
 - [x] Extract inherited builders into a focused internal module
 - [x] Extract rule-bearing parameter builders into a focused internal module
 - [x] Extract root-jobnet-aware builders into a focused internal module
-- [ ] Extract transfer-operation `top1` to `top4` builders into a focused
+- [x] Extract transfer-operation `top1` to `top4` builders into a focused
       internal module
 - [ ] Revisit `Rule.ts` family naming in a dedicated slice so
       `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and
@@ -62,3 +62,6 @@
 - 2026-04-12: root-jobnet-aware builders now live in
   `rootJobnetParameterBuilders.ts`, with `ParamFactory` still exposing the
   public entry point for `rg`.
+- 2026-04-12: transfer-operation builders now live in
+  `transferOperationParameterBuilders.ts`, with `ParamFactory` still exposing
+  the public entry points for `top1`, `top2`, `top3`, and `top4`.

--- a/src/domain/models/parameters/ParameterFactory.ts
+++ b/src/domain/models/parameters/ParameterFactory.ts
@@ -1,16 +1,14 @@
-import { Ncex, Ncl, Ncs, Top1, Top2, Top3, Top4, Ty } from "../parameters";
-import { Cj } from "../units/Cj";
-import { J } from "../units/J";
+import { Ncex, Ncl, Ncs, Ty } from "../parameters";
 import { UnitEntity } from "../units/UnitEntity";
 import { inheritedParameterBuilders } from "./inheritedParameterBuilders";
 import { optionalArrayParameterBuilders } from "./optionalArrayParameterBuilders";
 import { optionalScalarParameterBuilders } from "./optionalScalarParameterBuilders";
 import { rootJobnetParameterBuilders } from "./rootJobnetParameterBuilders";
 import { ruleParameterBuilders } from "./ruleParameterBuilders";
+import { transferOperationParameterBuilders } from "./transferOperationParameterBuilders";
 import {
   buildDefaultableParameter,
   buildRequiredParameter,
-  buildTopParameter,
 } from "./parameterHelpers";
 
 export class ParamFactory {
@@ -245,46 +243,10 @@ export class ParamFactory {
   static te = optionalScalarParameterBuilders.te;
   static tho = optionalScalarParameterBuilders.tho;
   static tmitv = optionalScalarParameterBuilders.tmitv;
-  static top1(unit: J | Cj) {
-    return buildTopParameter(
-      {
-        unit: unit,
-        parameter: "top1",
-        index: 1,
-      },
-      (param) => new Top1(param),
-    );
-  }
-  static top2(unit: J | Cj) {
-    return buildTopParameter(
-      {
-        unit: unit,
-        parameter: "top2",
-        index: 2,
-      },
-      (param) => new Top2(param),
-    );
-  }
-  static top3(unit: J | Cj) {
-    return buildTopParameter(
-      {
-        unit: unit,
-        parameter: "top3",
-        index: 3,
-      },
-      (param) => new Top3(param),
-    );
-  }
-  static top4(unit: J | Cj) {
-    return buildTopParameter(
-      {
-        unit: unit,
-        parameter: "top4",
-        index: 4,
-      },
-      (param) => new Top4(param),
-    );
-  }
+  static top1 = transferOperationParameterBuilders.top1;
+  static top2 = transferOperationParameterBuilders.top2;
+  static top3 = transferOperationParameterBuilders.top3;
+  static top4 = transferOperationParameterBuilders.top4;
   static ts1 = optionalScalarParameterBuilders.ts1;
   static ts2 = optionalScalarParameterBuilders.ts2;
   static ts3 = optionalScalarParameterBuilders.ts3;

--- a/src/domain/models/parameters/transferOperationParameterBuilders.ts
+++ b/src/domain/models/parameters/transferOperationParameterBuilders.ts
@@ -1,0 +1,47 @@
+import { Top1, Top2, Top3, Top4 } from "../parameters";
+import { Cj } from "../units/Cj";
+import { J } from "../units/J";
+import { buildTopParameter } from "./parameterHelpers";
+
+export const transferOperationParameterBuilders = {
+  top1(unit: J | Cj) {
+    return buildTopParameter(
+      {
+        unit: unit,
+        parameter: "top1",
+        index: 1,
+      },
+      (param) => new Top1(param),
+    );
+  },
+  top2(unit: J | Cj) {
+    return buildTopParameter(
+      {
+        unit: unit,
+        parameter: "top2",
+        index: 2,
+      },
+      (param) => new Top2(param),
+    );
+  },
+  top3(unit: J | Cj) {
+    return buildTopParameter(
+      {
+        unit: unit,
+        parameter: "top3",
+        index: 3,
+      },
+      (param) => new Top3(param),
+    );
+  },
+  top4(unit: J | Cj) {
+    return buildTopParameter(
+      {
+        unit: unit,
+        parameter: "top4",
+        index: 4,
+      },
+      (param) => new Top4(param),
+    );
+  },
+};

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -85,6 +85,23 @@ unit=root,,jp1admin,;
 }
 `;
 
+const transferDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=job1,j,+0+0;
+  unit=job1,,jp1admin,;
+  {
+    ty=j;
+    ts1=src-1;
+    td1=dst-1;
+    ts2=src-2;
+    ts3=src-3;
+    top4=keep;
+  }
+}
+`;
+
 const parseJob = (): J => {
   const result = parseAjs(definition);
   assert.deepStrictEqual(result.errors, []);
@@ -119,6 +136,13 @@ const parseRootDefaultJobnet = (): N => {
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as N;
+};
+
+const parseTransferJob = (): J => {
+  const result = parseAjs(transferDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as J;
 };
 
 suite("ParameterFactory", () => {
@@ -262,5 +286,14 @@ suite("ParameterFactory", () => {
       sd?.map((parameter) => parameter.value()),
       [DEFAULTS.Sd],
     );
+  });
+
+  test("returns transfer-operation parameters with derived and explicit values through the facade", () => {
+    const job = parseTransferJob();
+
+    assert.strictEqual(ParamFactory.top1(job)?.value(), "sav");
+    assert.strictEqual(ParamFactory.top2(job)?.value(), "del");
+    assert.strictEqual(ParamFactory.top3(job)?.value(), "del");
+    assert.strictEqual(ParamFactory.top4(job)?.value(), "keep");
   });
 });


### PR DESCRIPTION
## Summary
- extract top1-top4 transfer-operation builders into a focused module
- keep ParamFactory as the public facade while delegating this builder family
- add regression coverage for derived and explicit transfer-operation values

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build