### PR TITLE
Refine ParameterFactory thin facade

### DIFF
--- a/docs/specs/features/decompose-parameter-factory/PLANS.md
+++ b/docs/specs/features/decompose-parameter-factory/PLANS.md
@@ -69,6 +69,19 @@ focused builder modules while preserving behavior.
 - 2026-04-12: `ParamFactory` now delegates `top1`, `top2`, `top3`, and `top4`
   through a focused module, while the shared fallback behavior remains in
   `parameterHelpers.ts`.
+- 2026-04-12: `ncex`, `ncl`, and `ncs` stay in the optional-scalar builder
+  family, using a runtime-default variant so the decomposition still groups
+  builders by construction pattern rather than by jobnet-connector semantics.
+- 2026-04-12: `ParamFactory` now delegates those runtime-default optional
+  scalars through `optionalScalarParameterBuilders.ts`, with facade-level
+  regression coverage for passed-through default values.
+- 2026-04-12: the last required builder was extracted to
+  `requiredScalarParameterBuilders.ts`.
+- 2026-04-12: `ParamFactory` now delegates `ty` through the same facade style,
+  leaving `ParameterFactory.ts` as a thin static export surface only.
+- 2026-04-12: the end-state decision is to keep `ParamFactory` as that thin
+  facade instead of collapsing to direct exports, because the feature spec
+  treats the current import path as a compatibility contract.
 
 ## Proposed Slice Order
 
@@ -90,6 +103,9 @@ focused builder modules while preserving behavior.
    so the terminology consistently reflects schedule-rule-bearing parameters.
 8. Final pass to keep `ParamFactory.ts` as a thin facade only if that still
    reads better than direct exports
+   Status: completed on 2026-04-12
+   Notes: the facade stays because it preserves the stable public API while
+   keeping implementation ownership in focused internal modules.
 
 ## Validation
 

--- a/docs/specs/features/decompose-parameter-factory/TASKS.md
+++ b/docs/specs/features/decompose-parameter-factory/TASKS.md
@@ -21,11 +21,14 @@
 - [x] Extract root-jobnet-aware builders into a focused internal module
 - [x] Extract transfer-operation `top1` to `top4` builders into a focused
       internal module
+- [x] Keep `ParamFactory` as a thin facade by extracting the remaining
+      required builders and absorbing runtime-default optional scalars into
+      the optional-scalar family
 - [ ] Revisit `Rule.ts` family naming in a dedicated slice so
       `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and
       `cftd` can be renamed together if `schedule rule` terminology is
       adopted
-- [ ] Decide whether the end state should keep `ParamFactory` as a thin facade
+- [x] Decide whether the end state should keep `ParamFactory` as a thin facade
       or collapse to direct exports
 
 ## Notes
@@ -65,3 +68,14 @@
 - 2026-04-12: transfer-operation builders now live in
   `transferOperationParameterBuilders.ts`, with `ParamFactory` still exposing
   the public entry points for `top1`, `top2`, `top3`, and `top4`.
+- 2026-04-12: runtime-default optional scalar builders for `ncex`, `ncl`, and
+  `ncs` now live in `optionalScalarParameterBuilders.ts`, so that family
+  continues to group scalar builders by construction pattern rather than by
+  domain concept.
+- 2026-04-12: required scalar builders now live in
+  `requiredScalarParameterBuilders.ts`, with `ParamFactory` still exposing
+  the public entry point for `ty`.
+- 2026-04-12: `ParamFactory.ts` now reads as a thin facade only; the branch
+  decision is to keep that facade instead of collapsing to direct exports so
+  existing callers retain the stable public import path defined in the
+  feature spec.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -92,17 +92,14 @@ structure in `docs/specs/features/<feature>/`.
 3. Reduce `buildUnitListView.ts` incrementally:
    extract calendar, priority, and schedule parsing helpers into focused
    modules while preserving the existing `UnitListRowView` contract and tests.
-4. Decompose `ParameterFactory.ts` as a dedicated feature:
-   extract coherent builder families behind the existing facade instead of
-   attempting another large refactor in one pass.
-5. Keep schedule-rule terminology changes separate from extraction slices:
+4. Keep schedule-rule terminology changes separate from extraction slices:
    if `Rule.ts` and related helpers are renamed, do it as one focused pass
    across `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and
    `cftd` instead of piecemeal renames.
-6. Keep feature follow-up verification evidence concrete:
+5. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-7. Revisit a dedicated filter/search use case only if a second non-table
+6. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 
 ## Wrapper Semantics Matrix

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -35,6 +35,8 @@
     already exists, and keep manual smoke debt only where it is still needed.
 16. Revisit a dedicated filter/search use case only if a second non-table
     consumer appears and needs the same matching semantics.
+17. Decompose `ParameterFactory.ts` into focused builder modules while keeping
+    `ParamFactory` as the stable thin facade for existing callers.
 
 ## Current Roadmap
 
@@ -43,9 +45,7 @@
 2. Break down high-complexity functions in the application layer, starting
    with focused helper extraction from `buildUnitListView.ts` instead of
    another broad rewrite.
-3. Decompose `ParameterFactory.ts` by coherent builder families while keeping
-   `ParamFactory` as the stable facade during migration.
-4. Consolidate i18n translation files to reduce duplication between language
+3. Consolidate i18n translation files to reduce duplication between language
    variants.
 
 ## Deferred / Optional Slices
@@ -56,6 +56,8 @@
    complete and performance becomes a stronger priority.
 3. Revisit directory structure under `src/extension/webview/` only if the
    remaining files stop reading as one cohesive viewer module.
+4. Revisit schedule-rule terminology around `Rule.ts` only as a dedicated
+   rename slice across the full rule-bearing parameter family.
 
 ## Done Criteria For A Slice
 

--- a/src/domain/models/parameters/ParameterFactory.ts
+++ b/src/domain/models/parameters/ParameterFactory.ts
@@ -1,15 +1,10 @@
-import { Ncex, Ncl, Ncs, Ty } from "../parameters";
-import { UnitEntity } from "../units/UnitEntity";
 import { inheritedParameterBuilders } from "./inheritedParameterBuilders";
 import { optionalArrayParameterBuilders } from "./optionalArrayParameterBuilders";
 import { optionalScalarParameterBuilders } from "./optionalScalarParameterBuilders";
+import { requiredScalarParameterBuilders } from "./requiredScalarParameterBuilders";
 import { rootJobnetParameterBuilders } from "./rootJobnetParameterBuilders";
 import { ruleParameterBuilders } from "./ruleParameterBuilders";
 import { transferOperationParameterBuilders } from "./transferOperationParameterBuilders";
-import {
-  buildDefaultableParameter,
-  buildRequiredParameter,
-} from "./parameterHelpers";
 
 export class ParamFactory {
   static ab = optionalScalarParameterBuilders.ab;
@@ -154,39 +149,12 @@ export class ParamFactory {
   static msttp = optionalScalarParameterBuilders.msttp;
   static msunr = optionalScalarParameterBuilders.msunr;
   static mu = optionalScalarParameterBuilders.mu;
-  static ncex(unit: UnitEntity, defaultRawValue?: string) {
-    return buildDefaultableParameter(
-      {
-        unit: unit,
-        parameter: "ncex",
-        defaultRawValue: defaultRawValue,
-      },
-      (param) => new Ncex(param),
-    );
-  }
+  static ncex = optionalScalarParameterBuilders.ncex;
   static nchn = optionalScalarParameterBuilders.nchn;
-  static ncl(unit: UnitEntity, defaultRawValue?: string) {
-    return buildDefaultableParameter(
-      {
-        unit: unit,
-        parameter: "ncl",
-        defaultRawValue: defaultRawValue,
-      },
-      (param) => new Ncl(param),
-    );
-  }
+  static ncl = optionalScalarParameterBuilders.ncl;
   static ncn = optionalScalarParameterBuilders.ncn;
   static ncr = optionalScalarParameterBuilders.ncr;
-  static ncs(unit: UnitEntity, defaultRawValue?: string) {
-    return buildDefaultableParameter(
-      {
-        unit: unit,
-        parameter: "ncs",
-        defaultRawValue: defaultRawValue,
-      },
-      (param) => new Ncs(param),
-    );
-  }
+  static ncs = optionalScalarParameterBuilders.ncs;
   static ncsv = optionalScalarParameterBuilders.ncsv;
   static ni = inheritedParameterBuilders.ni;
   static nmg = optionalScalarParameterBuilders.nmg;
@@ -251,16 +219,7 @@ export class ParamFactory {
   static ts2 = optionalScalarParameterBuilders.ts2;
   static ts3 = optionalScalarParameterBuilders.ts3;
   static ts4 = optionalScalarParameterBuilders.ts4;
-  static ty(unit: UnitEntity) {
-    return buildRequiredParameter(
-      {
-        unit: unit,
-        parameter: "ty",
-      },
-      (param) => new Ty(param),
-      () => "Ty parameter should be specified.",
-    );
-  }
+  static ty = requiredScalarParameterBuilders.ty;
   static uem = optionalScalarParameterBuilders.uem;
   static un = optionalScalarParameterBuilders.un;
   static unit = optionalScalarParameterBuilders.unit;

--- a/src/domain/models/parameters/optionalScalarParameterBuilders.ts
+++ b/src/domain/models/parameters/optionalScalarParameterBuilders.ts
@@ -127,9 +127,12 @@ import {
   Msttp,
   Msunr,
   Mu,
+  Ncex,
   Nchn,
+  Ncl,
   Ncn,
   Ncr,
+  Ncs,
   Ncsv,
   Nmg,
   Ntcls,
@@ -196,6 +199,24 @@ const createOptionalScalarBuilder = <T, P extends ParamInternal["parameter"]>(
   defaultRawValue?: string,
 ) => {
   return (unit: UnitEntity): T | undefined =>
+    buildOptionalParameter(
+      {
+        unit: unit,
+        parameter: parameter,
+        defaultRawValue: defaultRawValue,
+      },
+      mapParam,
+    );
+};
+
+const createRuntimeDefaultOptionalScalarBuilder = <
+  T,
+  P extends ParamInternal["parameter"],
+>(
+  parameter: P,
+  mapParam: (param: ParamInternal) => T,
+) => {
+  return (unit: UnitEntity, defaultRawValue?: string): T | undefined =>
     buildOptionalParameter(
       {
         unit: unit,
@@ -443,9 +464,21 @@ export const optionalScalarParameterBuilders = {
   msttp: createOptionalScalarBuilder("msttp", (param) => new Msttp(param)),
   msunr: createOptionalScalarBuilder("msunr", (param) => new Msunr(param)),
   mu: createOptionalScalarBuilder("mu", (param) => new Mu(param)),
+  ncex: createRuntimeDefaultOptionalScalarBuilder(
+    "ncex",
+    (param) => new Ncex(param),
+  ),
   nchn: createOptionalScalarBuilder("nchn", (param) => new Nchn(param)),
+  ncl: createRuntimeDefaultOptionalScalarBuilder(
+    "ncl",
+    (param) => new Ncl(param),
+  ),
   ncn: createOptionalScalarBuilder("ncn", (param) => new Ncn(param)),
   ncr: createOptionalScalarBuilder("ncr", (param) => new Ncr(param)),
+  ncs: createRuntimeDefaultOptionalScalarBuilder(
+    "ncs",
+    (param) => new Ncs(param),
+  ),
   ncsv: createOptionalScalarBuilder("ncsv", (param) => new Ncsv(param)),
   nmg: createOptionalScalarBuilder(
     "nmg",

--- a/src/domain/models/parameters/requiredScalarParameterBuilders.ts
+++ b/src/domain/models/parameters/requiredScalarParameterBuilders.ts
@@ -1,0 +1,28 @@
+import { Ty } from "../parameters";
+import { UnitEntity } from "../units/UnitEntity";
+import { buildRequiredParameter } from "./parameterHelpers";
+import { ParamInternal } from "./parameter.types";
+
+const createRequiredScalarBuilder = <T, P extends ParamInternal["parameter"]>(
+  parameter: P,
+  mapParam: (param: ParamInternal) => T,
+  buildErrorMessage: (parameter: P) => string,
+) => {
+  return (unit: UnitEntity): T =>
+    buildRequiredParameter(
+      {
+        unit: unit,
+        parameter: parameter,
+      },
+      mapParam,
+      (missingParameter) => buildErrorMessage(missingParameter as P),
+    );
+};
+
+export const requiredScalarParameterBuilders = {
+  ty: createRequiredScalarBuilder(
+    "ty",
+    (param) => new Ty(param),
+    () => "Ty parameter should be specified.",
+  ),
+} as const;

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -85,6 +85,13 @@ unit=root,,jp1admin,;
 }
 `;
 
+const groupDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+}
+`;
+
 const transferDefinition = `
 unit=root,,jp1admin,;
 {
@@ -136,6 +143,12 @@ const parseRootDefaultJobnet = (): N => {
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as N;
+};
+
+const parseRootGroup = () => {
+  const result = parseAjs(groupDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  return tyFactory(result.rootUnits[0]);
 };
 
 const parseTransferJob = (): J => {
@@ -286,6 +299,25 @@ suite("ParameterFactory", () => {
       sd?.map((parameter) => parameter.value()),
       [DEFAULTS.Sd],
     );
+  });
+
+  test("returns connector-control defaults through the facade", () => {
+    const root = parseRootGroup();
+
+    assert.strictEqual(ParamFactory.ncl(root, "n")?.value(), "n");
+    assert.strictEqual(ParamFactory.ncs(root, "n")?.value(), "n");
+    assert.strictEqual(ParamFactory.ncex(root, "n")?.value(), "n");
+    assert.strictEqual(ParamFactory.ncl(root, "y")?.value(), "y");
+    assert.strictEqual(ParamFactory.ncs(root, "y")?.value(), "y");
+    assert.strictEqual(ParamFactory.ncex(root, "y")?.value(), "y");
+  });
+
+  test("returns required parameters through the facade", () => {
+    const job = parseJob();
+
+    const ty = ParamFactory.ty(job);
+
+    assert.strictEqual(ty.value(), "j");
   });
 
   test("returns transfer-operation parameters with derived and explicit values through the facade", () => {


### PR DESCRIPTION
## Summary
- keep ParamFactory as a thin facade while extracting the remaining required builder
- absorb runtime-default optional scalars into optionalScalarParameterBuilders instead of creating a domain-specific family
- sync decompose-parameter-factory specs and add facade regression coverage

## Testing
- npm run qlty
- npm test
- npm run test:web
- npm run build