### PR TITLE
Document inherited-builder follow-up

### DIFF
--- a/docs/specs/features/decompose-parameter-factory/PLANS.md
+++ b/docs/specs/features/decompose-parameter-factory/PLANS.md
@@ -76,6 +76,13 @@ focused builder modules while preserving behavior.
 - 2026-04-12: `ParamFactory` now delegates those runtime-default optional
   scalars through `optionalScalarParameterBuilders.ts`, with facade-level
   regression coverage for passed-through default values.
+- 2026-04-12: after `rg` joined the optional-scalar family, the main remaining
+  classification mismatch is that `inheritedParameterBuilders.ts` still uses
+  lookup strategy as its family boundary while other families are now
+  described primarily by parameter-construction shape.
+- 2026-04-12: keep that inherited-family question as an explicit follow-up
+  instead of folding it into the already-completed thin-facade work, because
+  it may require reshaping both scalar and array families together.
 - 2026-04-12: the last required builder was extracted to
   `requiredScalarParameterBuilders.ts`.
 - 2026-04-12: `ParamFactory` now delegates `ty` through the same facade style,

--- a/docs/specs/features/decompose-parameter-factory/TASKS.md
+++ b/docs/specs/features/decompose-parameter-factory/TASKS.md
@@ -25,6 +25,9 @@
 - [x] Keep `ParamFactory` as a thin facade by extracting the remaining
       required builders and absorbing runtime-default optional scalars into
       the optional-scalar family
+- [ ] Revisit whether inherited builders should remain a dedicated family or
+      be absorbed into scalar and array builder families so decomposition uses
+      one consistent construction-pattern axis
 - [ ] Revisit `Rule.ts` family naming in a dedicated slice so
       `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and
       `cftd` can be renamed together if `schedule rule` terminology is
@@ -74,6 +77,10 @@
   `ncs` now live in `optionalScalarParameterBuilders.ts`, so that family
   continues to group scalar builders by construction pattern rather than by
   domain concept.
+- 2026-04-12: after `rg` moved into the optional-scalar family, the remaining
+  axis mismatch is that `inheritedParameterBuilders.ts` is still organized by
+  lookup strategy while scalar and array builders are now organized by value
+  shape; that alignment question should stay as an explicit follow-up task.
 - 2026-04-12: required scalar builders now live in
   `requiredScalarParameterBuilders.ts`, with `ParamFactory` still exposing
   the public entry point for `ty`.


### PR DESCRIPTION
## Summary
- record the remaining inherited-builder classification mismatch as an explicit follow-up in decompose-parameter-factory docs
- keep the note in feature-local TASKS.md and PLANS.md without changing code or branch-level priorities

## Testing
- npm run lint:md
