### PR TITLE
Rename schedule rule parameter helpers

### DIFF
--- a/docs/specs/features/decompose-parameter-factory/PLANS.md
+++ b/docs/specs/features/decompose-parameter-factory/PLANS.md
@@ -98,6 +98,10 @@ focused builder modules while preserving behavior.
   shape as root-jobnet defaults at the call-site level, but the defaults
   themselves now live in the flat `DEFAULTS` table instead of nested
   sub-objects, so value ownership stays with the parameter definitions.
+- 2026-04-12: the dedicated terminology slice renamed `Rule.ts` to
+  `ScheduleRule.ts` and aligned the shared interface plus helper/builder names
+  around `schedule rule` terminology while preserving the `ParamFactory`
+  facade and parameter parsing behavior.
 
 ## Proposed Slice Order
 
@@ -121,9 +125,9 @@ focused builder modules while preserving behavior.
    option, and inherited array builders now reuse the array family through
    the same construction-pattern axis.
 8. Schedule-rule naming review as a dedicated follow-up slice
-   Status: deferred from the current extraction slice on 2026-04-12
-   Notes: if executed, rename `Rule.ts` and related helpers/builders together
-   so the terminology consistently reflects schedule-rule-bearing parameters.
+   Status: completed on 2026-04-12
+   Notes: `Rule.ts` and related helpers/builders were renamed together so the
+   terminology now consistently reflects schedule-rule-bearing parameters.
 9. Final pass to keep `ParamFactory.ts` as a thin facade only if that still
    reads better than direct exports
    Status: completed on 2026-04-12

--- a/docs/specs/features/decompose-parameter-factory/TASKS.md
+++ b/docs/specs/features/decompose-parameter-factory/TASKS.md
@@ -28,7 +28,7 @@
 - [x] Revisit whether inherited builders should remain a dedicated family or
       be absorbed into scalar and array builder families so decomposition uses
       one consistent construction-pattern axis
-- [ ] Revisit `Rule.ts` family naming in a dedicated slice so
+- [x] Revisit `Rule.ts` family naming in a dedicated slice so
       `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and
       `cftd` can be renamed together if `schedule rule` terminology is
       adopted
@@ -100,3 +100,7 @@
 - 2026-04-12: connector-control defaults are now parameter-keyed in
   the flat `DEFAULTS` table as well, so both connector-control and
   root-jobnet defaults read from the same per-parameter source of truth.
+- 2026-04-12: the deferred naming slice is now complete; `Rule.ts`,
+  its shared interface, and the builder/helper APIs now use
+  `ScheduleRule` terminology consistently without changing the
+  `ParamFactory` facade or parameter behavior.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -92,12 +92,11 @@ structure in `docs/specs/features/<feature>/`.
 3. Reduce `buildUnitListView.ts` incrementally:
    extract calendar, priority, and schedule parsing helpers into focused
    modules while preserving the existing `UnitListRowView` contract and tests.
-4. Keep schedule-rule terminology changes separate from extraction slices:
-   if `Rule.ts` and related helpers are renamed, do it as one focused pass
-   across `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and
-   `cftd` instead of piecemeal renames.
-   The inherited-builder shape follow-up inside the ParameterFactory
-   decomposition is complete; only the naming slice remains open there.
+4. The inherited-builder shape and schedule-rule naming follow-ups inside the
+   ParameterFactory decomposition are complete.
+   Keep any future terminology cleanup as one focused pass across `sd`, `st`,
+   `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and `cftd` instead of
+   piecemeal renames.
 5. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
@@ -258,6 +257,85 @@ Use-case note:
 -
 
 ## Current Task
+
+### Task
+
+Align the internal `ParameterFactory` rule family with `schedule rule`
+terminology without changing parameter behavior or the `ParamFactory` facade.
+
+### Why
+
+The decomposition work already isolated this family, but the remaining
+`Rule.ts` naming obscures that these parameters are organized around
+schedule-rule-bearing behavior rather than a generic rule concept.
+
+### Scope
+
+- `src/domain/models/parameters/ScheduleRule.ts` and dependent parameter modules
+- schedule-rule helper and builder naming under
+  `src/domain/models/parameters/`
+- regression-test wording and feature-plan synchronization
+
+### Non-Goals
+
+- changing JP1/AJS parsing behavior or default semantics
+- changing `ParamFactory` call sites or public import paths
+- moving parameter ownership outside the current domain layer
+
+### Constraints
+
+- Keep `engines.vscode` compatibility unless explicitly approved.
+- Keep desktop and web extension behavior intact.
+- Avoid direct `vscode` dependency in domain.
+- Start implementation from a dedicated git branch, not directly on `main`.
+- Do not `git push` until `npm run qlty`, `npm test`, `npm run test:web`,
+  and `npm run build` have all passed locally in that order for code changes.
+
+### Design
+
+#### Use case
+
+Behavior-preserving follow-up to the `decompose-parameter-factory` feature.
+
+#### Layers affected
+
+- domain: yes
+- application: no
+- infrastructure: no
+- presentation: no
+
+#### Key decisions
+
+- Keep `ParamFactory` as the stable public facade and rename only the internal
+  schedule-rule family surface.
+- Rename the file, shared interface, and helper/builder identifiers together
+  so terminology changes land in one coherent slice.
+
+### Acceptance Criteria
+
+- [ ] build passes
+- [ ] quality/lint passes
+- [ ] tests updated
+- [ ] desktop behavior preserved
+- [ ] web behavior preserved if affected
+
+### Test Plan
+
+- Run `npm run qlty`
+- Run `npm test`
+- Run `npm run test:web`
+- Run `npm run build`
+
+### Risks
+
+- Missing a remaining `ScheduleRule` import and breaking type exports.
+- Renaming helper APIs without preserving existing behavior for schedule-rule
+  sorting, alignment, or defaults.
+
+### Rollback Plan
+
+- Restore the previous file and identifier names while keeping the extracted
+  builder modules intact.
 
 ### Task: Decide unit-list filtering boundary
 

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -258,31 +258,31 @@ Use-case note:
 
 ## Current Task
 
-### Task
+### Current Slice
 
 Align the internal `ParameterFactory` rule family with `schedule rule`
 terminology without changing parameter behavior or the `ParamFactory` facade.
 
-### Why
+### Current Need
 
 The decomposition work already isolated this family, but the remaining
 `Rule.ts` naming obscures that these parameters are organized around
 schedule-rule-bearing behavior rather than a generic rule concept.
 
-### Scope
+### Current Scope
 
 - `src/domain/models/parameters/ScheduleRule.ts` and dependent parameter modules
 - schedule-rule helper and builder naming under
   `src/domain/models/parameters/`
 - regression-test wording and feature-plan synchronization
 
-### Non-Goals
+### Current Non-Goals
 
 - changing JP1/AJS parsing behavior or default semantics
 - changing `ParamFactory` call sites or public import paths
 - moving parameter ownership outside the current domain layer
 
-### Constraints
+### Current Constraints
 
 - Keep `engines.vscode` compatibility unless explicitly approved.
 - Keep desktop and web extension behavior intact.
@@ -291,27 +291,27 @@ schedule-rule-bearing behavior rather than a generic rule concept.
 - Do not `git push` until `npm run qlty`, `npm test`, `npm run test:web`,
   and `npm run build` have all passed locally in that order for code changes.
 
-### Design
+### Current Design
 
-#### Use case
+#### Current use case
 
 Behavior-preserving follow-up to the `decompose-parameter-factory` feature.
 
-#### Layers affected
+#### Current layers affected
 
 - domain: yes
 - application: no
 - infrastructure: no
 - presentation: no
 
-#### Key decisions
+#### Current key decisions
 
 - Keep `ParamFactory` as the stable public facade and rename only the internal
   schedule-rule family surface.
 - Rename the file, shared interface, and helper/builder identifiers together
   so terminology changes land in one coherent slice.
 
-### Acceptance Criteria
+### Current Acceptance Criteria
 
 - [ ] build passes
 - [ ] quality/lint passes
@@ -319,20 +319,20 @@ Behavior-preserving follow-up to the `decompose-parameter-factory` feature.
 - [ ] desktop behavior preserved
 - [ ] web behavior preserved if affected
 
-### Test Plan
+### Current Test Plan
 
 - Run `npm run qlty`
 - Run `npm test`
 - Run `npm run test:web`
 - Run `npm run build`
 
-### Risks
+### Current Risks
 
 - Missing a remaining `ScheduleRule` import and breaking type exports.
 - Renaming helper APIs without preserving existing behavior for schedule-rule
   sorting, alignment, or defaults.
 
-### Rollback Plan
+### Current Rollback Plan
 
 - Restore the previous file and identifier names while keeping the extracted
   builder modules intact.

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -56,8 +56,6 @@
    complete and performance becomes a stronger priority.
 3. Revisit directory structure under `src/extension/webview/` only if the
    remaining files stop reading as one cohesive viewer module.
-4. Revisit schedule-rule terminology around `Rule.ts` only as a dedicated
-   rename slice across the full rule-bearing parameter family.
 
 ## Done Criteria For A Slice
 

--- a/src/domain/models/parameters/ScheduleRule.ts
+++ b/src/domain/models/parameters/ScheduleRule.ts
@@ -2,12 +2,12 @@ import Day from "./Day";
 import Parameter from "./Parameter";
 import { ParamInternal } from "./parameter.types";
 
-interface Rule {
+interface ScheduleRule {
   get rule(): number;
 }
-export default Rule;
+export default ScheduleRule;
 
-export class Cftd extends Parameter implements Rule {
+export class Cftd extends Parameter implements ScheduleRule {
   /**
    * [N,]{no|be|af|db|da}[,n[,N]]    ((\d{1,3}),)?(no|be|af|db|da)((,(\d{1,2}))(,(\d{1,2}))?)?
    */
@@ -48,7 +48,7 @@ export class Cftd extends Parameter implements Rule {
   }
 }
 
-export class Cy extends Parameter implements Rule {
+export class Cy extends Parameter implements ScheduleRule {
   /**
    * [N,](n,{y|m|w|d})    ((\d{1,3}),)?\(((\d{1,3}),([ymwd]))\)
    */
@@ -76,7 +76,7 @@ export class Cy extends Parameter implements Rule {
   }
 }
 
-export class Ln extends Parameter implements Rule {
+export class Ln extends Parameter implements ScheduleRule {
   /**
    * [N,] n       ((\d{1,3}),)?(\d{1,3})
    */
@@ -104,7 +104,7 @@ export class Ln extends Parameter implements Rule {
   }
 }
 
-export class Sd extends Day implements Rule {
+export class Sd extends Day implements ScheduleRule {
   get rule() {
     return this._rule ?? 1;
   }
@@ -142,7 +142,7 @@ export class Sd extends Day implements Rule {
     return undefined;
   }
 }
-export class Sh extends Parameter implements Rule {
+export class Sh extends Parameter implements ScheduleRule {
   /**
    * [N,]{be|af|ca|no}      ((\d{1,3}),)?(be|af|ca|no)
    */
@@ -170,7 +170,7 @@ export class Sh extends Parameter implements Rule {
   }
 }
 
-export class Shd extends Parameter implements Rule {
+export class Shd extends Parameter implements ScheduleRule {
   /**
    * [N,] n       ((\d{1,3}),)?(\d{1,3})
    */
@@ -198,7 +198,7 @@ export class Shd extends Parameter implements Rule {
   }
 }
 
-export class Wc extends Parameter implements Rule {
+export class Wc extends Parameter implements ScheduleRule {
   /**
    * [N,] {no|N|un}       ((\d{1,3}),)?(.+)
    */

--- a/src/domain/models/parameters/Time.ts
+++ b/src/domain/models/parameters/Time.ts
@@ -1,8 +1,8 @@
 import { ParamInternal } from "./parameter.types";
 import Parameter from "./Parameter";
-import Rule from "./Rule";
+import ScheduleRule from "./ScheduleRule";
 
-abstract class Time extends Parameter implements Rule {
+abstract class Time extends Parameter implements ScheduleRule {
   /**
    * [N,]                   ((\d{1,3}),)?
    * {no|hh:mm|mmmm|un}     (no|([+]?)\d{2}:\d{2}|([MCU])?\d{1,4}|un)

--- a/src/domain/models/parameters/index.ts
+++ b/src/domain/models/parameters/index.ts
@@ -4,5 +4,5 @@ export * from "./Calendar";
 export * from "./Day";
 export * from "./PlainString";
 export * from "./EncordedString";
-export * from "./Rule";
+export * from "./ScheduleRule";
 export * from "./Time";

--- a/src/domain/models/parameters/parameterHelpers.ts
+++ b/src/domain/models/parameters/parameterHelpers.ts
@@ -1,7 +1,7 @@
 import { ParamSymbol, isParamSymbol } from "../../values/AjsType";
 import { DEFAULTS } from "./Defaults";
 import { ParamBase, ParamInternal } from "./parameter.types";
-import Rule, { Sd } from "./Rule";
+import ScheduleRule, { Sd } from "./ScheduleRule";
 
 export type ParamLookupArg = ParamBase & {
   inherit?: boolean;
@@ -152,8 +152,10 @@ export const buildRequiredParameter = <T>(
   return parameter;
 };
 
-/** Create a parameter value map with rule numbers as keys. */
-const mapByRule = <T extends Rule>(params: Array<T> | undefined) =>
+/** Create a parameter value map with schedule rule numbers as keys. */
+const mapByScheduleRule = <T extends ScheduleRule>(
+  params: Array<T> | undefined,
+) =>
   params
     ? params.reduce(
         (work, param) => {
@@ -164,16 +166,16 @@ const mapByRule = <T extends Rule>(params: Array<T> | undefined) =>
       )
     : undefined;
 
-export const adjustToSdItemCount = <T extends Rule>(
+export const adjustToSdItemCount = <T extends ScheduleRule>(
   sd: Array<Sd> | undefined,
   param: Array<T> | undefined,
   buildDefault: (rule: number) => T | null,
 ): Array<T | null> | undefined => {
-  const sdMap = mapByRule(sd);
+  const sdMap = mapByScheduleRule(sd);
   if (sdMap === undefined) {
     return undefined;
   }
-  const paramMap = mapByRule(param);
+  const paramMap = mapByScheduleRule(param);
   const newParams: Array<T | null> = [];
   Object.keys(sdMap).forEach((sdRule) => {
     const rule = sdMap[sdRule].rule;
@@ -182,7 +184,7 @@ export const adjustToSdItemCount = <T extends Rule>(
   return newParams;
 };
 
-export const buildSdAlignedParameters = <T extends Rule>(
+export const buildSdAlignedScheduleParameters = <T extends ScheduleRule>(
   params: ParamInternal[] | undefined,
   sd: Array<Sd> | undefined,
   mapParam: (param: ParamInternal) => T,
@@ -197,7 +199,7 @@ export const buildSdAlignedParameters = <T extends Rule>(
 export const resolveSdParameters = (
   unit: ParamLookupArg["unit"] & { isRoot: boolean },
 ): Array<Sd> | undefined =>
-  buildRootDefaultAwareRuleParameters(
+  buildRootDefaultAwareScheduleRuleParameters(
     {
       unit: unit,
       parameter: "sd",
@@ -207,11 +209,13 @@ export const resolveSdParameters = (
     (param) => new Sd(param),
   );
 
-export const buildSdAlignedEmptyRuleParameters = <T extends Rule>(
+export const buildSdAlignedEmptyScheduleRuleParameters = <
+  T extends ScheduleRule,
+>(
   arg: Omit<ParamLookupArg, "inherit" | "defaultRawValue">,
   mapParam: (param: ParamInternal) => T,
 ): Array<T | null> | undefined =>
-  buildSdAlignedParameters(
+  buildSdAlignedScheduleParameters(
     resolveParameterArray({
       unit: arg.unit,
       parameter: arg.parameter,
@@ -228,13 +232,15 @@ export const buildSdAlignedEmptyRuleParameters = <T extends Rule>(
       }),
   );
 
-export const buildSdAlignedDefaultRuleParameters = <T extends Rule>(
+export const buildSdAlignedDefaultScheduleRuleParameters = <
+  T extends ScheduleRule,
+>(
   arg: Omit<ParamLookupArg, "inherit"> & {
     buildFallbackRawValue: (rule: number) => string;
   },
   mapParam: (param: ParamInternal) => T,
 ): Array<T | null> | undefined =>
-  buildSdAlignedParameters(
+  buildSdAlignedScheduleParameters(
     resolveParameterArray({
       unit: arg.unit,
       parameter: arg.parameter,
@@ -252,7 +258,7 @@ export const buildSdAlignedDefaultRuleParameters = <T extends Rule>(
       }),
   );
 
-export const buildSortedRuleParameters = <T extends Rule>(
+export const buildSortedScheduleRuleParameters = <T extends ScheduleRule>(
   params: ParamInternal[] | undefined,
   mapParam: (param: ParamInternal) => T,
 ): Array<T> | undefined =>
@@ -299,14 +305,16 @@ export const buildRootJobnetParameter = <T>(
     mapParam,
   );
 
-export const buildRootDefaultAwareRuleParameters = <T extends Rule>(
+export const buildRootDefaultAwareScheduleRuleParameters = <
+  T extends ScheduleRule,
+>(
   arg: Omit<ParamLookupArg, "defaultRawValue" | "inherit"> & {
     isRootJobnet: boolean;
     rootDefaultParameter: RootJobnetDefaultParameter;
   },
   mapParam: (param: ParamInternal) => T,
 ): Array<T> | undefined =>
-  buildSortedRuleParameters(
+  buildSortedScheduleRuleParameters(
     resolveParameterArray({
       unit: arg.unit,
       parameter: arg.parameter,

--- a/src/domain/models/parameters/ruleParameterBuilders.ts
+++ b/src/domain/models/parameters/ruleParameterBuilders.ts
@@ -3,17 +3,17 @@ import { N } from "../units/N";
 import { UnitEntity } from "../units/UnitEntity";
 import { DEFAULTS } from "./Defaults";
 import {
-  buildRootDefaultAwareRuleParameters,
-  buildSortedRuleParameters,
-  buildSdAlignedDefaultRuleParameters,
-  buildSdAlignedEmptyRuleParameters,
+  buildRootDefaultAwareScheduleRuleParameters,
+  buildSortedScheduleRuleParameters,
+  buildSdAlignedDefaultScheduleRuleParameters,
+  buildSdAlignedEmptyScheduleRuleParameters,
   resolveParameterArray,
 } from "./parameterHelpers";
 import { ParamInternal } from "./parameter.types";
-import Rule from "./Rule";
+import ScheduleRule from "./ScheduleRule";
 
 const createScheduleRuleDefaultBuilder = <
-  T extends Rule,
+  T extends ScheduleRule,
   P extends ParamInternal["parameter"],
 >(
   parameter: P,
@@ -21,7 +21,7 @@ const createScheduleRuleDefaultBuilder = <
   defaultRawValue: string,
 ) => {
   return (unit: UnitEntity): Array<T | null> | undefined =>
-    buildSdAlignedDefaultRuleParameters(
+    buildSdAlignedDefaultScheduleRuleParameters(
       {
         unit: unit,
         parameter: parameter,
@@ -33,14 +33,14 @@ const createScheduleRuleDefaultBuilder = <
 };
 
 const createScheduleRuleEmptyBuilder = <
-  T extends Rule,
+  T extends ScheduleRule,
   P extends ParamInternal["parameter"],
 >(
   parameter: P,
   mapParam: (param: ParamInternal) => T,
 ) => {
   return (unit: UnitEntity): Array<T | null> | undefined =>
-    buildSdAlignedEmptyRuleParameters(
+    buildSdAlignedEmptyScheduleRuleParameters(
       {
         unit: unit,
         parameter: parameter,
@@ -49,15 +49,15 @@ const createScheduleRuleEmptyBuilder = <
     );
 };
 
-const createSortedRuleBuilder = <
-  T extends Rule,
+const createSortedScheduleRuleBuilder = <
+  T extends ScheduleRule,
   P extends ParamInternal["parameter"],
 >(
   parameter: P,
   mapParam: (param: ParamInternal) => T,
 ) => {
   return (unit: UnitEntity): Array<T> | undefined =>
-    buildSortedRuleParameters(
+    buildSortedScheduleRuleParameters(
       resolveParameterArray({
         unit: unit,
         parameter: parameter,
@@ -66,8 +66,8 @@ const createSortedRuleBuilder = <
     );
 };
 
-const createRootDefaultAwareRuleBuilder = <
-  T extends Rule,
+const createRootDefaultAwareScheduleRuleBuilder = <
+  T extends ScheduleRule,
   P extends ParamInternal["parameter"],
 >(
   parameter: P,
@@ -75,7 +75,7 @@ const createRootDefaultAwareRuleBuilder = <
   mapParam: (param: ParamInternal) => T,
 ) => {
   return (unit: N): Array<T> | undefined =>
-    buildRootDefaultAwareRuleParameters(
+    buildRootDefaultAwareScheduleRuleParameters(
       {
         unit: unit,
         parameter: parameter,
@@ -86,7 +86,7 @@ const createRootDefaultAwareRuleBuilder = <
     );
 };
 
-// Rule-bearing parameters are primarily meaningful on jobnets (`ty=n`),
+// Schedule-rule-bearing parameters are primarily meaningful on jobnets (`ty=n`),
 // but the split here is based on parameter structure, not owning unit type.
 export const ruleParameterBuilders = {
   cftd: createScheduleRuleDefaultBuilder(
@@ -96,8 +96,12 @@ export const ruleParameterBuilders = {
   ),
   cy: createScheduleRuleEmptyBuilder("cy", (param) => new Cy(param)),
   ey: createScheduleRuleEmptyBuilder("ey", (param) => new Ey(param)),
-  ln: createSortedRuleBuilder("ln", (param) => new Ln(param)),
-  sd: createRootDefaultAwareRuleBuilder("sd", "sd", (param) => new Sd(param)),
+  ln: createSortedScheduleRuleBuilder("ln", (param) => new Ln(param)),
+  sd: createRootDefaultAwareScheduleRuleBuilder(
+    "sd",
+    "sd",
+    (param) => new Sd(param),
+  ),
   sh: createScheduleRuleEmptyBuilder("sh", (param) => new Sh(param)),
   shd: createScheduleRuleDefaultBuilder(
     "shd",

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -267,7 +267,7 @@ suite("ParameterFactory", () => {
     );
   });
 
-  test("returns rule-bearing parameters sorted by rule", () => {
+  test("returns schedule-rule-bearing parameters sorted by rule", () => {
     const jobnet = parseScheduleJobnet();
 
     const ln = ParamFactory.ln(jobnet);
@@ -284,7 +284,7 @@ suite("ParameterFactory", () => {
     );
   });
 
-  test("returns explicit root-aware scalar and root-default-aware rule parameters through the facade", () => {
+  test("returns explicit root-aware scalar and root-default-aware schedule-rule parameters through the facade", () => {
     const jobnet = parseScheduleJobnet();
 
     const rg = ParamFactory.rg(jobnet);

--- a/src/test/suite/parameterHelpers.test.ts
+++ b/src/test/suite/parameterHelpers.test.ts
@@ -14,11 +14,11 @@ import {
   buildOptionalParameter,
   buildRequiredParameter,
   buildRootJobnetParameter,
-  buildRootDefaultAwareRuleParameters,
-  buildSdAlignedDefaultRuleParameters,
-  buildSdAlignedEmptyRuleParameters,
-  buildSdAlignedParameters,
-  buildSortedRuleParameters,
+  buildRootDefaultAwareScheduleRuleParameters,
+  buildSdAlignedDefaultScheduleRuleParameters,
+  buildSdAlignedEmptyScheduleRuleParameters,
+  buildSdAlignedScheduleParameters,
+  buildSortedScheduleRuleParameters,
   buildTopParameter,
   resolveSdParameters,
   resolveConnectorControlDefaultRawValue,
@@ -232,10 +232,10 @@ suite("Parameter helpers", () => {
     assert.strictEqual(unchanged, undefined);
   });
 
-  test("builds and aligns sd-based rule parameters in one helper", () => {
+  test("builds and aligns sd-based schedule-rule parameters in one helper", () => {
     const { jobnet } = parseJobnets();
 
-    const aligned = buildSdAlignedParameters(
+    const aligned = buildSdAlignedScheduleParameters(
       resolveParameterArray({
         unit: jobnet,
         parameter: "wc",
@@ -298,7 +298,7 @@ suite("Parameter helpers", () => {
     assert.deepStrictEqual(inheritedCloseDates, ["mo"]);
   });
 
-  test("builds root-jobnet-aware scalars and root-default-aware rule arrays", () => {
+  test("builds root-jobnet-aware scalars and root-default-aware schedule-rule arrays", () => {
     const rootJobnet = parseRootDefaultJobnet();
     const { subnet } = parseJobnets();
 
@@ -324,7 +324,7 @@ suite("Parameter helpers", () => {
     );
     assert.strictEqual(inheritedRg, "3");
 
-    const rootSd = buildRootDefaultAwareRuleParameters(
+    const rootSd = buildRootDefaultAwareScheduleRuleParameters(
       {
         unit: rootJobnet,
         parameter: "sd",
@@ -464,10 +464,10 @@ suite("Parameter helpers", () => {
     assert.strictEqual(missingNcex, undefined);
   });
 
-  test("builds sd-aligned empty-rule parameters with synthesized rule placeholders", () => {
+  test("builds sd-aligned empty schedule-rule parameters with synthesized rule placeholders", () => {
     const { jobnet } = parseJobnets();
 
-    const alignedEy = buildSdAlignedEmptyRuleParameters(
+    const alignedEy = buildSdAlignedEmptyScheduleRuleParameters(
       {
         unit: jobnet,
         parameter: "ey",
@@ -487,10 +487,10 @@ suite("Parameter helpers", () => {
     );
   });
 
-  test("builds sd-aligned default-rule parameters with synthesized defaults", () => {
+  test("builds sd-aligned default schedule-rule parameters with synthesized defaults", () => {
     const { jobnet } = parseJobnets();
 
-    const alignedWc = buildSdAlignedDefaultRuleParameters(
+    const alignedWc = buildSdAlignedDefaultScheduleRuleParameters(
       {
         unit: jobnet,
         parameter: "wc",
@@ -573,10 +573,10 @@ suite("Parameter helpers", () => {
     );
   });
 
-  test("builds sorted rule parameters for simple rule arrays", () => {
+  test("builds sorted schedule-rule parameters for simple rule arrays", () => {
     const { jobnet } = parseJobnets();
 
-    const sortedLn = buildSortedRuleParameters(
+    const sortedLn = buildSortedScheduleRuleParameters(
       [
         {
           unit: jobnet,


### PR DESCRIPTION
## Summary
- rename the internal rule parameter family to use ScheduleRule terminology
- update helper and builder names to match the schedule-rule concept without changing ParamFactory
- sync decompose-parameter-factory specs, plans, and task tracking

## Testing
- npm run qlty
- npm test
- npm run test:web
- npm run build