### PR TITLE
Plan buildUnitListView decomposition

### DIFF
--- a/docs/specs/features/build-unit-list-view/TASKS.md
+++ b/docs/specs/features/build-unit-list-view/TASKS.md
@@ -38,3 +38,6 @@
   can be extracted independently from `buildUnitListView.ts` without changing
   the `UnitListRowView` contract, so future complexity-reduction slices should
   prefer helper extraction over another broad rewrite.
+- 2026-04-12: follow-up decomposition work is now tracked in
+  `docs/specs/features/decompose-build-unit-list-view/` so the delivered
+  use-case docs stay separate from behavior-preserving refactor planning.

--- a/docs/specs/features/decompose-build-unit-list-view/PLANS.md
+++ b/docs/specs/features/decompose-build-unit-list-view/PLANS.md
@@ -1,0 +1,71 @@
+# PLANS: decompose-build-unit-list-view
+
+## Objective
+
+Make `buildUnitListView.ts` reviewable and lower-risk by decomposing its row
+projection logic into focused application helpers while preserving behavior.
+
+## Scope
+
+- `src/application/unit-list/buildUnitListView.ts`
+- new helper modules under `src/application/unit-list/`
+- focused regression tests for extracted projection families
+- sync updates to `docs/specs/plans.md` and, if priorities change,
+  `docs/specs/roadmap.md`
+
+## Risks To Control
+
+- Silent drift in `UnitListRowView` field values or optionality
+- Regressions in inherited priority behavior for jobnet and job rows
+- Regressions in schedule-oriented array shaping for `group10`
+- Over-extraction that only moves parameter lookups without clarifying
+  projection ownership
+
+## Slice Strategy
+
+1. Document the decomposition boundary and slice order
+2. Extract one projection family at a time behind the existing
+   `buildUnitListView(...)` entry point
+3. Add or update focused tests for that family
+4. Run the full serial validation baseline for code slices
+5. Re-sync feature `TASKS.md`, branch `plans.md`, and `roadmap.md`
+
+## Current Status
+
+- 2026-04-12: `buildUnitListView.ts` is about 617 lines and still combines
+  row traversal, linked-unit projection, calendar shaping, priority lookup,
+  schedule parsing, and direct group DTO assembly in one function.
+- 2026-04-12: existing feature docs for `build-unit-list-view` describe the
+  delivered use case, but they do not yet track decomposition slices or
+  extraction-specific risks.
+- 2026-04-12: existing tests already cover a broad end-to-end row projection,
+  which is a stable baseline for behavior-preserving extraction.
+
+## Proposed Slice Order
+
+1. Calendar projection helper extraction
+   Status: proposed
+   Notes: `group6` already depends on dedicated helper parsing and has a small
+   isolated DTO surface.
+2. Priority projection helper extraction
+   Status: proposed
+   Notes: `group7` and `group11` share the caching and inheritance behavior,
+   so one focused helper can narrow the remaining branching in the main file.
+3. Schedule projection helper extraction
+   Status: proposed
+   Notes: `group10` is the densest projection family and should move only
+   after the lighter extractions establish the pattern.
+4. Shared row context and linked-unit projection extraction
+   Status: proposed
+   Notes: the `previousUnits`/`nextUnits` logic is self-contained but touches
+   relation traversal, so it should follow once the helper layout is settled.
+5. Remaining direct group projections
+   Status: proposed
+   Notes: keep these grouped by DTO concern; avoid one-file-per-group if that
+   would create mechanical sprawl without clarifying ownership.
+
+## Validation
+
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/decompose-build-unit-list-view/SPECS.md
+++ b/docs/specs/features/decompose-build-unit-list-view/SPECS.md
@@ -1,0 +1,51 @@
+# SPECS: decompose-build-unit-list-view
+
+## Purpose
+
+Reduce the structural risk of
+`src/application/unit-list/buildUnitListView.ts` without changing
+`UnitListRowView` behavior.
+
+## Origin
+
+This is a behavior-preserving refactor slice under the existing
+`build-unit-list-view` feature, not a new end-user use case.
+
+## Acceptance Criteria
+
+- `buildUnitListView(document)` returns the same `UnitListRowView[]`
+  shape and values for existing desktop and web extension consumers.
+- Table rendering and CSV export can keep consuming the current row/group DTO
+  contract without call-site changes.
+- Refactoring proceeds in small slices that keep tests readable and localized.
+- Extracted helpers stay in the application layer and do not introduce
+  `vscode` dependencies or parser-internal coupling.
+- Existing schedule-oriented table shaping may remain presentation-facing;
+  this slice does not force those semantics into domain normalization.
+
+## Implementation Notes
+
+- Prefer extracting coherent projection helpers over moving fields by
+  arbitrary line count.
+- Keep `buildUnitListView.ts` as the stable entry point while moving
+  internal projection logic into focused modules.
+- Start with the areas already identified as safe extractions:
+  calendar projection, priority projection, and schedule projection.
+- Preserve the current `UnitListRowView` group numbering and property names.
+- Avoid combining this refactor with new table features, CSV behavior changes,
+  or normalized model redesign.
+
+## Candidate Projection Families
+
+1. Row-level shared context and linked-unit projection
+2. Calendar projection for `group6`
+3. Priority projection for `group7` and `group11`
+4. Schedule projection for `group10`
+5. Remaining group projection families grouped by stable DTO concern
+
+## Initial Non-Goals
+
+- Redesigning `UnitListRowView` or table column groups
+- Moving schedule value parsing into domain normalization
+- Introducing a new application use case for filtering/search
+- Changing VS Code compatibility requirements

--- a/docs/specs/features/decompose-build-unit-list-view/TASKS.md
+++ b/docs/specs/features/decompose-build-unit-list-view/TASKS.md
@@ -1,0 +1,35 @@
+# TASKS: decompose-build-unit-list-view
+
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
+## Completed
+
+- [x] Define the feature boundary and decomposition goal before code changes
+- [x] Identify initial projection families and a low-risk extraction order
+
+## Planned Slices
+
+- [ ] Extract `group6` calendar projection into a focused helper module
+- [ ] Extract shared priority projection for `group7` and `group11`
+- [ ] Extract `group10` schedule projection into a focused helper module
+- [ ] Revisit whether linked-unit projection should become its own helper
+      family or stay near the main row builder after the first extractions
+- [ ] Decide whether the end state should keep one coordinator file or
+      collapse to direct helper composition from a smaller entry module
+
+## Notes
+
+- 2026-04-12: `buildUnitListView.ts` is still one of the larger handwritten
+  application files and now acts as both traversal coordinator and group DTO
+  projection hub.
+- 2026-04-12: the safest first slices are the families that already have
+  concentrated tests or helper dependencies, especially `group6`, `group7`,
+  `group11`, and `group10`.
+- 2026-04-12: this decomposition must keep the current `UnitListRowView`
+  contract stable so table rendering and CSV export do not need follow-up
+  rewiring in the same slice.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -172,23 +172,23 @@ Use-case note:
 
 ## Task Template
 
-### Task
+### Template Task
 
 <!-- A single sentence describing what will be changed. -->
 
-### Why
+### Template Why
 
 <!-- Why this change is necessary. -->
 
-### Scope
+### Template Scope
 
 <!-- Target files, modules, or use cases for the change. -->
 
-### Non-Goals
+### Template Non-Goals
 
 <!-- What is out of scope for this task. -->
 
-### Constraints
+### Template Constraints
 
 - Keep `engines.vscode` compatibility unless explicitly approved.
 - Keep desktop and web extension behavior intact.
@@ -210,25 +210,25 @@ Use-case note:
   `docs/specs/roadmap.md` as sync targets that should be updated at the time a
   task outcome becomes known, not in a later cleanup pass.
 
-### Design
+### Template Design
 
-#### Use case
+#### Template use case
 
 <!-- Which use case(s) will be addressed. -->
 
-#### Layers affected
+#### Template layers affected
 
 - domain:
 - application:
 - infrastructure:
 - presentation:
 
-#### Key decisions
+#### Template key decisions
 
 -
 -
 
-### Acceptance Criteria
+### Template Acceptance Criteria
 
 - [ ] build passes
 - [ ] quality/lint passes
@@ -240,17 +240,17 @@ Use-case note:
 - [ ] desktop behavior preserved
 - [ ] web behavior preserved if affected
 
-### Test Plan
+### Template Test Plan
 
 -
 -
 
-### Risks
+### Template Risks
 
 -
 -
 
-### Rollback Plan
+### Template Rollback Plan
 
 -
 -

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -257,31 +257,31 @@ Use-case note:
 
 ## Current Task
 
-### Task
+### Current Slice
 
 Define a dedicated decomposition feature for `buildUnitListView.ts` and fix
 the initial extraction order before runtime code changes begin.
 
-### Why
+### Current Need
 
 The branch priorities already identify `buildUnitListView.ts` as the next
 complexity hotspot, but the repository does not yet have feature-local docs
 that separate decomposition work from the already-delivered
 `build-unit-list-view` use case.
 
-### Scope
+### Current Scope
 
 - create `docs/specs/features/decompose-build-unit-list-view/`
 - define decomposition-specific scope, risks, and slice order
 - sync branch-level planning with the new dedicated feature
 
-### Non-Goals
+### Current Non-Goals
 
 - changing runtime behavior in `buildUnitListView.ts`
 - redesigning `UnitListRowView` or table column group contracts
 - combining this planning slice with helper extraction implementation
 
-### Constraints
+### Current Constraints
 
 - Keep `engines.vscode` compatibility unless explicitly approved.
 - Keep desktop and web extension behavior intact.
@@ -289,45 +289,45 @@ that separate decomposition work from the already-delivered
 - Start implementation from a dedicated git branch, not directly on `main`.
 - Docs-only changes may validate with `npm run lint:md`.
 
-### Design
+### Current Design
 
-#### Use case
+#### Current use case
 
 Behavior-preserving follow-up to the existing `build-unit-list-view` feature.
 
-#### Layers affected
+#### Current layers affected
 
 - domain: no
 - application: planning only
 - infrastructure: no
 - presentation: no
 
-#### Key decisions
+#### Current key decisions
 
 - Track `buildUnitListView.ts` decomposition as its own feature so extraction
   slices do not blur with the original use-case delivery docs.
 - Start with calendar, priority, and schedule projection families because
   they already read as coherent seams in code and tests.
 
-### Acceptance Criteria
+### Current Acceptance Criteria
 
 - [ ] dedicated feature docs exist for `buildUnitListView.ts` decomposition
 - [ ] branch-level plan points at the new feature instead of stale follow-ups
 - [ ] the first extraction candidates and non-goals are explicit
 - [ ] docs-only validation passes
 
-### Test Plan
+### Current Test Plan
 
 - Run `npm run lint:md`
 
-### Risks
+### Current Risks
 
 - Creating docs that are too abstract to drive a small first implementation
   slice
 - Choosing a slice order that hides relation traversal or priority-caching
   risks until too late
 
-### Rollback Plan
+### Current Rollback Plan
 
 - Remove the new feature docs and restore `docs/specs/plans.md` to its prior
   planning state.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -69,6 +69,10 @@ structure in `docs/specs/features/<feature>/`.
   automated tests cover table and flow dialog-open triggers plus the shared
   normalized DTO mapping, so that feature no longer depends on a separate
   manual smoke note.
+- ParameterFactory decomposition follow-ups are closed:
+  inherited-builder shape alignment and schedule-rule naming cleanup were
+  completed in focused slices, so no immediate ParameterFactory follow-up
+  remains on this branch priority list.
 
 ### How To Maintain This Section
 
@@ -92,15 +96,10 @@ structure in `docs/specs/features/<feature>/`.
 3. Reduce `buildUnitListView.ts` incrementally:
    extract calendar, priority, and schedule parsing helpers into focused
    modules while preserving the existing `UnitListRowView` contract and tests.
-4. The inherited-builder shape and schedule-rule naming follow-ups inside the
-   ParameterFactory decomposition are complete.
-   Keep any future terminology cleanup as one focused pass across `sd`, `st`,
-   `sy`, `ey`, `ln`, `cy`, `sh`, `shd`, `wt`, `wc`, and `cftd` instead of
-   piecemeal renames.
-5. Keep feature follow-up verification evidence concrete:
+4. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-6. Revisit a dedicated filter/search use case only if a second non-table
+5. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 
 ## Wrapper Semantics Matrix
@@ -258,154 +257,77 @@ Use-case note:
 
 ## Current Task
 
-### Current Slice
+### Task
 
-Align the internal `ParameterFactory` rule family with `schedule rule`
-terminology without changing parameter behavior or the `ParamFactory` facade.
+Define a dedicated decomposition feature for `buildUnitListView.ts` and fix
+the initial extraction order before runtime code changes begin.
 
-### Current Need
+### Why
 
-The decomposition work already isolated this family, but the remaining
-`Rule.ts` naming obscures that these parameters are organized around
-schedule-rule-bearing behavior rather than a generic rule concept.
+The branch priorities already identify `buildUnitListView.ts` as the next
+complexity hotspot, but the repository does not yet have feature-local docs
+that separate decomposition work from the already-delivered
+`build-unit-list-view` use case.
 
-### Current Scope
+### Scope
 
-- `src/domain/models/parameters/ScheduleRule.ts` and dependent parameter modules
-- schedule-rule helper and builder naming under
-  `src/domain/models/parameters/`
-- regression-test wording and feature-plan synchronization
+- create `docs/specs/features/decompose-build-unit-list-view/`
+- define decomposition-specific scope, risks, and slice order
+- sync branch-level planning with the new dedicated feature
 
-### Current Non-Goals
+### Non-Goals
 
-- changing JP1/AJS parsing behavior or default semantics
-- changing `ParamFactory` call sites or public import paths
-- moving parameter ownership outside the current domain layer
+- changing runtime behavior in `buildUnitListView.ts`
+- redesigning `UnitListRowView` or table column group contracts
+- combining this planning slice with helper extraction implementation
 
-### Current Constraints
+### Constraints
 
 - Keep `engines.vscode` compatibility unless explicitly approved.
 - Keep desktop and web extension behavior intact.
 - Avoid direct `vscode` dependency in domain.
 - Start implementation from a dedicated git branch, not directly on `main`.
-- Do not `git push` until `npm run qlty`, `npm test`, `npm run test:web`,
-  and `npm run build` have all passed locally in that order for code changes.
+- Docs-only changes may validate with `npm run lint:md`.
 
-### Current Design
+### Design
 
-#### Current use case
+#### Use case
 
-Behavior-preserving follow-up to the `decompose-parameter-factory` feature.
+Behavior-preserving follow-up to the existing `build-unit-list-view` feature.
 
-#### Current layers affected
+#### Layers affected
 
-- domain: yes
-- application: no
+- domain: no
+- application: planning only
 - infrastructure: no
 - presentation: no
 
-#### Current key decisions
+#### Key decisions
 
-- Keep `ParamFactory` as the stable public facade and rename only the internal
-  schedule-rule family surface.
-- Rename the file, shared interface, and helper/builder identifiers together
-  so terminology changes land in one coherent slice.
+- Track `buildUnitListView.ts` decomposition as its own feature so extraction
+  slices do not blur with the original use-case delivery docs.
+- Start with calendar, priority, and schedule projection families because
+  they already read as coherent seams in code and tests.
 
-### Current Acceptance Criteria
+### Acceptance Criteria
 
-- [ ] build passes
-- [ ] quality/lint passes
-- [ ] tests updated
-- [ ] desktop behavior preserved
-- [ ] web behavior preserved if affected
+- [ ] dedicated feature docs exist for `buildUnitListView.ts` decomposition
+- [ ] branch-level plan points at the new feature instead of stale follow-ups
+- [ ] the first extraction candidates and non-goals are explicit
+- [ ] docs-only validation passes
 
-### Current Test Plan
+### Test Plan
 
-- Run `npm run qlty`
-- Run `npm test`
-- Run `npm run test:web`
-- Run `npm run build`
+- Run `npm run lint:md`
 
-### Current Risks
+### Risks
 
-- Missing a remaining `ScheduleRule` import and breaking type exports.
-- Renaming helper APIs without preserving existing behavior for schedule-rule
-  sorting, alignment, or defaults.
+- Creating docs that are too abstract to drive a small first implementation
+  slice
+- Choosing a slice order that hides relation traversal or priority-caching
+  risks until too late
 
-### Current Rollback Plan
+### Rollback Plan
 
-- Restore the previous file and identifier names while keeping the extracted
-  builder modules intact.
-
-### Task: Decide unit-list filtering boundary
-
-Decide whether unit-list filtering/search should move into a dedicated
-application use case or remain in presentation.
-
-### Why: Architectural decision closure
-
-The build-unit-list task list still carried an open architectural decision.
-That decision should be closed explicitly, because leaving it open suggests
-there is unresolved shared business logic when the current implementation is
-still table-specific presentation behavior.
-
-### Scope: Review and decide filtering boundary
-
-- review the current filtering/search implementation and its dependencies
-- decide whether the behavior is reusable application logic or
-  table-specific presentation logic
-- update build-unit-list tasks with the decision and rationale
-- sync branch-level planning docs after closing the follow-up
-
-### Non-Goals: Avoid premature extraction
-
-- changing table filtering behavior
-- introducing a new application use case without a second consumer
-- rewriting current UI-specific matching rules into fake domain logic
-
-### Constraints: Keep behavior unchanged
-
-- Keep desktop and web extension behavior unchanged.
-- Keep the slice docs-only.
-- Treat TanStack row access and fuzzy matching over rendered values as
-  presentation concerns unless another consumer proves otherwise.
-
-### Design: Boundary decision
-
-#### Use case: Build-unit-list boundary decision
-
-#### Layers affected: Docs sync
-
-- docs/specs/features: build-unit-list task sync
-- docs/specs: branch-level planning sync
-
-#### Key decisions: Keep in presentation
-
-- Keep filtering/search in presentation while it still depends on
-  table-library row access and presentation column values.
-- Extract an application use case only when matching semantics become shared
-  across multiple non-presentation consumers.
-
-### Acceptance Criteria: Docs updated
-
-- [x] `docs/specs/features/build-unit-list/TASKS.md` reflects the boundary
-      decision and rationale
-- [x] branch-level priorities no longer treat this decision as unresolved
-- [x] roadmap wording reflects that a dedicated filter/search use case is
-      deferred until another consumer appears
-
-### Test Plan: Lint check
-
-- run `npm run lint:md`
-
-### Risks: Mislabeling concerns
-
-- a presentation-specific concern could be mislabeled as reusable business
-  logic
-- the deferred note could be lost if roadmap and feature tasks drift apart
-
-### Rollback Plan: Reopen if needed
-
-- reopen the build-unit-list follow-up if a second consumer later needs the
-  same matching semantics
-- keep any future filter/search extraction as a separate code slice
+- Remove the new feature docs and restore `docs/specs/plans.md` to its prior
+  planning state.


### PR DESCRIPTION
## Summary
- add dedicated feature docs for buildUnitListView decomposition
- update branch-level plans to point at the new decomposition feature
- clean up the stale completed ParameterFactory follow-up from next priorities

## Testing
- npm run lint:md