### PR TITLE
Extract group6 unit-list projection helper

### DIFF
--- a/docs/specs/features/decompose-build-unit-list-view/PLANS.md
+++ b/docs/specs/features/decompose-build-unit-list-view/PLANS.md
@@ -40,13 +40,16 @@ projection logic into focused application helpers while preserving behavior.
   extraction-specific risks.
 - 2026-04-12: existing tests already cover a broad end-to-end row projection,
   which is a stable baseline for behavior-preserving extraction.
+- 2026-04-12: the first extraction slice is now `group6`; it is small,
+  DTO-shaped, and already anchored in existing helper behavior for calendar
+  weekday parsing.
 
 ## Proposed Slice Order
 
 1. Calendar projection helper extraction
-   Status: proposed
-   Notes: `group6` already depends on dedicated helper parsing and has a small
-   isolated DTO surface.
+   Status: completed
+   Notes: `group6` now builds through a dedicated helper module while keeping
+   the `UnitListRowView` shape unchanged for table and CSV consumers.
 2. Priority projection helper extraction
    Status: proposed
    Notes: `group7` and `group11` share the caching and inheritance behavior,

--- a/docs/specs/features/decompose-build-unit-list-view/TASKS.md
+++ b/docs/specs/features/decompose-build-unit-list-view/TASKS.md
@@ -14,7 +14,7 @@
 
 ## Planned Slices
 
-- [ ] Extract `group6` calendar projection into a focused helper module
+- [x] Extract `group6` calendar projection into a focused helper module
 - [ ] Extract shared priority projection for `group7` and `group11`
 - [ ] Extract `group10` schedule projection into a focused helper module
 - [ ] Revisit whether linked-unit projection should become its own helper
@@ -33,3 +33,6 @@
 - 2026-04-12: this decomposition must keep the current `UnitListRowView`
   contract stable so table rendering and CSV export do not need follow-up
   rewiring in the same slice.
+- 2026-04-12: `group6` calendar projection now lives in
+  `src/application/unit-list/buildUnitListGroup6View.ts`, with focused
+  regression coverage in `src/test/suite/buildUnitListGroup6View.test.ts`.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -259,27 +259,28 @@ Use-case note:
 
 ### Current Slice
 
-Define a dedicated decomposition feature for `buildUnitListView.ts` and fix
-the initial extraction order before runtime code changes begin.
+Extract `group6` calendar projection from `buildUnitListView.ts` into a
+focused helper module without changing the `UnitListRowView` contract.
 
 ### Current Need
 
 The branch priorities already identify `buildUnitListView.ts` as the next
-complexity hotspot, but the repository does not yet have feature-local docs
-that separate decomposition work from the already-delivered
-`build-unit-list-view` use case.
+complexity hotspot, and the dedicated decomposition feature now exists. The
+next step is to prove the extraction pattern on the smallest coherent
+projection family before moving on to priority and schedule logic.
 
 ### Current Scope
 
-- create `docs/specs/features/decompose-build-unit-list-view/`
-- define decomposition-specific scope, risks, and slice order
-- sync branch-level planning with the new dedicated feature
+- extract `group6` calendar projection behind the existing
+  `buildUnitListView(...)` entry point
+- add focused regression coverage for the extracted helper
+- sync feature-local and branch-level planning docs with the completed slice
 
 ### Current Non-Goals
 
-- changing runtime behavior in `buildUnitListView.ts`
+- changing runtime behavior outside `group6` extraction
 - redesigning `UnitListRowView` or table column group contracts
-- combining this planning slice with helper extraction implementation
+- mixing the priority or schedule extraction slices into this change
 
 ### Current Constraints
 
@@ -287,7 +288,8 @@ that separate decomposition work from the already-delivered
 - Keep desktop and web extension behavior intact.
 - Avoid direct `vscode` dependency in domain.
 - Start implementation from a dedicated git branch, not directly on `main`.
-- Docs-only changes may validate with `npm run lint:md`.
+- Code changes must validate with the serial baseline:
+  `npm run qlty`, `npm test`, `npm run test:web`, `npm run build`.
 
 ### Current Design
 
@@ -298,36 +300,38 @@ Behavior-preserving follow-up to the existing `build-unit-list-view` feature.
 #### Current layers affected
 
 - domain: no
-- application: planning only
+- application: `buildUnitListView.ts` and extracted helper module
 - infrastructure: no
-- presentation: no
+- presentation: no contract changes expected
 
 #### Current key decisions
 
-- Track `buildUnitListView.ts` decomposition as its own feature so extraction
-  slices do not blur with the original use-case delivery docs.
-- Start with calendar, priority, and schedule projection families because
-  they already read as coherent seams in code and tests.
+- Keep `buildUnitListView(...)` as the stable entry point while moving one
+  projection family at a time behind helper modules.
+- Use `group6` as the proving slice because its weekday and date shaping is
+  self-contained and already backed by broad row-view assertions.
 
 ### Current Acceptance Criteria
 
-- [ ] dedicated feature docs exist for `buildUnitListView.ts` decomposition
-- [ ] branch-level plan points at the new feature instead of stale follow-ups
-- [ ] the first extraction candidates and non-goals are explicit
-- [ ] docs-only validation passes
+- [ ] `group6` projection builds through a focused helper module
+- [ ] `buildUnitListView(...)` keeps the current `UnitListRowView` shape
+- [ ] focused regression coverage exists for the extracted helper
+- [ ] `npm run qlty`, `npm test`, `npm run test:web`, and `npm run build` pass
 
 ### Current Test Plan
 
-- Run `npm run lint:md`
+- Run `npm run qlty`
+- Run `npm test`
+- Run `npm run test:web`
+- Run `npm run build`
 
 ### Current Risks
 
-- Creating docs that are too abstract to drive a small first implementation
-  slice
-- Choosing a slice order that hides relation traversal or priority-caching
-  risks until too late
+- Accidentally changing non-group unit output by over-typing the helper return
+- Extracting only call sites without actually reducing branching in the main
+  row builder
 
 ### Current Rollback Plan
 
-- Remove the new feature docs and restore `docs/specs/plans.md` to its prior
-  planning state.
+- Inline the helper body back into `buildUnitListView.ts` and remove the
+  focused helper test if the extraction adds churn without reducing risk.

--- a/src/application/unit-list/buildUnitListGroup6View.ts
+++ b/src/application/unit-list/buildUnitListGroup6View.ts
@@ -1,0 +1,27 @@
+import {
+  AjsUnit,
+  findAjsUnitParameterValues,
+} from "../../domain/models/ajs/AjsDocument";
+import type { UnitListGroup6View } from "./buildUnitListView";
+import {
+  buildCalendarWeekView,
+  isNonWeekCalendarValue,
+} from "./unitListViewHelpers";
+
+export const buildUnitListGroup6View = (unit: AjsUnit): UnitListGroup6View => {
+  if (unit.unitType !== "g") {
+    return {
+      openDates: [],
+      closeDates: [],
+    };
+  }
+
+  const openValues = findAjsUnitParameterValues(unit, "op");
+  const closeValues = findAjsUnitParameterValues(unit, "cl");
+
+  return {
+    ...buildCalendarWeekView(openValues, closeValues),
+    openDates: openValues.filter(isNonWeekCalendarValue),
+    closeDates: closeValues.filter(isNonWeekCalendarValue),
+  };
+};

--- a/src/application/unit-list/buildUnitListView.ts
+++ b/src/application/unit-list/buildUnitListView.ts
@@ -9,10 +9,9 @@ import {
   findParentAjsUnit,
   flattenAjsUnits,
 } from "../../domain/models/ajs/AjsDocument";
+import { buildUnitListGroup6View } from "./buildUnitListGroup6View";
 import {
-  buildCalendarWeekView,
   getPriorityForUnitTypes,
-  isNonWeekCalendarValue,
   parseCftd,
   parseCy,
   parseLnParentRule,
@@ -368,24 +367,7 @@ export const buildUnitListView = (document: AjsDocument): UnitListRowView[] => {
             : undefined,
         jobGroupType: unit.unitType === "g" ? unit.groupType : undefined,
       },
-      group6:
-        unit.unitType === "g"
-          ? {
-              ...buildCalendarWeekView(
-                findAjsUnitParameterValues(unit, "op"),
-                findAjsUnitParameterValues(unit, "cl"),
-              ),
-              openDates: findAjsUnitParameterValues(unit, "op").filter(
-                isNonWeekCalendarValue,
-              ),
-              closeDates: findAjsUnitParameterValues(unit, "cl").filter(
-                isNonWeekCalendarValue,
-              ),
-            }
-          : {
-              openDates: [],
-              closeDates: [],
-            },
+      group6: buildUnitListGroup6View(unit),
       group7: {
         concurrentExecution:
           unit.unitType === "n" ||

--- a/src/test/suite/buildUnitListGroup6View.test.ts
+++ b/src/test/suite/buildUnitListGroup6View.test.ts
@@ -1,0 +1,52 @@
+import * as assert from "assert";
+import { parseAjs } from "../../domain/services/parser/AjsParser";
+import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
+import { buildUnitListGroup6View } from "../../application/unit-list/buildUnitListGroup6View";
+
+const definition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  op=mo:1;
+  op=2024/01/01;
+  cl=tu:2;
+  cl=2024/01/02;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+  }
+}
+`;
+
+suite("Build Unit List Group 6 View", () => {
+  test("projects calendar week flags and non-week dates for group units", () => {
+    const result = parseAjs(definition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const root = document.rootUnits[0];
+
+    const view = buildUnitListGroup6View(root);
+
+    assert.strictEqual(view.mo, true);
+    assert.strictEqual(view.tu, false);
+    assert.strictEqual(view.we, undefined);
+    assert.deepStrictEqual(view.openDates, ["2024/01/01"]);
+    assert.deepStrictEqual(view.closeDates, ["2024/01/02"]);
+  });
+
+  test("returns empty date arrays for non-group units", () => {
+    const result = parseAjs(definition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const jobnet = document.rootUnits[0]?.children[0];
+
+    assert.ok(jobnet);
+
+    const view = buildUnitListGroup6View(jobnet);
+
+    assert.deepStrictEqual(view.openDates, []);
+    assert.deepStrictEqual(view.closeDates, []);
+    assert.strictEqual(view.mo, undefined);
+    assert.strictEqual(view.tu, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- extract the group6 calendar projection from buildUnitListView into a focused helper
- add focused regression coverage for the extracted helper
- update decomposition planning docs for the completed slice

## Validation
- npm run qlty
- npm test
- npm run test:web
- npm run build