### PR TITLE
Extract shared priority projections for group7 and group11

### DIFF
--- a/docs/specs/features/decompose-build-unit-list-view/PLANS.md
+++ b/docs/specs/features/decompose-build-unit-list-view/PLANS.md
@@ -51,9 +51,11 @@ projection logic into focused application helpers while preserving behavior.
    Notes: `group6` now builds through a dedicated helper module while keeping
    the `UnitListRowView` shape unchanged for table and CSV consumers.
 2. Priority projection helper extraction
-   Status: proposed
+   Status: completed
    Notes: `group7` and `group11` share the caching and inheritance behavior,
    so one focused helper can narrow the remaining branching in the main file.
+   `buildUnitListView.ts` now delegates these DTOs to
+   `buildUnitListPriorityViews.ts` with focused regression coverage.
 3. Schedule projection helper extraction
    Status: proposed
    Notes: `group10` is the densest projection family and should move only

--- a/docs/specs/features/decompose-build-unit-list-view/TASKS.md
+++ b/docs/specs/features/decompose-build-unit-list-view/TASKS.md
@@ -15,7 +15,7 @@
 ## Planned Slices
 
 - [x] Extract `group6` calendar projection into a focused helper module
-- [ ] Extract shared priority projection for `group7` and `group11`
+- [x] Extract shared priority projection for `group7` and `group11`
 - [ ] Extract `group10` schedule projection into a focused helper module
 - [ ] Revisit whether linked-unit projection should become its own helper
       family or stay near the main row builder after the first extractions
@@ -36,3 +36,6 @@
 - 2026-04-12: `group6` calendar projection now lives in
   `src/application/unit-list/buildUnitListGroup6View.ts`, with focused
   regression coverage in `src/test/suite/buildUnitListGroup6View.test.ts`.
+- 2026-04-13: shared priority projection for `group7` and `group11` now lives
+  in `src/application/unit-list/buildUnitListPriorityViews.ts`, with focused
+  regression coverage in `src/test/suite/buildUnitListPriorityViews.test.ts`.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -94,8 +94,9 @@ structure in `docs/specs/features/<feature>/`.
 2. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, or shared adapters change.
 3. Reduce `buildUnitListView.ts` incrementally:
-   extract calendar, priority, and schedule parsing helpers into focused
-   modules while preserving the existing `UnitListRowView` contract and tests.
+   calendar and priority projections now build through focused helpers;
+   continue with schedule extraction while preserving the existing
+   `UnitListRowView` contract and tests.
 4. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.

--- a/src/application/unit-list/buildUnitListPriorityViews.ts
+++ b/src/application/unit-list/buildUnitListPriorityViews.ts
@@ -1,0 +1,93 @@
+import {
+  AjsDocument,
+  AjsUnit,
+  AjsUnitType,
+  findAjsUnitParameterValue,
+} from "../../domain/models/ajs/AjsDocument";
+import type {
+  UnitListGroup11View,
+  UnitListGroup7View,
+} from "./buildUnitListView";
+import { getPriorityForUnitTypes } from "./unitListViewHelpers";
+
+const group7FieldUnitTypes: readonly AjsUnitType[] = ["n", "rn", "rm", "rr"];
+const group7PriorityUnitTypes: readonly AjsUnitType[] = ["n", "rn"];
+const group11PriorityUnitTypes: readonly AjsUnitType[] = [
+  "j",
+  "rj",
+  "pj",
+  "rp",
+  "qj",
+  "rq",
+];
+
+const supportsGroup7Fields = (unit: AjsUnit): boolean =>
+  group7FieldUnitTypes.includes(unit.unitType);
+
+export const buildUnitListGroup7View = (
+  document: AjsDocument,
+  unit: AjsUnit,
+  priorityById: Map<string, number>,
+): UnitListGroup7View => ({
+  concurrentExecution: supportsGroup7Fields(unit)
+    ? findAjsUnitParameterValue(unit, "mp")
+    : undefined,
+  retainedGenerationCount: supportsGroup7Fields(unit)
+    ? findAjsUnitParameterValue(unit, "rg")
+    : undefined,
+  targetManager: supportsGroup7Fields(unit)
+    ? findAjsUnitParameterValue(unit, "rh")
+    : undefined,
+  priority: getPriorityForUnitTypes(
+    document,
+    unit,
+    priorityById,
+    group7PriorityUnitTypes,
+  ),
+  timeoutPeriod: supportsGroup7Fields(unit)
+    ? findAjsUnitParameterValue(unit, "cd")
+    : undefined,
+  scheduleOption: supportsGroup7Fields(unit)
+    ? findAjsUnitParameterValue(unit, "ms")
+    : undefined,
+  requiredExecutionTime: supportsGroup7Fields(unit)
+    ? findAjsUnitParameterValue(unit, "fd")
+    : undefined,
+});
+
+export const buildUnitListGroup11View = (
+  document: AjsDocument,
+  unit: AjsUnit,
+  priorityById: Map<string, number>,
+): UnitListGroup11View => ({
+  commandText: findAjsUnitParameterValue(unit, "te"),
+  scriptFileName: findAjsUnitParameterValue(unit, "sc"),
+  parameters: findAjsUnitParameterValue(unit, "prm"),
+  environmentVariable: findAjsUnitParameterValue(unit, "env"),
+  environmentVariableFile: findAjsUnitParameterValue(unit, "ev"),
+  workPathName: findAjsUnitParameterValue(unit, "wkp"),
+  standardInputFile: findAjsUnitParameterValue(unit, "si"),
+  standardOutputFile: findAjsUnitParameterValue(unit, "so"),
+  standardOutputAction: findAjsUnitParameterValue(unit, "soa"),
+  standardErrorFile: findAjsUnitParameterValue(unit, "se"),
+  standardErrorAction: findAjsUnitParameterValue(unit, "sea"),
+  queueManager: findAjsUnitParameterValue(unit, "qm"),
+  queueName: findAjsUnitParameterValue(unit, "qu"),
+  requestJobName: findAjsUnitParameterValue(unit, "req"),
+  priority: getPriorityForUnitTypes(
+    document,
+    unit,
+    priorityById,
+    group11PriorityUnitTypes,
+  ),
+  endJudgment: findAjsUnitParameterValue(unit, "jd"),
+  waitThreshold: findAjsUnitParameterValue(unit, "wth"),
+  timeoutHold: findAjsUnitParameterValue(unit, "tho"),
+  judgmentFile: findAjsUnitParameterValue(unit, "jdf"),
+  automaticRetryEnabled: findAjsUnitParameterValue(unit, "abr"),
+  retryStart: findAjsUnitParameterValue(unit, "rjs"),
+  retryEnd: findAjsUnitParameterValue(unit, "rje"),
+  retryCount: findAjsUnitParameterValue(unit, "rec"),
+  retryInterval: findAjsUnitParameterValue(unit, "rei"),
+  targetUserName: findAjsUnitParameterValue(unit, "un"),
+});

--- a/src/application/unit-list/buildUnitListView.ts
+++ b/src/application/unit-list/buildUnitListView.ts
@@ -11,7 +11,10 @@ import {
 } from "../../domain/models/ajs/AjsDocument";
 import { buildUnitListGroup6View } from "./buildUnitListGroup6View";
 import {
-  getPriorityForUnitTypes,
+  buildUnitListGroup11View,
+  buildUnitListGroup7View,
+} from "./buildUnitListPriorityViews";
+import {
   parseCftd,
   parseCy,
   parseLnParentRule,
@@ -368,54 +371,7 @@ export const buildUnitListView = (document: AjsDocument): UnitListRowView[] => {
         jobGroupType: unit.unitType === "g" ? unit.groupType : undefined,
       },
       group6: buildUnitListGroup6View(unit),
-      group7: {
-        concurrentExecution:
-          unit.unitType === "n" ||
-          unit.unitType === "rn" ||
-          unit.unitType === "rm" ||
-          unit.unitType === "rr"
-            ? findAjsUnitParameterValue(unit, "mp")
-            : undefined,
-        retainedGenerationCount:
-          unit.unitType === "n" ||
-          unit.unitType === "rn" ||
-          unit.unitType === "rm" ||
-          unit.unitType === "rr"
-            ? findAjsUnitParameterValue(unit, "rg")
-            : undefined,
-        targetManager:
-          unit.unitType === "n" ||
-          unit.unitType === "rn" ||
-          unit.unitType === "rm" ||
-          unit.unitType === "rr"
-            ? findAjsUnitParameterValue(unit, "rh")
-            : undefined,
-        priority: getPriorityForUnitTypes(document, unit, group7PriorityById, [
-          "n",
-          "rn",
-        ]),
-        timeoutPeriod:
-          unit.unitType === "n" ||
-          unit.unitType === "rn" ||
-          unit.unitType === "rm" ||
-          unit.unitType === "rr"
-            ? findAjsUnitParameterValue(unit, "cd")
-            : undefined,
-        scheduleOption:
-          unit.unitType === "n" ||
-          unit.unitType === "rn" ||
-          unit.unitType === "rm" ||
-          unit.unitType === "rr"
-            ? findAjsUnitParameterValue(unit, "ms")
-            : undefined,
-        requiredExecutionTime:
-          unit.unitType === "n" ||
-          unit.unitType === "rn" ||
-          unit.unitType === "rm" ||
-          unit.unitType === "rr"
-            ? findAjsUnitParameterValue(unit, "fd")
-            : undefined,
-      },
+      group7: buildUnitListGroup7View(document, unit, group7PriorityById),
       group10: {
         deleteAfterExecution: findAjsUnitParameterValue(unit, "de"),
         executionDate: findAjsUnitParameterValue(unit, "ed"),
@@ -456,40 +412,7 @@ export const buildUnitListView = (document: AjsDocument): UnitListRowView[] => {
           parseTimeValue(value),
         ),
       },
-      group11: {
-        commandText: findAjsUnitParameterValue(unit, "te"),
-        scriptFileName: findAjsUnitParameterValue(unit, "sc"),
-        parameters: findAjsUnitParameterValue(unit, "prm"),
-        environmentVariable: findAjsUnitParameterValue(unit, "env"),
-        environmentVariableFile: findAjsUnitParameterValue(unit, "ev"),
-        workPathName: findAjsUnitParameterValue(unit, "wkp"),
-        standardInputFile: findAjsUnitParameterValue(unit, "si"),
-        standardOutputFile: findAjsUnitParameterValue(unit, "so"),
-        standardOutputAction: findAjsUnitParameterValue(unit, "soa"),
-        standardErrorFile: findAjsUnitParameterValue(unit, "se"),
-        standardErrorAction: findAjsUnitParameterValue(unit, "sea"),
-        queueManager: findAjsUnitParameterValue(unit, "qm"),
-        queueName: findAjsUnitParameterValue(unit, "qu"),
-        requestJobName: findAjsUnitParameterValue(unit, "req"),
-        priority: getPriorityForUnitTypes(document, unit, group11PriorityById, [
-          "j",
-          "rj",
-          "pj",
-          "rp",
-          "qj",
-          "rq",
-        ]),
-        endJudgment: findAjsUnitParameterValue(unit, "jd"),
-        waitThreshold: findAjsUnitParameterValue(unit, "wth"),
-        timeoutHold: findAjsUnitParameterValue(unit, "tho"),
-        judgmentFile: findAjsUnitParameterValue(unit, "jdf"),
-        automaticRetryEnabled: findAjsUnitParameterValue(unit, "abr"),
-        retryStart: findAjsUnitParameterValue(unit, "rjs"),
-        retryEnd: findAjsUnitParameterValue(unit, "rje"),
-        retryCount: findAjsUnitParameterValue(unit, "rec"),
-        retryInterval: findAjsUnitParameterValue(unit, "rei"),
-        targetUserName: findAjsUnitParameterValue(unit, "un"),
-      },
+      group11: buildUnitListGroup11View(document, unit, group11PriorityById),
       group12: {
         endJudgment: findAjsUnitParameterValue(unit, "ej"),
         judgmentReturnCode: findAjsUnitParameterValue(unit, "ejc"),

--- a/src/test/suite/buildUnitListPriorityViews.test.ts
+++ b/src/test/suite/buildUnitListPriorityViews.test.ts
@@ -1,0 +1,131 @@
+import * as assert from "assert";
+import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
+import { parseAjs } from "../../domain/services/parser/AjsParser";
+import {
+  buildUnitListGroup11View,
+  buildUnitListGroup7View,
+} from "../../application/unit-list/buildUnitListPriorityViews";
+
+const definition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    mp=y;
+    rg=3;
+    rh="manager-a";
+    pr=4;
+    cd=10;
+    ms=sch;
+    fd=30;
+    unit=subnet,,jp1admin,;
+    {
+      ty=n;
+    }
+    unit=job,,jp1admin,;
+    {
+      ty=rj;
+      te="run.sh";
+      sc="script.ksh";
+      prm=--job;
+      env="ENV=1";
+      ev="envfile.env";
+      wkp="/tmp";
+      si="stdin.txt";
+      so="stdout.txt";
+      soa=add;
+      se="stderr.txt";
+      sea=new;
+      jd=nm;
+      wth=20;
+      tho=5;
+      jdf="judge.txt";
+      abr=y;
+      rjs=1;
+      rje=9;
+      rec=3;
+      rei=60;
+      un=target-user;
+    }
+    unit=qjob,,jp1admin,;
+    {
+      ty=qj;
+      qm=queue-manager;
+      qu=queue-name;
+      req=request-job;
+      ni=0;
+    }
+  }
+}
+`;
+
+suite("Build Unit List Priority Views", () => {
+  test("projects group7 fields and inherits priority for child jobnets", () => {
+    const result = parseAjs(definition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const jobnet = document.rootUnits[0]?.children[0];
+    const subnet = jobnet?.children[0];
+
+    assert.ok(jobnet);
+    assert.ok(subnet);
+
+    const priorityById = new Map<string, number>();
+    const jobnetView = buildUnitListGroup7View(document, jobnet, priorityById);
+    const subnetView = buildUnitListGroup7View(document, subnet, priorityById);
+
+    assert.strictEqual(jobnetView.concurrentExecution, "y");
+    assert.strictEqual(jobnetView.retainedGenerationCount, "3");
+    assert.strictEqual(jobnetView.targetManager, '"manager-a"');
+    assert.strictEqual(jobnetView.priority, 4);
+    assert.strictEqual(jobnetView.timeoutPeriod, "10");
+    assert.strictEqual(jobnetView.scheduleOption, "sch");
+    assert.strictEqual(jobnetView.requiredExecutionTime, "30");
+    assert.strictEqual(subnetView.priority, 4);
+  });
+
+  test("projects group11 fields and reuses shared priority lookup", () => {
+    const result = parseAjs(definition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const jobnet = document.rootUnits[0]?.children[0];
+    const job = jobnet?.children[1];
+    const qjob = jobnet?.children[2];
+
+    assert.ok(job);
+    assert.ok(qjob);
+
+    const priorityById = new Map<string, number>();
+    const jobView = buildUnitListGroup11View(document, job, priorityById);
+    const qjobView = buildUnitListGroup11View(document, qjob, priorityById);
+
+    assert.strictEqual(jobView.commandText, '"run.sh"');
+    assert.strictEqual(jobView.scriptFileName, '"script.ksh"');
+    assert.strictEqual(jobView.parameters, "--job");
+    assert.strictEqual(jobView.environmentVariable, '"ENV=1"');
+    assert.strictEqual(jobView.environmentVariableFile, '"envfile.env"');
+    assert.strictEqual(jobView.workPathName, '"/tmp"');
+    assert.strictEqual(jobView.standardInputFile, '"stdin.txt"');
+    assert.strictEqual(jobView.standardOutputFile, '"stdout.txt"');
+    assert.strictEqual(jobView.standardOutputAction, "add");
+    assert.strictEqual(jobView.standardErrorFile, '"stderr.txt"');
+    assert.strictEqual(jobView.standardErrorAction, "new");
+    assert.strictEqual(jobView.priority, 4);
+    assert.strictEqual(jobView.endJudgment, "nm");
+    assert.strictEqual(jobView.waitThreshold, "20");
+    assert.strictEqual(jobView.timeoutHold, "5");
+    assert.strictEqual(jobView.judgmentFile, '"judge.txt"');
+    assert.strictEqual(jobView.automaticRetryEnabled, "y");
+    assert.strictEqual(jobView.retryStart, "1");
+    assert.strictEqual(jobView.retryEnd, "9");
+    assert.strictEqual(jobView.retryCount, "3");
+    assert.strictEqual(jobView.retryInterval, "60");
+    assert.strictEqual(jobView.targetUserName, "target-user");
+    assert.strictEqual(qjobView.queueManager, "queue-manager");
+    assert.strictEqual(qjobView.queueName, "queue-name");
+    assert.strictEqual(qjobView.requestJobName, "request-job");
+    assert.strictEqual(qjobView.priority, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- extract shared priority projection helpers for group7 and group11
- keep buildUnitListView as the stable coordinator while delegating those DTOs
- add focused regression tests and sync decomposition plans/tasks

## Validation
- npm run qlty
- npm run build
- npm test
- npm run test:web