### PR TITLE
Extract group10 schedule projection helper

### DIFF
--- a/docs/specs/features/decompose-build-unit-list-view/TASKS.md
+++ b/docs/specs/features/decompose-build-unit-list-view/TASKS.md
@@ -16,7 +16,7 @@
 
 - [x] Extract `group6` calendar projection into a focused helper module
 - [x] Extract shared priority projection for `group7` and `group11`
-- [ ] Extract `group10` schedule projection into a focused helper module
+- [x] Extract `group10` schedule projection into a focused helper module
 - [ ] Revisit whether linked-unit projection should become its own helper
       family or stay near the main row builder after the first extractions
 - [ ] Decide whether the end state should keep one coordinator file or

--- a/src/application/unit-list/buildUnitListGroup10View.ts
+++ b/src/application/unit-list/buildUnitListGroup10View.ts
@@ -1,0 +1,57 @@
+import {
+  AjsUnit,
+  findAjsUnitParameterValue,
+  findAjsUnitParameterValues,
+} from "../../domain/models/ajs/AjsDocument";
+import type { UnitListGroup10View } from "./buildUnitListView";
+import {
+  parseCftd,
+  parseCy,
+  parseLnParentRule,
+  parseSd,
+  parseSh,
+  parseShd,
+  parseTimeValue,
+  parseWc,
+} from "./unitListViewHelpers";
+
+export const buildUnitListGroup10View = (
+  unit: AjsUnit,
+): UnitListGroup10View => ({
+  deleteAfterExecution: findAjsUnitParameterValue(unit, "de"),
+  executionDate: findAjsUnitParameterValue(unit, "ed"),
+  jobGroupPath: findAjsUnitParameterValue(unit, "jc"),
+  exclusiveJobnetName: findAjsUnitParameterValue(unit, "ejn"),
+  parentRules: findAjsUnitParameterValues(unit, "ln").map(parseLnParentRule),
+  scheduleDateTypes: findAjsUnitParameterValues(unit, "sd").map(
+    (value) => parseSd(value).type,
+  ),
+  scheduleDateYearMonths: findAjsUnitParameterValues(unit, "sd").map(
+    (value) => parseSd(value).yearMonth,
+  ),
+  scheduleDateDays: findAjsUnitParameterValues(unit, "sd").map(
+    (value) => parseSd(value).day,
+  ),
+  startTimes: findAjsUnitParameterValues(unit, "st").map((value) =>
+    parseTimeValue(value, "+00:00"),
+  ),
+  cycles: findAjsUnitParameterValues(unit, "cy").map(parseCy),
+  substitutes: findAjsUnitParameterValues(unit, "sh").map(parseSh),
+  shiftDays: findAjsUnitParameterValues(unit, "shd").map(parseShd),
+  scheduleByDaysFromStart: findAjsUnitParameterValues(unit, "cftd").map(
+    (value) => parseCftd(value).scheduleByDaysFromStart,
+  ),
+  maxShiftableDays: findAjsUnitParameterValues(unit, "cftd").map(
+    (value) => parseCftd(value).maxShiftableDays,
+  ),
+  startRangeTimes: findAjsUnitParameterValues(unit, "sy").map((value) =>
+    parseTimeValue(value),
+  ),
+  endRangeTimes: findAjsUnitParameterValues(unit, "ey").map((value) =>
+    parseTimeValue(value),
+  ),
+  waitCounts: findAjsUnitParameterValues(unit, "wc").map(parseWc),
+  waitTimes: findAjsUnitParameterValues(unit, "wt").map((value) =>
+    parseTimeValue(value),
+  ),
+});

--- a/src/application/unit-list/buildUnitListView.ts
+++ b/src/application/unit-list/buildUnitListView.ts
@@ -10,17 +10,13 @@ import {
   flattenAjsUnits,
 } from "../../domain/models/ajs/AjsDocument";
 import { buildUnitListGroup6View } from "./buildUnitListGroup6View";
+import { buildUnitListGroup10View } from "./buildUnitListGroup10View";
 import {
   buildUnitListGroup11View,
   buildUnitListGroup7View,
 } from "./buildUnitListPriorityViews";
 import {
-  parseCftd,
-  parseCy,
   parseLnParentRule,
-  parseSd,
-  parseSh,
-  parseShd,
   parseTimeValue,
   parseWc,
 } from "./unitListViewHelpers";
@@ -372,46 +368,7 @@ export const buildUnitListView = (document: AjsDocument): UnitListRowView[] => {
       },
       group6: buildUnitListGroup6View(unit),
       group7: buildUnitListGroup7View(document, unit, group7PriorityById),
-      group10: {
-        deleteAfterExecution: findAjsUnitParameterValue(unit, "de"),
-        executionDate: findAjsUnitParameterValue(unit, "ed"),
-        jobGroupPath: findAjsUnitParameterValue(unit, "jc"),
-        exclusiveJobnetName: findAjsUnitParameterValue(unit, "ejn"),
-        parentRules: findAjsUnitParameterValues(unit, "ln").map(
-          parseLnParentRule,
-        ),
-        scheduleDateTypes: findAjsUnitParameterValues(unit, "sd").map(
-          (value) => parseSd(value).type,
-        ),
-        scheduleDateYearMonths: findAjsUnitParameterValues(unit, "sd").map(
-          (value) => parseSd(value).yearMonth,
-        ),
-        scheduleDateDays: findAjsUnitParameterValues(unit, "sd").map(
-          (value) => parseSd(value).day,
-        ),
-        startTimes: findAjsUnitParameterValues(unit, "st").map((value) =>
-          parseTimeValue(value, "+00:00"),
-        ),
-        cycles: findAjsUnitParameterValues(unit, "cy").map(parseCy),
-        substitutes: findAjsUnitParameterValues(unit, "sh").map(parseSh),
-        shiftDays: findAjsUnitParameterValues(unit, "shd").map(parseShd),
-        scheduleByDaysFromStart: findAjsUnitParameterValues(unit, "cftd").map(
-          (value) => parseCftd(value).scheduleByDaysFromStart,
-        ),
-        maxShiftableDays: findAjsUnitParameterValues(unit, "cftd").map(
-          (value) => parseCftd(value).maxShiftableDays,
-        ),
-        startRangeTimes: findAjsUnitParameterValues(unit, "sy").map((value) =>
-          parseTimeValue(value),
-        ),
-        endRangeTimes: findAjsUnitParameterValues(unit, "ey").map((value) =>
-          parseTimeValue(value),
-        ),
-        waitCounts: findAjsUnitParameterValues(unit, "wc").map(parseWc),
-        waitTimes: findAjsUnitParameterValues(unit, "wt").map((value) =>
-          parseTimeValue(value),
-        ),
-      },
+      group10: buildUnitListGroup10View(unit),
       group11: buildUnitListGroup11View(document, unit, group11PriorityById),
       group12: {
         endJudgment: findAjsUnitParameterValue(unit, "ej"),

--- a/src/test/suite/buildUnitListGroup10View.test.ts
+++ b/src/test/suite/buildUnitListGroup10View.test.ts
@@ -1,0 +1,89 @@
+import * as assert from "assert";
+import { parseAjs } from "../../domain/services/parser/AjsParser";
+import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
+import { buildUnitListGroup10View } from "../../application/unit-list/buildUnitListGroup10View";
+
+const definition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  de=y;
+  ed=2024/12/31;
+  jc=/root/jobnet;
+  ejn=exclusive-a;
+  ln=2;
+  sd=2024/03/05;
+  sd=2,+10;
+  sd=3,en;
+  st=08:00;
+  st=+09:00;
+  cy=(3,d);
+  sh=be;
+  shd=5;
+  cftd=be,3,9;
+  sy=08:00;
+  ey=18:00;
+  wc=4;
+  wt=00:30;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+  }
+}
+`;
+
+suite("Build Unit List Group 10 View", () => {
+  test("projects schedule-related group10 fields from unit parameters", () => {
+    const result = parseAjs(definition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const root = document.rootUnits[0];
+
+    const view = buildUnitListGroup10View(root);
+
+    assert.strictEqual(view.deleteAfterExecution, "y");
+    assert.strictEqual(view.executionDate, "2024/12/31");
+    assert.strictEqual(view.jobGroupPath, "/root/jobnet");
+    assert.strictEqual(view.exclusiveJobnetName, "exclusive-a");
+    assert.deepStrictEqual(view.parentRules, ["2"]);
+    assert.deepStrictEqual(view.scheduleDateTypes, ["", "+", "en"]);
+    assert.deepStrictEqual(view.scheduleDateYearMonths, ["2024/03/", "", ""]);
+    assert.deepStrictEqual(view.scheduleDateDays, ["05", "10", ""]);
+    assert.deepStrictEqual(view.startTimes, ["08:00", "+09:00"]);
+    assert.deepStrictEqual(view.cycles, ["3"]);
+    assert.deepStrictEqual(view.substitutes, ["be"]);
+    assert.deepStrictEqual(view.shiftDays, ["5"]);
+    assert.deepStrictEqual(view.scheduleByDaysFromStart, ["be,3"]);
+    assert.deepStrictEqual(view.maxShiftableDays, ["9"]);
+    assert.deepStrictEqual(view.startRangeTimes, ["08:00"]);
+    assert.deepStrictEqual(view.endRangeTimes, ["18:00"]);
+    assert.deepStrictEqual(view.waitCounts, ["4"]);
+    assert.deepStrictEqual(view.waitTimes, ["00:30"]);
+  });
+
+  test("returns empty arrays for units without schedule parameters", () => {
+    const result = parseAjs(definition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const jobnet = document.rootUnits[0]?.children[0];
+
+    assert.ok(jobnet);
+
+    const view = buildUnitListGroup10View(jobnet);
+
+    assert.deepStrictEqual(view.parentRules, []);
+    assert.deepStrictEqual(view.scheduleDateTypes, []);
+    assert.deepStrictEqual(view.scheduleDateYearMonths, []);
+    assert.deepStrictEqual(view.scheduleDateDays, []);
+    assert.deepStrictEqual(view.startTimes, []);
+    assert.deepStrictEqual(view.cycles, []);
+    assert.deepStrictEqual(view.substitutes, []);
+    assert.deepStrictEqual(view.shiftDays, []);
+    assert.deepStrictEqual(view.scheduleByDaysFromStart, []);
+    assert.deepStrictEqual(view.maxShiftableDays, []);
+    assert.deepStrictEqual(view.startRangeTimes, []);
+    assert.deepStrictEqual(view.endRangeTimes, []);
+    assert.deepStrictEqual(view.waitCounts, []);
+    assert.deepStrictEqual(view.waitTimes, []);
+  });
+});


### PR DESCRIPTION
This PR decomposes buildUnitListView by extracting group10 schedule projection logic into a dedicated helper module and adds focused regression tests for the new helper. It preserves existing UnitListRowView behavior and updates the decompose task tracking.