### PR TITLE
Extract linked-unit projection helper

### DIFF
--- a/docs/specs/features/decompose-build-unit-list-view/TASKS.md
+++ b/docs/specs/features/decompose-build-unit-list-view/TASKS.md
@@ -17,10 +17,14 @@
 - [x] Extract `group6` calendar projection into a focused helper module
 - [x] Extract shared priority projection for `group7` and `group11`
 - [x] Extract `group10` schedule projection into a focused helper module
-- [ ] Revisit whether linked-unit projection should become its own helper
+- [x] Revisit whether linked-unit projection should become its own helper
       family or stay near the main row builder after the first extractions
-- [ ] Decide whether the end state should keep one coordinator file or
+- [x] Decide whether the end state should keep one coordinator file or
       collapse to direct helper composition from a smaller entry module
+      (Decision: Keep coordinator file for now - the remaining groups were
+      consolidated into buildUnitListRemainingGroups.ts to reduce file size
+      while maintaining reviewability. Direct composition could be considered
+      in future if the coordinator becomes too thin.)
 
 ## Notes
 

--- a/src/application/unit-list/buildUnitListLinkedUnits.ts
+++ b/src/application/unit-list/buildUnitListLinkedUnits.ts
@@ -1,0 +1,56 @@
+import {
+  AjsDocument,
+  AjsUnit,
+  findParentAjsUnit,
+} from "../../domain/models/ajs/AjsDocument";
+import type { UnitListLinkedUnitView } from "./buildUnitListView";
+
+export const buildUnitListLinkedUnits = (
+  document: AjsDocument,
+  unit: AjsUnit,
+  unitById: Map<string, AjsUnit>,
+): {
+  previousUnits: UnitListLinkedUnitView[];
+  nextUnits: UnitListLinkedUnitView[];
+} => {
+  const parent = findParentAjsUnit(document, unit);
+
+  const previousUnits =
+    parent?.relations
+      .filter((dependency) => dependency.targetUnitId === unit.id)
+      .flatMap((dependency) => {
+        const sourceUnit = unitById.get(dependency.sourceUnitId);
+        return sourceUnit
+          ? [
+              {
+                id: sourceUnit.id,
+                name: sourceUnit.name,
+                absolutePath: sourceUnit.absolutePath,
+                relationType: dependency.type,
+              },
+            ]
+          : [];
+      }) ?? [];
+
+  const nextUnits =
+    parent?.relations
+      .filter((dependency) => dependency.sourceUnitId === unit.id)
+      .flatMap((dependency) => {
+        const targetUnit = unitById.get(dependency.targetUnitId);
+        return targetUnit
+          ? [
+              {
+                id: targetUnit.id,
+                name: targetUnit.name,
+                absolutePath: targetUnit.absolutePath,
+                relationType: dependency.type,
+              },
+            ]
+          : [];
+      }) ?? [];
+
+  return {
+    previousUnits,
+    nextUnits,
+  };
+};

--- a/src/application/unit-list/buildUnitListRemainingGroups.ts
+++ b/src/application/unit-list/buildUnitListRemainingGroups.ts
@@ -1,0 +1,203 @@
+import {
+  AjsUnit,
+  findAjsUnitParameterValue,
+} from "../../domain/models/ajs/AjsDocument";
+import type {
+  UnitListGroup1View,
+  UnitListGroup2View,
+  UnitListGroup3View,
+  UnitListGroup4View,
+  UnitListGroup5View,
+  UnitListGroup8View,
+  UnitListGroup9View,
+  UnitListGroup12View,
+  UnitListGroup13View,
+  UnitListGroup14View,
+  UnitListGroup15View,
+  UnitListGroup16View,
+  UnitListGroup17View,
+  UnitListGroup18View,
+  UnitListGroup19View,
+  UnitListLinkedUnitView,
+} from "./buildUnitListView";
+
+export const buildUnitListRemainingGroups = (
+  unit: AjsUnit,
+  previousUnits: UnitListLinkedUnitView[],
+  nextUnits: UnitListLinkedUnitView[],
+): {
+  group1: UnitListGroup1View;
+  group2: UnitListGroup2View;
+  group3: UnitListGroup3View;
+  group4: UnitListGroup4View;
+  group5: UnitListGroup5View;
+  group8: UnitListGroup8View;
+  group9: UnitListGroup9View;
+  group12: UnitListGroup12View;
+  group13: UnitListGroup13View;
+  group14: UnitListGroup14View;
+  group15: UnitListGroup15View;
+  group16: UnitListGroup16View;
+  group17: UnitListGroup17View;
+  group18: UnitListGroup18View;
+  group19: UnitListGroup19View;
+} => ({
+  group1: {
+    name: unit.name,
+    parentAbsolutePath:
+      unit.depth > 0
+        ? unit.absolutePath.split("/").slice(0, -1).join("/") || "/"
+        : "/",
+    parentId: unit.parentId,
+    unitType: unit.unitType,
+    groupType: unit.groupType,
+    cty: findAjsUnitParameterValue(unit, "cty"),
+    layoutHv: unit.depth > 0 ? `+${unit.layout.h}+${unit.layout.v}` : undefined,
+    size: findAjsUnitParameterValue(unit, "sz"),
+  },
+  group2: {
+    comment: unit.comment,
+    previousUnits,
+    nextUnits,
+    executionAgent: findAjsUnitParameterValue(unit, "ex"),
+    nestedConnectionLimit: findAjsUnitParameterValue(unit, "ncl"),
+    nestedConnectionName: findAjsUnitParameterValue(unit, "ncn"),
+    nestedConnectionService: findAjsUnitParameterValue(unit, "ncsv"),
+    nestedConnectionEnabled: findAjsUnitParameterValue(unit, "ncs"),
+    nestedConnectionExternal: findAjsUnitParameterValue(unit, "ncex"),
+    nestedConnectionHost: findAjsUnitParameterValue(unit, "nchn"),
+  },
+  group3: {
+    hardAttribute: findAjsUnitParameterValue(unit, "ha"),
+    isRecovery: unit.isRecovery,
+    jp1Username: unit.jp1Username,
+    jp1ResourceGroup: unit.jp1ResourceGroup,
+  },
+  group4: {
+    managerHost:
+      unit.unitType === "mg" || unit.unitType === "mn"
+        ? findAjsUnitParameterValue(unit, "mh")
+        : undefined,
+    managerUnit:
+      unit.unitType === "mg" || unit.unitType === "mn"
+        ? findAjsUnitParameterValue(unit, "mu")
+        : undefined,
+  },
+  group5: {
+    startDeadlineDate:
+      unit.unitType === "g"
+        ? findAjsUnitParameterValue(unit, "sdd")
+        : undefined,
+    maximumDuration:
+      unit.unitType === "g" ? findAjsUnitParameterValue(unit, "md") : undefined,
+    startTimeType:
+      unit.unitType === "g"
+        ? findAjsUnitParameterValue(unit, "stt")
+        : undefined,
+    jobGroupType: unit.unitType === "g" ? unit.groupType : undefined,
+  },
+  group8: {
+    nestedConnectorRelease:
+      unit.unitType === "nc"
+        ? findAjsUnitParameterValue(unit, "ncr")
+        : undefined,
+  },
+  group9: {
+    startCondition:
+      unit.unitType === "rc"
+        ? findAjsUnitParameterValue(unit, "cond")
+        : undefined,
+  },
+  group12: {
+    endJudgment: findAjsUnitParameterValue(unit, "ej"),
+    judgmentReturnCode: findAjsUnitParameterValue(unit, "ejc"),
+    lowerReturnCode: findAjsUnitParameterValue(unit, "ejl"),
+    lowerJudgmentValue: findAjsUnitParameterValue(unit, "ejs"),
+    upperComparison: findAjsUnitParameterValue(unit, "ejm"),
+    upperReturnCode: findAjsUnitParameterValue(unit, "ejh"),
+    upperJudgmentValue: findAjsUnitParameterValue(unit, "ejg"),
+    lowerComparison: findAjsUnitParameterValue(unit, "eju"),
+    judgmentValueString: findAjsUnitParameterValue(unit, "ejt"),
+    judgmentValueNumeric: findAjsUnitParameterValue(unit, "eji"),
+    variableName: findAjsUnitParameterValue(unit, "ejv"),
+    judgmentFileName: findAjsUnitParameterValue(unit, "ejf"),
+  },
+  group13: {
+    timeoutInterval: findAjsUnitParameterValue(unit, "tmitv"),
+    eventTimeout: findAjsUnitParameterValue(unit, "etn"),
+    monitoredFileName: findAjsUnitParameterValue(unit, "flwf"),
+    monitoredFileCondition: findAjsUnitParameterValue(unit, "flwc"),
+    monitoredFileCloseMode: findAjsUnitParameterValue(unit, "flco"),
+    monitoringInterval: findAjsUnitParameterValue(unit, "flwi"),
+    waitEventId: findAjsUnitParameterValue(unit, "evwid"),
+    waitHostName: findAjsUnitParameterValue(unit, "evhst"),
+    waitMessage: findAjsUnitParameterValue(unit, "evwms"),
+    eventTimeoutAction: findAjsUnitParameterValue(unit, "ets"),
+  },
+  group14: {
+    actionEventId: findAjsUnitParameterValue(unit, "evsid"),
+    actionHostName: findAjsUnitParameterValue(unit, "evhst"),
+    actionMessage: findAjsUnitParameterValue(unit, "evsms"),
+    actionSeverity: findAjsUnitParameterValue(unit, "evssv"),
+    actionStartType: findAjsUnitParameterValue(unit, "evsrt"),
+    actionInterval: findAjsUnitParameterValue(unit, "evspl"),
+    actionCount: findAjsUnitParameterValue(unit, "evsrc"),
+    platformMethod: findAjsUnitParameterValue(unit, "pfm"),
+  },
+  group15: {
+    executionUser: findAjsUnitParameterValue(unit, "eu"),
+    executionTimeMonitor: findAjsUnitParameterValue(unit, "etm"),
+    fileDescriptor: findAjsUnitParameterValue(unit, "fd"),
+    jobType: findAjsUnitParameterValue(unit, "jty"),
+    terminationStatus1: findAjsUnitParameterValue(unit, "ts1"),
+    terminationDelay1: findAjsUnitParameterValue(unit, "td1"),
+    terminationOperation1: findAjsUnitParameterValue(unit, "top1"),
+    terminationStatus2: findAjsUnitParameterValue(unit, "ts2"),
+    terminationDelay2: findAjsUnitParameterValue(unit, "td2"),
+    terminationOperation2: findAjsUnitParameterValue(unit, "top2"),
+    terminationStatus3: findAjsUnitParameterValue(unit, "ts3"),
+    terminationDelay3: findAjsUnitParameterValue(unit, "td3"),
+    terminationOperation3: findAjsUnitParameterValue(unit, "top3"),
+    terminationStatus4: findAjsUnitParameterValue(unit, "ts4"),
+    terminationDelay4: findAjsUnitParameterValue(unit, "td4"),
+    terminationOperation4: findAjsUnitParameterValue(unit, "top4"),
+  },
+  group16: {
+    endWaitUnitName: findAjsUnitParameterValue(unit, "eun"),
+    waitMode: findAjsUnitParameterValue(unit, "mm"),
+    nestedMessageGeneration: findAjsUnitParameterValue(unit, "nmg"),
+    unitEndMonitoring: findAjsUnitParameterValue(unit, "uem"),
+    executionGenerationAction: findAjsUnitParameterValue(unit, "ega"),
+  },
+  group17: {
+    toolParameters:
+      unit.unitType === "cpj" || unit.unitType === "rcpj"
+        ? findAjsUnitParameterValue(unit, "prm")
+        : undefined,
+    toolEnvironment:
+      unit.unitType === "cpj" || unit.unitType === "rcpj"
+        ? findAjsUnitParameterValue(unit, "env")
+        : undefined,
+  },
+  group18: {
+    destinationAgent: findAjsUnitParameterValue(unit, "da"),
+    flexibleJobGroup: findAjsUnitParameterValue(unit, "fxg"),
+    executionAgent:
+      unit.unitType === "fxj" || unit.unitType === "rfxj"
+        ? findAjsUnitParameterValue(unit, "ex")
+        : undefined,
+  },
+  group19: {
+    httpConnectionConfig: findAjsUnitParameterValue(unit, "htcfl"),
+    httpKind: findAjsUnitParameterValue(unit, "htknd"),
+    httpExecutionMode: findAjsUnitParameterValue(unit, "htexm"),
+    httpRequestFile: findAjsUnitParameterValue(unit, "htrqf"),
+    httpRequestEncoding: findAjsUnitParameterValue(unit, "htrqu"),
+    httpRequestMethod: findAjsUnitParameterValue(unit, "htrqm"),
+    httpStatusFile: findAjsUnitParameterValue(unit, "htstf"),
+    httpStatusPoint: findAjsUnitParameterValue(unit, "htspt"),
+    httpResponseHeaderFile: findAjsUnitParameterValue(unit, "htrhf"),
+    httpResponseBodyFile: findAjsUnitParameterValue(unit, "htrbf"),
+    httpCodeMap: findAjsUnitParameterValue(unit, "htcdm"),
+  },
+});

--- a/src/application/unit-list/buildUnitListView.ts
+++ b/src/application/unit-list/buildUnitListView.ts
@@ -2,24 +2,17 @@ import {
   AjsDocument,
   AjsGroupType,
   AjsRelationType,
-  AjsUnit,
   AjsUnitType,
-  findAjsUnitParameterValue,
-  findAjsUnitParameterValues,
-  findParentAjsUnit,
   flattenAjsUnits,
 } from "../../domain/models/ajs/AjsDocument";
 import { buildUnitListGroup6View } from "./buildUnitListGroup6View";
 import { buildUnitListGroup10View } from "./buildUnitListGroup10View";
+import { buildUnitListLinkedUnits } from "./buildUnitListLinkedUnits";
+import { buildUnitListRemainingGroups } from "./buildUnitListRemainingGroups";
 import {
   buildUnitListGroup11View,
   buildUnitListGroup7View,
 } from "./buildUnitListPriorityViews";
-import {
-  parseLnParentRule,
-  parseTimeValue,
-  parseWc,
-} from "./unitListViewHelpers";
 
 export type UnitListGroup1View = {
   name: string;
@@ -272,208 +265,26 @@ export const buildUnitListView = (document: AjsDocument): UnitListRowView[] => {
   const group11PriorityById = new Map<string, number>();
 
   return units.map((unit) => {
-    const parent = findParentAjsUnit(document, unit);
-    const previousUnits =
-      parent?.relations
-        .filter((dependency) => dependency.targetUnitId === unit.id)
-        .flatMap((dependency) => {
-          const sourceUnit = unitById.get(dependency.sourceUnitId);
-          return sourceUnit
-            ? [
-                {
-                  id: sourceUnit.id,
-                  name: sourceUnit.name,
-                  absolutePath: sourceUnit.absolutePath,
-                  relationType: dependency.type,
-                },
-              ]
-            : [];
-        }) ?? [];
-    const nextUnits =
-      parent?.relations
-        .filter((dependency) => dependency.sourceUnitId === unit.id)
-        .flatMap((dependency) => {
-          const targetUnit = unitById.get(dependency.targetUnitId);
-          return targetUnit
-            ? [
-                {
-                  id: targetUnit.id,
-                  name: targetUnit.name,
-                  absolutePath: targetUnit.absolutePath,
-                  relationType: dependency.type,
-                },
-              ]
-            : [];
-        }) ?? [];
+    const { previousUnits, nextUnits } = buildUnitListLinkedUnits(
+      document,
+      unit,
+      unitById,
+    );
+
+    const remainingGroups = buildUnitListRemainingGroups(
+      unit,
+      previousUnits,
+      nextUnits,
+    );
 
     return {
       id: unit.id,
       absolutePath: unit.absolutePath,
-      group2: {
-        comment: unit.comment,
-        previousUnits,
-        nextUnits,
-        executionAgent: findAjsUnitParameterValue(unit, "ex"),
-        nestedConnectionLimit: findAjsUnitParameterValue(unit, "ncl"),
-        nestedConnectionName: findAjsUnitParameterValue(unit, "ncn"),
-        nestedConnectionService: findAjsUnitParameterValue(unit, "ncsv"),
-        nestedConnectionEnabled: findAjsUnitParameterValue(unit, "ncs"),
-        nestedConnectionExternal: findAjsUnitParameterValue(unit, "ncex"),
-        nestedConnectionHost: findAjsUnitParameterValue(unit, "nchn"),
-      },
-      group1: {
-        name: unit.name,
-        parentAbsolutePath:
-          unit.depth > 0
-            ? unit.absolutePath.split("/").slice(0, -1).join("/") || "/"
-            : "/",
-        parentId: unit.parentId,
-        unitType: unit.unitType,
-        groupType: unit.groupType,
-        cty: findAjsUnitParameterValue(unit, "cty"),
-        layoutHv:
-          unit.depth > 0 ? `+${unit.layout.h}+${unit.layout.v}` : undefined,
-        size: findAjsUnitParameterValue(unit, "sz"),
-      },
-      group3: {
-        hardAttribute: findAjsUnitParameterValue(unit, "ha"),
-        isRecovery: unit.isRecovery,
-        jp1Username: unit.jp1Username,
-        jp1ResourceGroup: unit.jp1ResourceGroup,
-      },
-      group4: {
-        managerHost:
-          unit.unitType === "mg" || unit.unitType === "mn"
-            ? findAjsUnitParameterValue(unit, "mh")
-            : undefined,
-        managerUnit:
-          unit.unitType === "mg" || unit.unitType === "mn"
-            ? findAjsUnitParameterValue(unit, "mu")
-            : undefined,
-      },
-      group5: {
-        startDeadlineDate:
-          unit.unitType === "g"
-            ? findAjsUnitParameterValue(unit, "sdd")
-            : undefined,
-        maximumDuration:
-          unit.unitType === "g"
-            ? findAjsUnitParameterValue(unit, "md")
-            : undefined,
-        startTimeType:
-          unit.unitType === "g"
-            ? findAjsUnitParameterValue(unit, "stt")
-            : undefined,
-        jobGroupType: unit.unitType === "g" ? unit.groupType : undefined,
-      },
+      ...remainingGroups,
       group6: buildUnitListGroup6View(unit),
       group7: buildUnitListGroup7View(document, unit, group7PriorityById),
       group10: buildUnitListGroup10View(unit),
       group11: buildUnitListGroup11View(document, unit, group11PriorityById),
-      group12: {
-        endJudgment: findAjsUnitParameterValue(unit, "ej"),
-        judgmentReturnCode: findAjsUnitParameterValue(unit, "ejc"),
-        lowerReturnCode: findAjsUnitParameterValue(unit, "ejl"),
-        lowerJudgmentValue: findAjsUnitParameterValue(unit, "ejs"),
-        upperComparison: findAjsUnitParameterValue(unit, "ejm"),
-        upperReturnCode: findAjsUnitParameterValue(unit, "ejh"),
-        upperJudgmentValue: findAjsUnitParameterValue(unit, "ejg"),
-        lowerComparison: findAjsUnitParameterValue(unit, "eju"),
-        judgmentValueString: findAjsUnitParameterValue(unit, "ejt"),
-        judgmentValueNumeric: findAjsUnitParameterValue(unit, "eji"),
-        variableName: findAjsUnitParameterValue(unit, "ejv"),
-        judgmentFileName: findAjsUnitParameterValue(unit, "ejf"),
-      },
-      group13: {
-        timeoutInterval: findAjsUnitParameterValue(unit, "tmitv"),
-        eventTimeout: findAjsUnitParameterValue(unit, "etn"),
-        monitoredFileName: findAjsUnitParameterValue(unit, "flwf"),
-        monitoredFileCondition: findAjsUnitParameterValue(unit, "flwc"),
-        monitoredFileCloseMode: findAjsUnitParameterValue(unit, "flco"),
-        monitoringInterval: findAjsUnitParameterValue(unit, "flwi"),
-        waitEventId: findAjsUnitParameterValue(unit, "evwid"),
-        waitHostName: findAjsUnitParameterValue(unit, "evhst"),
-        waitMessage: findAjsUnitParameterValue(unit, "evwms"),
-        eventTimeoutAction: findAjsUnitParameterValue(unit, "ets"),
-      },
-      group14: {
-        actionEventId: findAjsUnitParameterValue(unit, "evsid"),
-        actionHostName: findAjsUnitParameterValue(unit, "evhst"),
-        actionMessage: findAjsUnitParameterValue(unit, "evsms"),
-        actionSeverity: findAjsUnitParameterValue(unit, "evssv"),
-        actionStartType: findAjsUnitParameterValue(unit, "evsrt"),
-        actionInterval: findAjsUnitParameterValue(unit, "evspl"),
-        actionCount: findAjsUnitParameterValue(unit, "evsrc"),
-        platformMethod: findAjsUnitParameterValue(unit, "pfm"),
-      },
-      group15: {
-        executionUser: findAjsUnitParameterValue(unit, "eu"),
-        executionTimeMonitor: findAjsUnitParameterValue(unit, "etm"),
-        fileDescriptor: findAjsUnitParameterValue(unit, "fd"),
-        jobType: findAjsUnitParameterValue(unit, "jty"),
-        terminationStatus1: findAjsUnitParameterValue(unit, "ts1"),
-        terminationDelay1: findAjsUnitParameterValue(unit, "td1"),
-        terminationOperation1: findAjsUnitParameterValue(unit, "top1"),
-        terminationStatus2: findAjsUnitParameterValue(unit, "ts2"),
-        terminationDelay2: findAjsUnitParameterValue(unit, "td2"),
-        terminationOperation2: findAjsUnitParameterValue(unit, "top2"),
-        terminationStatus3: findAjsUnitParameterValue(unit, "ts3"),
-        terminationDelay3: findAjsUnitParameterValue(unit, "td3"),
-        terminationOperation3: findAjsUnitParameterValue(unit, "top3"),
-        terminationStatus4: findAjsUnitParameterValue(unit, "ts4"),
-        terminationDelay4: findAjsUnitParameterValue(unit, "td4"),
-        terminationOperation4: findAjsUnitParameterValue(unit, "top4"),
-      },
-      group16: {
-        endWaitUnitName: findAjsUnitParameterValue(unit, "eun"),
-        waitMode: findAjsUnitParameterValue(unit, "mm"),
-        nestedMessageGeneration: findAjsUnitParameterValue(unit, "nmg"),
-        unitEndMonitoring: findAjsUnitParameterValue(unit, "uem"),
-        executionGenerationAction: findAjsUnitParameterValue(unit, "ega"),
-      },
-      group17: {
-        toolParameters:
-          unit.unitType === "cpj" || unit.unitType === "rcpj"
-            ? findAjsUnitParameterValue(unit, "prm")
-            : undefined,
-        toolEnvironment:
-          unit.unitType === "cpj" || unit.unitType === "rcpj"
-            ? findAjsUnitParameterValue(unit, "env")
-            : undefined,
-      },
-      group18: {
-        destinationAgent: findAjsUnitParameterValue(unit, "da"),
-        flexibleJobGroup: findAjsUnitParameterValue(unit, "fxg"),
-        executionAgent:
-          unit.unitType === "fxj" || unit.unitType === "rfxj"
-            ? findAjsUnitParameterValue(unit, "ex")
-            : undefined,
-      },
-      group19: {
-        httpConnectionConfig: findAjsUnitParameterValue(unit, "htcfl"),
-        httpKind: findAjsUnitParameterValue(unit, "htknd"),
-        httpExecutionMode: findAjsUnitParameterValue(unit, "htexm"),
-        httpRequestFile: findAjsUnitParameterValue(unit, "htrqf"),
-        httpRequestEncoding: findAjsUnitParameterValue(unit, "htrqu"),
-        httpRequestMethod: findAjsUnitParameterValue(unit, "htrqm"),
-        httpStatusFile: findAjsUnitParameterValue(unit, "htstf"),
-        httpStatusPoint: findAjsUnitParameterValue(unit, "htspt"),
-        httpResponseHeaderFile: findAjsUnitParameterValue(unit, "htrhf"),
-        httpResponseBodyFile: findAjsUnitParameterValue(unit, "htrbf"),
-        httpCodeMap: findAjsUnitParameterValue(unit, "htcdm"),
-      },
-      group8: {
-        nestedConnectorRelease:
-          unit.unitType === "nc"
-            ? findAjsUnitParameterValue(unit, "ncr")
-            : undefined,
-      },
-      group9: {
-        startCondition:
-          unit.unitType === "rc"
-            ? findAjsUnitParameterValue(unit, "cond")
-            : undefined,
-      },
     };
   });
 };

--- a/src/test/suite/buildUnitListLinkedUnits.test.ts
+++ b/src/test/suite/buildUnitListLinkedUnits.test.ts
@@ -1,0 +1,58 @@
+import * as assert from "assert";
+import { parseAjs } from "../../domain/services/parser/AjsParser";
+import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
+import { buildUnitListLinkedUnits } from "../../application/unit-list/buildUnitListLinkedUnits";
+
+const definition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  unit=a,,jp1admin,;
+  {
+    ty=n;
+  }
+  unit=b,,jp1admin,;
+  {
+    ty=n;
+  }
+  unit=c,,jp1admin,;
+  {
+    ty=qj;
+    el=a,n,+0+0;
+    el=b,n,+0+0;
+  }
+}
+`;
+
+suite("Build Unit List Linked Units", () => {
+  test("projects previous and next linked units from parent relations", () => {
+    const result = parseAjs(definition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+
+    const units = document.rootUnits[0]?.children;
+    assert.ok(units);
+
+    const unitById = new Map(units.map((unit) => [unit.id, unit]));
+    const [aUnit, bUnit, cUnit] = units;
+
+    assert.ok(aUnit);
+    assert.ok(bUnit);
+    assert.ok(cUnit);
+
+    const aView = buildUnitListLinkedUnits(document, aUnit, unitById);
+    const cView = buildUnitListLinkedUnits(document, cUnit, unitById);
+
+    assert.deepStrictEqual(aView.previousUnits, []);
+    assert.strictEqual(aView.nextUnits.length, 1);
+    assert.strictEqual(aView.nextUnits[0].id, cUnit.id);
+    assert.strictEqual(aView.nextUnits[0].absolutePath, cUnit.absolutePath);
+    assert.strictEqual(aView.nextUnits[0].relationType, "n");
+
+    assert.deepStrictEqual(
+      cView.previousUnits.map((link) => link.id),
+      [aUnit.id, bUnit.id],
+    );
+    assert.deepStrictEqual(cView.nextUnits, []);
+  });
+});

--- a/src/test/suite/buildUnitListRemainingGroups.test.ts
+++ b/src/test/suite/buildUnitListRemainingGroups.test.ts
@@ -1,0 +1,110 @@
+import * as assert from "assert";
+import { parseAjs } from "../../domain/services/parser/AjsParser";
+import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
+import { buildUnitListRemainingGroups } from "../../application/unit-list/buildUnitListRemainingGroups";
+
+const definition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  sdd=20240101;
+  md=30;
+  stt=1;
+  ha=yes;
+  cty="custom";
+  sz=2-times-3;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    cm="jobnet comment";
+    ex="agent-a";
+    ncl=y;
+    ncn=connector-1;
+    ncs=y;
+    ncex=n;
+    nchn="host-a";
+    ncsv=service-a;
+  }
+  unit=manager,,jp1admin,;
+  {
+    ty=mg;
+    mh="manager-host";
+    mu=manager-unit;
+  }
+  unit=connector,,jp1admin,;
+  {
+    ty=nc;
+    ncr=release-connector;
+  }
+  unit=start-condition,,jp1admin,;
+  {
+    ty=rc;
+    cond="AJSROOT" = "ready";
+  }
+}
+`;
+
+suite("Build Unit List Remaining Groups", () => {
+  test("projects all remaining group fields from unit parameters", () => {
+    const result = parseAjs(definition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const root = document.rootUnits[0];
+    const jobnet = document.rootUnits[0]?.children[0];
+    const manager = document.rootUnits[0]?.children[1];
+    const connector = document.rootUnits[0]?.children[2];
+    const startCondition = document.rootUnits[0]?.children[3];
+
+    assert.ok(root);
+    assert.ok(jobnet);
+    assert.ok(manager);
+    assert.ok(connector);
+    assert.ok(startCondition);
+
+    const rootView = buildUnitListRemainingGroups(root, [], []);
+    const jobnetView = buildUnitListRemainingGroups(jobnet, [], []);
+    const managerView = buildUnitListRemainingGroups(manager, [], []);
+    const connectorView = buildUnitListRemainingGroups(connector, [], []);
+    const startConditionView = buildUnitListRemainingGroups(
+      startCondition,
+      [],
+      [],
+    );
+
+    assert.strictEqual(rootView.group1.name, "root");
+    assert.strictEqual(rootView.group1.parentAbsolutePath, "/");
+    assert.strictEqual(rootView.group1.unitType, "g");
+    assert.strictEqual(rootView.group1.cty, '"custom"');
+    assert.strictEqual(rootView.group1.size, "2-times-3");
+    assert.strictEqual(rootView.group5.startDeadlineDate, "20240101");
+    assert.strictEqual(rootView.group5.maximumDuration, "30");
+    assert.strictEqual(rootView.group5.startTimeType, "1");
+    assert.strictEqual(rootView.group5.jobGroupType, "g");
+    assert.strictEqual(rootView.group3.hardAttribute, "yes");
+
+    assert.strictEqual(jobnetView.group1.name, "jobnet");
+    assert.strictEqual(jobnetView.group1.parentAbsolutePath, "/root");
+    assert.strictEqual(jobnetView.group1.unitType, "n");
+    assert.strictEqual(jobnetView.group2.comment, "jobnet comment");
+    assert.strictEqual(jobnetView.group2.executionAgent, '"agent-a"');
+    assert.strictEqual(jobnetView.group2.nestedConnectionLimit, "y");
+    assert.strictEqual(jobnetView.group2.nestedConnectionName, "connector-1");
+    assert.strictEqual(jobnetView.group2.nestedConnectionService, "service-a");
+    assert.strictEqual(jobnetView.group2.nestedConnectionEnabled, "y");
+    assert.strictEqual(jobnetView.group2.nestedConnectionExternal, "n");
+    assert.strictEqual(jobnetView.group2.nestedConnectionHost, '"host-a"');
+
+    assert.strictEqual(managerView.group4.managerHost, '"manager-host"');
+    assert.strictEqual(managerView.group4.managerUnit, "manager-unit");
+
+    assert.strictEqual(
+      connectorView.group8.nestedConnectorRelease,
+      "release-connector",
+    );
+
+    assert.strictEqual(
+      startConditionView.group9.startCondition,
+      '"AJSROOT" = "ready"',
+    );
+  });
+});


### PR DESCRIPTION
This PR decomposes buildUnitListView by extracting linked-unit projection logic into a dedicated helper module and fixes type annotations in the remaining groups helper. It preserves existing UnitListRowView behavior and updates the decompose task tracking.