### PR TITLE
docs: add refactor-unit-model-classes planning docs

### DIFF
--- a/docs/specs/features/refactor-unit-model-classes/PLANS.md
+++ b/docs/specs/features/refactor-unit-model-classes/PLANS.md
@@ -1,0 +1,30 @@
+# PLANS: refactor-unit-model-classes
+
+## Objective
+
+Reduce duplicate wrapper boilerplate in the normalized unit model while
+preserving unit-local JP1/AJS semantics and existing behavior.
+
+## Scope
+
+- Review `src/domain/models/units/*` wrapper classes for repeated parameter
+  getter patterns.
+- Identify shared extraction points for common parameters and helper logic.
+- Keep per-wrapper local semantics such as group planning, connector control
+  defaults, schedule ownership, and root-jobnet behavior on the owning class.
+- Add tests that validate both shared helper behavior and wrapper-specific
+  edge cases.
+
+## Milestones
+
+1. Review current unit wrapper class patterns and capability interfaces.
+2. Define extraction approach for common wrapper getters and shared
+   semantics.
+3. Implement refactor in small vertical slices.
+4. Add regression coverage for extracted behavior and unit-local rules.
+5. Validate with repository-wide checks.
+
+## Validation
+
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`, `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/refactor-unit-model-classes/SPECS.md
+++ b/docs/specs/features/refactor-unit-model-classes/SPECS.md
@@ -1,0 +1,30 @@
+# SPECS: refactor-unit-model-classes
+
+## Problem
+
+Many unit wrapper classes in `src/domain/models/units/` duplicate the same
+`ParamFactory` getter boilerplate and capability wiring. This increases
+maintenance cost and makes it harder to keep wrapper behavior selective.
+
+## Requirements
+
+- Extract shared wrapper behavior across similar unit types without changing
+  the external unit model surface.
+- Preserve per-unit local semantics on the owning wrapper when a rule is
+  genuinely unit-local.
+- Keep the existing `PrioritizableUnit` and `WaitableUnit` contracts intact.
+- Avoid adding new public runtime dependencies outside the domain layer.
+- Ensure `tyFactory` still returns the same wrapper classes and normalized
+  model behavior remains unchanged.
+- Add or update tests to cover both extracted shared behavior and unit-local
+  edge cases.
+
+## Acceptance Criteria
+
+- Wrapper class duplication is reduced by extracting shared parameter
+  behaviors into base helpers or common abstractions.
+- No existing public wrapper behavior changes.
+- Existing regression tests continue to pass.
+- New tests verify the refactor does not affect root-jobnet defaults,
+  group-specific planning semantics, or wait/priority resolution.
+- Documentation and branch planning reflect the active slice.

--- a/docs/specs/features/refactor-unit-model-classes/TASKS.md
+++ b/docs/specs/features/refactor-unit-model-classes/TASKS.md
@@ -1,0 +1,30 @@
+# TASKS: refactor-unit-model-classes
+
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If the change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
+## Completed
+
+- [x] Confirm this feature aligns with `docs/specs/plans.md` and
+  `docs/specs/roadmap.md`.
+- [x] Create feature-level SPECS and PLANS.
+
+## Remaining
+
+- [ ] Review wrapper class duplication across `src/domain/models/units/`.
+- [ ] Identify common extraction points for parameter getters and helper logic.
+- [ ] Implement shared wrapper abstractions while preserving unit-local rules.
+- [ ] Add regression tests covering shared behavior and wrapper-specific cases.
+- [ ] Run validation: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`.
+
+## Notes
+
+- This feature is the implementation slice for the roadmap item:
+  "Refactor unit model classes to reduce code duplication across similar
+  unit types."
+- Keep wrapper refactor selective: extract only genuinely shared semantics.

--- a/docs/specs/features/refactor-unit-model-classes/TASKS.md
+++ b/docs/specs/features/refactor-unit-model-classes/TASKS.md
@@ -10,7 +10,7 @@
 ## Completed
 
 - [x] Confirm this feature aligns with `docs/specs/plans.md` and
-  `docs/specs/roadmap.md`.
+      `docs/specs/roadmap.md`.
 - [x] Create feature-level SPECS and PLANS.
 
 ## Remaining
@@ -20,7 +20,7 @@
 - [ ] Implement shared wrapper abstractions while preserving unit-local rules.
 - [ ] Add regression tests covering shared behavior and wrapper-specific cases.
 - [ ] Run validation: `npm run qlty`, `npm test`, `npm run test:web`,
-  `npm run build`.
+      `npm run build`.
 
 ## Notes
 

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -97,6 +97,7 @@ structure in `docs/specs/features/<feature>/`.
    extract only semantics that are cross-unit or shared with normalization,
    and keep unit-local JP1/AJS rules on the owning wrapper when abstraction
    would be artificial.
+   - Feature planning now exists in `docs/specs/features/refactor-unit-model-classes/`.
 2. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, or shared adapters change.
 3. Profile webview bundle size and evaluate deferred optimization:


### PR DESCRIPTION
Add feature-level SPECS, PLANS, and TASKS for the refactor-unit-model-classes docs-only slice.