### PR TITLE
docs: refresh SDD roadmap and feature slices

### DIFF
--- a/docs/requirements/use-cases/uc-generate-ajs-commands.md
+++ b/docs/requirements/use-cases/uc-generate-ajs-commands.md
@@ -1,0 +1,47 @@
+# UC: Generate AJS Commands
+
+## Goal
+
+Generate JP1/AJS command text for a selected scope by using a dedicated,
+reference-aligned command-generation contract instead of embedding that logic
+inside one presentation-specific builder.
+
+## Trigger
+
+- a user requests command text for a selected unit or scope
+- another feature needs JP1/AJS command text derived from the current
+  definition context
+
+## Inputs
+
+- selected unit or scope identity
+- normalized or equivalent application-facing definition data
+- JP1/Automatic Job Management System 3 version 13 command rules
+
+## Outputs
+
+- generated `ajs` command text or structured command-generation results
+
+## Rules
+
+- JP1/Automatic Job Management System 3 version 13 Command Reference is the
+  normative source for generated command behavior
+- command generation must be isolated from view-specific dialog assembly so it
+  can be reused outside `buildUnitDefinition.ts`
+- generation logic should depend on stable application-facing data instead of
+  webview component state
+
+## Acceptance Notes
+
+- command-generation behavior can be tested without opening a viewer dialog
+- show-unit-definition and other consumers can obtain command text through the
+  same dedicated contract
+- command support can expand incrementally across documented JP1/AJS commands
+  without rewriting the consumer surface each time
+
+## Risks Or Edge Cases
+
+- some commands may require context not currently present in existing DTOs
+- command options can vary by platform or deployment mode
+- preserving current user-visible command text while broadening supported
+  commands may require explicit compatibility notes

--- a/docs/requirements/use-cases/uc-import-ajs-definition-via-webapi.md
+++ b/docs/requirements/use-cases/uc-import-ajs-definition-via-webapi.md
@@ -1,0 +1,49 @@
+# UC: Import AJS Definition Via WebAPI
+
+## Goal
+
+Load JP1/AJS definition information from a server through the JP1/AJS WebAPI so
+the extension is not limited to local definition files.
+
+## Trigger
+
+- the user requests server-side JP1/AJS definition data
+- the application needs to load a definition source exposed by the JP1/AJS
+  WebAPI
+
+## Inputs
+
+- target server or connection context
+- API request parameters needed to identify the definition scope to load
+- authentication context required by the JP1/AJS WebAPI
+
+## Outputs
+
+- read-only definition data that downstream parsing, normalization, list, or
+  flow features can consume
+
+## Rules
+
+- initial scope is read-only import only
+- WebAPI transport, authentication, and endpoint details must remain behind an
+  infrastructure boundary
+- imported definition data should be converted to stable application-facing
+  structures before presentation-specific handling
+
+## Acceptance Notes
+
+- a user can request server-side definition loading without relying on a local
+  exported file as the primary source
+- downstream features can consume imported data through explicit application
+  contracts instead of direct WebAPI response objects
+- desktop and web compatibility implications are documented explicitly for the
+  chosen transport approach
+
+## Risks Or Edge Cases
+
+- authentication and network constraints can differ sharply between desktop and
+  web hosts
+- API response formats may not match the parser's existing local-file input
+  shape directly
+- read-only import scope can still require careful error handling, timeouts,
+  and partial-data reporting

--- a/docs/requirements/use-cases/uc-interpret-jp1-parameters.md
+++ b/docs/requirements/use-cases/uc-interpret-jp1-parameters.md
@@ -1,0 +1,51 @@
+# UC: Interpret JP1 Parameters
+
+## Goal
+
+Interpret JP1/AJS parameters in a way that is explicitly aligned with the
+target product reference so multiple features can rely on the same semantics.
+
+## Trigger
+
+- an application or presentation path needs parameter syntax, defaults,
+  inheritance, or value interpretation
+- a feature needs parameter information for display, validation, navigation,
+  or command generation
+
+## Inputs
+
+- parsed or normalized unit parameter data
+- the target JP1/Automatic Job Management System 3 version 13 parameter rules
+
+## Outputs
+
+- reusable parameter interpretation results
+- stable metadata that downstream features can use without depending directly
+  on one-off manual parsing logic
+
+## Rules
+
+- JP1/Automatic Job Management System 3 version 13 Definition File Reference is
+  the normative source for parameter interpretation
+- interpretation logic should be reusable across hover, unit definition,
+  flow/list presentation, and future import or generation features when they
+  need the same rule
+- manual-aligned semantics should not be duplicated independently in multiple
+  viewers or adapters
+
+## Acceptance Notes
+
+- parameter parsing behavior is described against one named product version
+- shared consumers can reuse the same parameter interpretation results instead
+  of re-deriving semantics ad hoc
+- existing behavior can be preserved incrementally while mismatches against the
+  chosen manual are made explicit and corrected in focused slices
+
+## Risks Or Edge Cases
+
+- the current implementation might rely on wrapper-specific shortcuts that do
+  not map cleanly to the manual wording
+- some manual rules can be context-sensitive by unit type, inheritance, or
+  schedule-rule alignment
+- version-specific manual behavior must remain visible in docs so future
+  upgrades do not silently reinterpret parameters

--- a/docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md
+++ b/docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md
@@ -1,0 +1,49 @@
+# UC: Navigate Between Unit List And Flow Graph
+
+## Goal
+
+Let users move from a unit in one viewer to the corresponding unit in the
+other viewer when that counterpart view is available.
+
+## Trigger
+
+- the user invokes a jump action from the unit-list for a selected unit
+- the user invokes a jump action from the flow-graph for a selected unit
+
+## Inputs
+
+- selected unit identity
+- current document or definition context
+- availability of the counterpart viewer and target unit scope
+
+## Outputs
+
+- the counterpart viewer opens or focuses the corresponding unit
+- if the counterpart viewer is unavailable, the current viewer state is kept
+  stable and the action fails predictably
+
+## Rules
+
+- navigation must be based on stable unit identity or path, not transient UI
+  row or graph-node implementation details
+- list and flow viewers should not require direct imports of each other's
+  internal component state
+- desktop and web hosts should be able to use the same application-facing
+  navigation contract
+
+## Acceptance Notes
+
+- a jump from unit-list to flow-graph lands on the matching unit scope when a
+  flow view can be built
+- a jump from flow-graph to unit-list lands on the matching unit row when a
+  list view can be built
+- the action does not require `UnitEntity` reconstruction in the presentation
+  layer if stable normalized or DTO identity is sufficient
+
+## Risks Or Edge Cases
+
+- target viewers might not already be open
+- some units might not have a meaningful flow scope or list row under the same
+  presentation rules
+- navigation semantics can drift if unit identity differs between list and flow
+  DTO mappings

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -197,6 +197,51 @@ Migration should be incremental and use-case driven.
   changes can break both desktop and web viewers even if parsing remains
   correct
 
+## Planned Boundary Tightening
+
+### Package manager and toolchain
+
+- the repository may migrate from `npm` to `pnpm`, but package-manager changes
+  must stay outside domain/application behavior contracts
+- build, test, and docs validation commands should remain explicit in SDD docs
+  during the migration period so contributors can tell whether current
+  instructions describe the live toolchain or the target toolchain
+
+### Serialization boundary
+
+- viewer payloads should move away from `flatted` as an implicit transport
+  contract
+- presentation payloads should prefer DTOs that can be serialized by standard
+  JSON boundaries without circular-reference assumptions
+- serialization simplification is expected to support bundle-size reduction,
+  but the primary architectural goal is a clearer adapter boundary
+
+### Identity and hashing
+
+- `UnitEntity` identity semantics should remain stable, but internal hashing
+  should prefer a common, well-understood algorithm instead of repository-local
+  bespoke logic when behavior can be preserved
+- hash-algorithm changes should remain an implementation detail unless a
+  public or persisted identity contract is affected
+
+### JP1 reference alignment
+
+- JP1/AJS3 version 13 is the current normative product target for new
+  parameter-parsing and command-generation slices
+- manual-aligned parsing rules belong in domain/application seams that are
+  reusable by hover, definition rendering, navigation, and future import paths
+- command generation should be isolated behind an application-facing service or
+  use case instead of remaining embedded in a presentation-oriented
+  unit-definition builder
+
+### JP1/AJS WebAPI integration
+
+- JP1/AJS WebAPI access should sit behind infrastructure adapters with
+  application-facing DTOs or use cases
+- initial scope is read-only import of server-side definition information
+- WebAPI transport details, authentication, and endpoint wiring should stay
+  outside domain logic and outside webview presentation modules
+
 ## First Good Vertical Slice
 
 ### Recommended slice
@@ -234,3 +279,7 @@ normalized model where practical.
    boundaries
 3. Reduce residual raw-`Unit` / wrapper usage where application slices already
    provide stable models
+4. Simplify viewer serialization and dependency weight where adapter contracts
+   are still broader than necessary
+5. Add application and infrastructure seams for JP1/AJS3 version 13
+   reference-aligned parameter, command, and WebAPI work

--- a/docs/specs/current-state.md
+++ b/docs/specs/current-state.md
@@ -18,6 +18,19 @@ The repository currently mixes legacy and target-oriented structure.
 - parser-adjacent logic can still leak toward UI-oriented code
 - DTO and use-case boundaries are still being clarified
 - old folder names coexist with the target clean-architecture layout
+- package-management and validation workflow still assume `npm`, which makes
+  lockfile strategy and dependency hygiene harder to modernize incrementally
+- webview payloads still depend on `flatted`, so viewer serialization carries
+  avoidable format coupling across desktop and web hosts
+- webview bundle-size pressure remains visible in roadmap planning, especially
+  while shared dependencies continue to grow
+- some legacy `UnitEntity` mechanics still rely on custom implementation
+  details, such as a bespoke hash algorithm, where broader ecosystem
+  conventions would reduce maintenance risk
+- JP1/AJS parameter interpretation and command generation are not yet described
+  as explicitly reference-aligned to one target manual edition
+- server-side definition loading through the JP1/AJS WebAPI is not yet part of
+  the documented product boundary
 
 ## Constraints To Preserve During Migration
 
@@ -26,6 +39,8 @@ The repository currently mixes legacy and target-oriented structure.
 - domain code must stay free of direct `vscode` imports
 - parser, list, flow, CSV, diagnostics, hover, and telemetry behavior should
   remain stable
+- dependency upgrades should be routine, but compatibility exceptions must stay
+  documented and reviewable
 
 ## Immediate Documentation Need
 
@@ -52,3 +67,17 @@ The repository already contains reusable AJS definitions in `sample/`.
 When new parser, normalization, unit-list, or flow-graph tests are added,
 prefer these shared fixtures over ad hoc inline definitions unless the test is
 specifically about a narrow edge case.
+
+## Newly Confirmed Product Direction
+
+- JP1 reference alignment should target JP1/Automatic Job Management System 3
+  version 13 documentation
+- parameter parsing should use the Definition File Reference as the normative
+  source
+- generated `ajs` command support should use the Command Reference as the
+  normative source
+- JP1/AJS WebAPI support is currently planned as read-only import of server
+  definition data
+- flow-graph improvements are currently aimed at visual resemblance to
+  JP1/AJS View, progressive nested expansion, and explicit navigation between
+  list and flow views when both are available

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -1,0 +1,26 @@
+# PLANS: align-jp1-v13-parameter-and-command-reference
+
+## Objective
+
+Move parameter interpretation and command generation onto explicit JP1/AJS3
+version 13 reference-driven contracts.
+
+## Scope
+
+- align parameter parsing with the Definition File Reference
+- separate command generation from `buildUnitDefinition.ts`
+- expand generated command support incrementally using the Command Reference
+
+## Milestones
+
+1. Identify the current parameter and command seams
+2. Define stable reusable contracts for parameter interpretation
+3. Extract command generation behind a dedicated application-facing seam
+4. Add manual-aligned coverage in small command and parameter slices
+5. Update consumers such as show-unit-definition
+
+## Validation
+
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -1,0 +1,46 @@
+# SPECS: align-jp1-v13-parameter-and-command-reference
+
+## Purpose
+
+Align parameter interpretation and `ajs` command generation to named
+JP1/AJS3 version 13 reference documents.
+
+## Origin
+
+- Source use case: docs/requirements/use-cases/uc-interpret-jp1-parameters.md
+- Source use case: docs/requirements/use-cases/uc-generate-ajs-commands.md
+- Related use case: docs/requirements/use-cases/uc-show-unit-definition.md
+
+## Acceptance Criteria
+
+- JP1/Automatic Job Management System 3 version 13 is named explicitly as the
+  target product version
+- parameter parsing scope is tied to the Definition File Reference
+- command generation scope is tied to the Command Reference
+- `buildUnitDefinition.ts` no longer needs to own command-generation logic as
+  an inseparable concern
+- reference alignment can proceed incrementally without hiding known gaps
+
+## Implementation Notes
+
+- prefer isolating reusable parameter and command semantics in domain or
+  application seams rather than viewer-specific helpers
+- keep command generation reusable so show-unit-definition is one consumer, not
+  the owner of the logic
+- when manual coverage is partial, document supported commands and remaining
+  gaps explicitly in `TASKS.md`
+- avoid bundling these reference-alignment slices with unrelated flow-graph or
+  package-manager work
+
+## Reference Documents
+
+- Definition File Reference:
+  [JP1/Automatic Job Management System 3 version 13](https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0211.HTM)
+- Command Reference:
+  [JP1/Automatic Job Management System 3 version 13](https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0067.HTM)
+
+## Non-Goals
+
+- claiming support for every JP1/AJS3 command in one change
+- mixing reference-alignment work with unrelated dependency modernization
+- hiding version-specific assumptions behind generic "latest JP1" wording

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -1,0 +1,29 @@
+# TASKS: align-jp1-v13-parameter-and-command-reference
+
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
+## Completed
+
+- [x] Record JP1/AJS3 version 13 as the target reference for parameter parsing
+  and command generation
+- [x] Record that command generation should be separated from
+  `buildUnitDefinition.ts`
+
+## Remaining Follow-up
+
+- [ ] Inventory current parameter semantics that already match the version 13
+  definition reference
+- [ ] Inventory current command-generation behavior and its coupling to
+  show-unit-definition
+- [ ] Decide the first supported set of auto-generated `ajs` commands
+- [ ] Define how manual mismatches are tracked and closed incrementally
+
+## Notes
+
+- 2026-04-18: normative parameter and command sources were fixed to the user
+  supplied JP1/AJS3 version 13 reference documents.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -10,16 +10,16 @@
 ## Completed
 
 - [x] Record JP1/AJS3 version 13 as the target reference for parameter parsing
-  and command generation
+      and command generation
 - [x] Record that command generation should be separated from
-  `buildUnitDefinition.ts`
+      `buildUnitDefinition.ts`
 
 ## Remaining Follow-up
 
 - [ ] Inventory current parameter semantics that already match the version 13
-  definition reference
+      definition reference
 - [ ] Inventory current command-generation behavior and its coupling to
-  show-unit-definition
+      show-unit-definition
 - [ ] Decide the first supported set of auto-generated `ajs` commands
 - [ ] Define how manual mismatches are tracked and closed incrementally
 

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -1,0 +1,25 @@
+# PLANS: enhance-flow-graph-experience
+
+## Objective
+
+Deliver a clearer and more navigable flow-graph experience in focused slices.
+
+## Scope
+
+- visual refresh toward JP1/AJS View
+- nested graph expansion inside one screen
+- jump actions between list and flow viewers
+
+## Milestones
+
+1. Confirm viewer-facing requirements and stable navigation identity
+2. Document the visual refresh target and its non-goals
+3. Add progressive nested-expansion behavior
+4. Add explicit list-to-flow and flow-to-list navigation actions
+5. Validate desktop and web viewer behavior
+
+## Validation
+
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/enhance-flow-graph-experience/SPECS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/SPECS.md
@@ -1,0 +1,42 @@
+# SPECS: enhance-flow-graph-experience
+
+## Purpose
+
+Improve flow-graph usability and presentation by aligning its look more closely
+to JP1/AJS View, supporting nested expansion in one screen, and adding
+navigation from and to the unit list.
+
+## Origin
+
+- Source use case: docs/requirements/use-cases/uc-build-flow-graph.md
+- Source use case:
+  docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md
+
+## Acceptance Criteria
+
+- flow-graph presentation goals are described as visual resemblance to
+  JP1/AJS View, not full interaction parity in one slice
+- nested graphs can be revealed progressively in the same screen
+- a one-click expand-all path is considered in the design, even if it lands
+  after the first incremental expansion slice
+- explicit navigation between unit-list and flow-graph units is defined when
+  the counterpart view exists
+- desktop and web compatibility remain explicit for all viewer-facing work
+
+## Implementation Notes
+
+- keep graph DTO construction separate from viewer styling and interaction
+  controls
+- prefer stable unit identity or path when coordinating list/flow navigation
+- split the work into small viewer-facing slices:
+  visual refresh, nested expansion, and cross-view navigation do not need to
+  land in one commit
+- avoid coupling the flow UI refresh to unrelated parser or command-generation
+  changes
+
+## Non-Goals
+
+- full JP1/AJS View feature parity in one slice
+- hidden dependence on `UnitEntity` reconstruction in presentation modules
+- desktop-only interaction paths that cannot be mirrored or degraded
+  predictably in web

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -10,17 +10,17 @@
 ## Completed
 
 - [x] Record the new SDD scope for flow-graph visual refresh, nested expansion,
-  and list/flow navigation
+      and list/flow navigation
 
 ## Remaining Follow-up
 
 - [ ] Define the visual cues that most matter for JP1/AJS View resemblance
 - [ ] Decide whether expand-all ships in the same slice as incremental
-  expansion or immediately after
+      expansion or immediately after
 - [ ] Document the target behavior when a counterpart list or flow view is not
-  available
+      available
 - [ ] Add focused validation plans for selection, navigation, and nested
-  expansion state
+      expansion state
 
 ## Notes
 

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -1,0 +1,28 @@
+# TASKS: enhance-flow-graph-experience
+
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
+## Completed
+
+- [x] Record the new SDD scope for flow-graph visual refresh, nested expansion,
+  and list/flow navigation
+
+## Remaining Follow-up
+
+- [ ] Define the visual cues that most matter for JP1/AJS View resemblance
+- [ ] Decide whether expand-all ships in the same slice as incremental
+  expansion or immediately after
+- [ ] Document the target behavior when a counterpart list or flow view is not
+  available
+- [ ] Add focused validation plans for selection, navigation, and nested
+  expansion state
+
+## Notes
+
+- 2026-04-18: user intent is visual resemblance first; full interaction parity
+  is explicitly out of scope for the initial slice.

--- a/docs/specs/features/import-definition-via-webapi/PLANS.md
+++ b/docs/specs/features/import-definition-via-webapi/PLANS.md
@@ -1,0 +1,25 @@
+# PLANS: import-definition-via-webapi
+
+## Objective
+
+Define and deliver the first read-only JP1/AJS WebAPI import slice.
+
+## Scope
+
+- identify the import trigger and application-facing contract
+- define infrastructure boundaries for API access
+- clarify downstream mapping into existing parsing or normalization flows
+
+## Milestones
+
+1. Confirm WebAPI scope and host constraints
+2. Define import DTOs or equivalent application-facing results
+3. Design infrastructure adapters for transport and authentication
+4. Add focused integration and compatibility checks
+5. Update docs and remaining follow-up tasks
+
+## Validation
+
+- code changes: `npm run qlty`, `npm test`, `npm run test:web`,
+  `npm run build`
+- docs-only changes: `npm run lint:md`

--- a/docs/specs/features/import-definition-via-webapi/SPECS.md
+++ b/docs/specs/features/import-definition-via-webapi/SPECS.md
@@ -1,0 +1,32 @@
+# SPECS: import-definition-via-webapi
+
+## Purpose
+
+Add a read-only JP1/AJS WebAPI import path for server-side definition data.
+
+## Origin
+
+- Source use case:
+  docs/requirements/use-cases/uc-import-ajs-definition-via-webapi.md
+
+## Acceptance Criteria
+
+- initial scope is explicitly read-only
+- application and infrastructure responsibilities are named before
+  implementation starts
+- downstream consumers do not depend directly on raw WebAPI transport objects
+- desktop and web compatibility risks are called out explicitly
+
+## Implementation Notes
+
+- keep network transport and authentication outside domain logic
+- design imported-data normalization so local-file and WebAPI-backed flows can
+  converge on stable downstream contracts where practical
+- document host-specific constraints early because browser-hosted execution may
+  not support the same connection model as desktop
+
+## Non-Goals
+
+- write or update operations against the JP1/AJS WebAPI
+- hidden assumptions that server-side definitions already match local parser
+  input byte-for-byte

--- a/docs/specs/features/import-definition-via-webapi/TASKS.md
+++ b/docs/specs/features/import-definition-via-webapi/TASKS.md
@@ -1,0 +1,25 @@
+# TASKS: import-definition-via-webapi
+
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
+## Completed
+
+- [x] Record read-only JP1/AJS WebAPI import as a planned feature slice
+
+## Remaining Follow-up
+
+- [ ] Identify the first user-visible import trigger
+- [ ] Document desktop and web host constraints for WebAPI access
+- [ ] Decide whether imported data feeds the existing parser directly or
+  requires a separate normalization seam
+- [ ] Define authentication and error-reporting expectations
+
+## Notes
+
+- 2026-04-18: scope is intentionally limited to loading server-side
+  definitions; update and save scenarios are deferred.

--- a/docs/specs/features/import-definition-via-webapi/TASKS.md
+++ b/docs/specs/features/import-definition-via-webapi/TASKS.md
@@ -16,7 +16,7 @@
 - [ ] Identify the first user-visible import trigger
 - [ ] Document desktop and web host constraints for WebAPI access
 - [ ] Decide whether imported data feeds the existing parser directly or
-  requires a separate normalization seam
+      requires a separate normalization seam
 - [ ] Define authentication and error-reporting expectations
 
 ## Notes

--- a/docs/specs/features/modernize-runtime-boundaries/PLANS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/PLANS.md
@@ -1,0 +1,29 @@
+# PLANS: modernize-runtime-boundaries
+
+## Objective
+
+Deliver the modernization slices for package management, viewer serialization,
+hashing internals, and bundle-size reduction while preserving behavior.
+
+## Scope
+
+- Plan `npm` to `pnpm` migration
+- Remove `flatted`-based payload assumptions
+- Reduce webview bundle size
+- Replace custom `UnitEntity` hashing with a common algorithm when safe
+
+## Milestones
+
+1. Document current and target runtime/tooling boundaries
+2. Split serialization cleanup from package-manager migration where useful
+3. Sequence bundle-size work after the highest-value dependency and payload
+   simplifications are identified
+4. Add or update compatibility and regression checks
+5. Close each sub-slice with explicit docs sync
+
+## Validation
+
+- code changes before `pnpm` migration lands:
+  `npm run qlty`, `npm test`, `npm run test:web`, `npm run build`
+- docs-only changes: `npm run lint:md`
+- after `pnpm` migration lands, update this section in the same commit

--- a/docs/specs/features/modernize-runtime-boundaries/SPECS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/SPECS.md
@@ -1,0 +1,41 @@
+# SPECS: modernize-runtime-boundaries
+
+## Purpose
+
+Modernize repository runtime boundaries and maintenance workflow without
+changing end-user extension behavior.
+
+## Origin
+
+This is a behavior-preserving modernization slice spanning dependency tooling,
+serialization boundaries, hashing internals, and bundle-size follow-up work.
+
+## Acceptance Criteria
+
+- package-management migration from `npm` to `pnpm` is planned explicitly and
+  does not weaken current validation expectations during transition
+- viewer payload contracts no longer require `flatted` as the default
+  serialization assumption
+- bundle-size reduction is tracked as an explicit outcome, not an implicit
+  side effect
+- `UnitEntity` hashing can move to a common algorithm without changing stable
+  identity behavior relied on by the extension
+- desktop and web compatibility risks are named before implementation work
+
+## Implementation Notes
+
+- keep package-manager migration, serialization simplification, hash migration,
+  and bundle-size reduction in reviewable slices even if they share one
+  feature umbrella
+- prioritize serialization-boundary cleanup before bundle-size tuning when the
+  same dependencies influence both concerns
+- document current-state commands separately from target-state commands while
+  the repository is in transition
+- do not combine runtime-boundary modernization with unrelated new end-user
+  features in the same slice
+
+## Non-Goals
+
+- raising `engines.vscode`
+- changing domain semantics beyond the documented internal modernization scope
+- broad UI redesign unrelated to transport or bundle constraints

--- a/docs/specs/features/modernize-runtime-boundaries/TASKS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/TASKS.md
@@ -1,0 +1,30 @@
+# TASKS: modernize-runtime-boundaries
+
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- If that change affects branch priorities or repository sequencing, update
+  `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
+
+## Completed
+
+- [x] Document the modernization scope in SDD:
+  `pnpm`, `flatted` removal, bundle-size reduction, dependency freshness, and
+  `UnitEntity` hash replacement
+
+## Remaining Follow-up
+
+- [ ] Decide the review order between `pnpm` migration and viewer
+  serialization cleanup
+- [ ] Document the current `flatted` payload seams before replacement
+- [ ] Define bundle-size measurement and acceptance thresholds
+- [ ] Identify identity and persistence checks needed before changing the hash
+  algorithm
+- [ ] Update validation commands after package-manager migration lands
+
+## Notes
+
+- 2026-04-18: repository-level policy now states that dependencies should stay
+  as current as practical, with explicit documentation when compatibility or
+  ecosystem regressions require a hold.

--- a/docs/specs/features/modernize-runtime-boundaries/TASKS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/TASKS.md
@@ -10,17 +10,17 @@
 ## Completed
 
 - [x] Document the modernization scope in SDD:
-  `pnpm`, `flatted` removal, bundle-size reduction, dependency freshness, and
-  `UnitEntity` hash replacement
+      `pnpm`, `flatted` removal, bundle-size reduction, dependency freshness, and
+      `UnitEntity` hash replacement
 
 ## Remaining Follow-up
 
 - [ ] Decide the review order between `pnpm` migration and viewer
-  serialization cleanup
+      serialization cleanup
 - [ ] Document the current `flatted` payload seams before replacement
 - [ ] Define bundle-size measurement and acceptance thresholds
 - [ ] Identify identity and persistence checks needed before changing the hash
-  algorithm
+      algorithm
 - [ ] Update validation commands after package-manager migration lands
 
 ## Notes

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -97,15 +97,25 @@ structure in `docs/specs/features/<feature>/`.
 
 ### Next Priority Tasks
 
-1. Continue treating desktop and web compatibility as an explicit acceptance
-   criterion whenever bootstrap, preview, parsing, or shared adapters change.
-2. Profile webview bundle size and evaluate deferred optimization:
-   if compatibility work is stable, consider selective tree-shaking or
-   lazy-load of lower-priority viewers.
-3. Keep feature follow-up verification evidence concrete:
+1. Plan the package-manager migration from `npm` to `pnpm` as a behavior-safe
+   infrastructure slice, while keeping validation commands explicit during the
+   transition.
+2. Remove `flatted` assumptions from viewer payloads before or alongside
+   bundle-size work so the transport contract is simpler and easier to trim.
+3. Refresh flow-graph UX in focused slices:
+   visual parity with JP1/AJS View first, then progressive nested expansion and
+   view-to-view navigation.
+4. Align parameter parsing and `ajs` command generation with
+   JP1/Automatic Job Management System 3 version 13 reference manuals.
+5. Define a read-only JP1/AJS WebAPI import boundary with clear application
+   and infrastructure responsibilities.
+6. Continue treating desktop and web compatibility as an explicit acceptance
+   criterion whenever bootstrap, preview, parsing, shared adapters, or package
+   runtime behavior change.
+7. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-4. Revisit a dedicated filter/search use case only if a second non-table
+8. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 
 ## Wrapper Semantics Matrix
@@ -163,6 +173,14 @@ model.
     needed.
 12. Summarize compatibility risks and follow-up work.
 
+Package-manager transition note:
+
+- until the `pnpm` migration slice lands, repository docs may discuss `pnpm`
+  as a target state while validation instructions still use the current
+  `npm`-based commands
+- when the migration lands, update this file, `docs/specs/README.md`, and any
+  affected feature `PLANS.md` validation sections in the same commit
+
 Docs-only exception:
 
 - `npm run build` is not required
@@ -175,3 +193,20 @@ Use-case note:
   refactors
 - `docs/specs/` is for implementation decisions, branch planning, and task
   execution
+
+## Confirmed Assumptions For Upcoming Slices
+
+- JP1 manual alignment targets JP1/Automatic Job Management System 3 version 13
+- normative parameter source:
+  [Definition File Reference](https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0211.HTM)
+- normative command source:
+  [Command Reference](https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0067.HTM)
+- JP1/AJS WebAPI scope is read-only import at first
+- flow-graph refresh targets visual resemblance to JP1/AJS View, not full
+  interaction parity in one slice
+- nested graph expansion should support both incremental reveal and one-click
+  expand-all behavior
+- unit-list and flow-graph integration currently targets explicit navigation
+  when the counterpart view exists
+- dependency freshness follows the "keep current when practical, document
+  compatibility holds when necessary" rule

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -48,10 +48,29 @@
 
 ## Current Roadmap
 
-1. Consolidate i18n translation files to reduce duplication between language
-   variants.
-2. Profile and address webview bundle size if compatibility and stability
-   goals are stable.
+1. Migrate package management from `npm` to `pnpm` without changing extension
+   behavior or weakening current validation expectations.
+2. Remove `flatted`-dependent viewer payload assumptions and simplify the
+   serialization boundary to standard JSON-safe DTOs.
+3. Profile and address webview bundle size once serialization and dependency
+   boundaries are clearer.
+4. Refresh the flow-graph presentation so its visual design is closer to
+   JP1/AJS View while preserving current desktop and web compatibility.
+5. Add progressive nested-graph expansion in the flow view, with both
+   user-driven incremental expansion and a one-click expand-all path.
+6. Add explicit navigation between unit-list and flow-graph units when the
+   counterpart view for the selected unit is available.
+7. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+   version 13 Definition File Reference.
+8. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
+   generated commands with JP1/Automatic Job Management System 3 version 13
+   Command Reference.
+9. Add a read-only JP1/AJS WebAPI import path for loading server-side
+   definition data.
+10. Replace the custom `UnitEntity` hash implementation with a common
+    algorithm once identity and compatibility checks are explicit.
+11. Consolidate i18n translation files to reduce duplication between language
+    variants.
 
 ## Deferred / Optional Slices
 
@@ -59,6 +78,10 @@
    need to be shared outside the table presentation layer.
 2. Revisit directory structure under `src/extension/webview/` only if the
    remaining files stop reading as one cohesive viewer module.
+3. Add deeper JP1/AJS View interaction parity only after the visual refresh
+   and nested expansion slices settle.
+4. Extend JP1/AJS WebAPI support beyond read-only import only after the
+   initial boundary and authentication model are stable.
 
 ## Done Criteria For A Slice
 
@@ -73,3 +96,5 @@
   roadmap priorities
 - open task lists prefer actionable remaining work over evergreen policy or
   maintenance reminders
+- when a slice depends on a JP1/AJS manual or API reference, the target
+  product version and source document are named explicitly

--- a/docs/specs/vision.md
+++ b/docs/specs/vision.md
@@ -18,3 +18,13 @@ extension for understanding job definitions.
 - fast navigation
 - maintainability
 - cross-environment support (desktop + web)
+- reference-aligned JP1/AJS behavior
+- sustainable dependency freshness
+
+## Ongoing Maintenance Policy
+
+- keep dependencies as current as practical
+- allow temporary version freezes only when needed to preserve declared
+  VS Code compatibility, web-extension compatibility, or to avoid verified
+  ecosystem regressions
+- prefer explicit documentation of version-hold reasons over silent drift


### PR DESCRIPTION
## Summary
- update repository-level SDD docs for dependency freshness, runtime modernization, and JP1/AJS3 v13 alignment
- add new use cases for list/flow navigation, JP1 parameter interpretation, command generation, and WebAPI import
- add feature slices for runtime modernization, flow-graph UX, JP1 v13 parameter and command alignment, and WebAPI import

## Validation
- npm run lint:md