### PR TITLE
Remove direct flatted dependency

### DIFF
--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -193,9 +193,9 @@ Migration should be incremental and use-case driven.
 - `src/extension/webview/messageHandlers.ts` imports `os`; webpack currently
   provides a browser fallback, but this remains an environment-specific
   adapter concern that needs continued verification
-- `src/ui-component` receives flatted JSON payloads, so serialization format
-  changes can break both desktop and web viewers even if parsing remains
-  correct
+- `src/ui-component` receives webview event payloads rebuilt from plain DTO
+  documents, so serialization-boundary changes still affect both desktop and
+  web viewers even when parsing behavior is unchanged
 
 ## Planned Boundary Tightening
 
@@ -209,8 +209,9 @@ Migration should be incremental and use-case driven.
 
 ### Serialization boundary
 
-- viewer payloads should move away from `flatted` as an implicit transport
-  contract
+- viewer payloads should stay on plain DTO and event-object transport
+  contracts instead of reintroducing `flatted`-style implicit serialization
+  assumptions
 - presentation payloads should prefer DTOs that can be serialized by standard
   JSON boundaries without circular-reference assumptions
 - serialization simplification is expected to support bundle-size reduction,

--- a/docs/specs/current-state.md
+++ b/docs/specs/current-state.md
@@ -20,8 +20,9 @@ The repository currently mixes legacy and target-oriented structure.
 - old folder names coexist with the target clean-architecture layout
 - package-management and validation workflow still assume `npm`, which makes
   lockfile strategy and dependency hygiene harder to modernize incrementally
-- webview payloads still depend on `flatted`, so viewer serialization carries
-  avoidable format coupling across desktop and web hosts
+- webview payload contracts are now plain DTOs and event objects, but some
+  specs and follow-up tasks still need to finish removing stale
+  serialization-boundary assumptions from the remaining modernization docs
 - webview bundle-size pressure remains visible in roadmap planning, especially
   while shared dependencies continue to grow
 - some legacy `UnitEntity` mechanics still rely on custom implementation

--- a/docs/specs/features/modernize-runtime-boundaries/PLANS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/PLANS.md
@@ -12,14 +12,44 @@ hashing internals, and bundle-size reduction while preserving behavior.
 - Reduce webview bundle size
 - Replace custom `UnitEntity` hashing with a common algorithm when safe
 
+## Current-State Findings
+
+- No current source file imports `flatted` directly.
+- The repository manifest no longer declares `flatted` as a direct runtime
+  dependency, though the current `package-lock.json` may still contain it as a
+  transitive dependency of tooling packages.
+- The extension-to-webview transport currently posts plain event objects via
+  `panel.webview.postMessage(...)` and `window.vscode.postMessage(...)`.
+- The main document payload seam is
+  `buildUnitList(...) -> UnitListDocumentDto -> changeDocument`:
+  `src/application/unit-list/buildUnitList.ts` constructs a DTO containing
+  only `unitAttribute`, `parameters`, and nested `children`, and both table
+  and flow viewers reconstruct normalized state through
+  `toAjsDocument(document)`.
+- Resource and save events are already string- and object-based contracts:
+  `MyAppResource`, operation names, and CSV save bodies do not require custom
+  cyclic serialization.
+
+## Ordering Decision
+
+- Review and implement viewer serialization cleanup before the `pnpm`
+  migration.
+- Treat the first modernization sub-slice as "prove and document that current
+  viewer payloads are JSON-safe DTO contracts, then remove the stale
+  dependency assumption".
+- Start `pnpm` migration only after the repository no longer carries
+  ambiguous serialization baggage in docs or manifests; this keeps package
+  manager diffs focused on tooling behavior instead of mixed runtime cleanup.
+
 ## Milestones
 
 1. Document current and target runtime/tooling boundaries
-2. Split serialization cleanup from package-manager migration where useful
-3. Sequence bundle-size work after the highest-value dependency and payload
+2. Remove stale `flatted` assumptions from viewer payload docs and manifests
+3. Migrate package management from `npm` to `pnpm` with validation parity
+4. Sequence bundle-size work after the highest-value dependency and payload
    simplifications are identified
-4. Add or update compatibility and regression checks
-5. Close each sub-slice with explicit docs sync
+5. Add or update compatibility and regression checks
+6. Close each sub-slice with explicit docs sync
 
 ## Validation
 
@@ -27,3 +57,10 @@ hashing internals, and bundle-size reduction while preserving behavior.
   `npm run qlty`, `npm test`, `npm run test:web`, `npm run build`
 - docs-only changes: `npm run lint:md`
 - after `pnpm` migration lands, update this section in the same commit
+
+## This Slice
+
+- Remove the direct `flatted` dependency from `package.json`
+- Keep `package-lock.json` aligned with the current npm toolchain state
+- Sync modernization docs so they describe DTO-based viewer payloads instead
+  of obsolete `flatted` transport coupling

--- a/docs/specs/features/modernize-runtime-boundaries/TASKS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/TASKS.md
@@ -12,12 +12,19 @@
 - [x] Document the modernization scope in SDD:
       `pnpm`, `flatted` removal, bundle-size reduction, dependency freshness, and
       `UnitEntity` hash replacement
+- [x] Decide the review order between viewer serialization cleanup and
+      `pnpm` migration:
+      remove stale `flatted` assumptions first so package-manager diffs stay
+      tooling-focused
+- [x] Document the current `flatted` payload seams before replacement:
+      current webview transport uses plain event objects and a
+      `UnitListDocumentDto` payload that is rebuilt into normalized state in
+      the viewers
+- [x] Remove the direct `flatted` dependency from repository manifests and
+      align the modernization docs with the current DTO-based transport seam
 
 ## Remaining Follow-up
 
-- [ ] Decide the review order between `pnpm` migration and viewer
-      serialization cleanup
-- [ ] Document the current `flatted` payload seams before replacement
 - [ ] Define bundle-size measurement and acceptance thresholds
 - [ ] Identify identity and persistence checks needed before changing the hash
       algorithm
@@ -28,3 +35,10 @@
 - 2026-04-18: repository-level policy now states that dependencies should stay
   as current as practical, with explicit documentation when compatibility or
   ecosystem regressions require a hold.
+- 2026-04-18: current implementation evidence for the serialization seam is
+  `buildUnitList(...) -> UnitListDocumentDto -> panel.webview.postMessage`
+  on the extension side, followed by `toAjsDocument(document)` in both table
+  and flow viewers.
+- 2026-04-18: after `npm uninstall flatted`, the package manifest no longer
+  declares `flatted` directly; remaining lockfile entries are currently
+  transitive tooling dependencies rather than viewer transport requirements.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -97,11 +97,12 @@ structure in `docs/specs/features/<feature>/`.
 
 ### Next Priority Tasks
 
-1. Plan the package-manager migration from `npm` to `pnpm` as a behavior-safe
-   infrastructure slice, while keeping validation commands explicit during the
-   transition.
-2. Remove `flatted` assumptions from viewer payloads before or alongside
-   bundle-size work so the transport contract is simpler and easier to trim.
+1. Remove stale `flatted` assumptions from viewer payload docs and manifests
+   first, now that the current transport seam is documented as plain DTOs and
+   postMessage event objects rather than cyclic runtime state.
+2. Plan the package-manager migration from `npm` to `pnpm` as a behavior-safe
+   infrastructure slice after the serialization boundary is simplified, while
+   keeping validation commands explicit during the transition.
 3. Refresh flow-graph UX in focused slices:
    visual parity with JP1/AJS View first, then progressive nested expansion and
    view-to-view navigation.
@@ -177,7 +178,8 @@ Package-manager transition note:
 
 - until the `pnpm` migration slice lands, repository docs may discuss `pnpm`
   as a target state while validation instructions still use the current
-  `npm`-based commands
+  `npm`-based commands; serialization cleanup may remove stale dependencies
+  first if it reduces the package-manager diff surface
 - when the migration lands, update this file, `docs/specs/README.md`, and any
   affected feature `PLANS.md` validation sections in the same commit
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -48,10 +48,10 @@
 
 ## Current Roadmap
 
-1. Migrate package management from `npm` to `pnpm` without changing extension
-   behavior or weakening current validation expectations.
-2. Remove `flatted`-dependent viewer payload assumptions and simplify the
+1. Remove `flatted`-dependent viewer payload assumptions and simplify the
    serialization boundary to standard JSON-safe DTOs.
+2. Migrate package management from `npm` to `pnpm` without changing extension
+   behavior or weakening current validation expectations.
 3. Profile and address webview bundle size once serialization and dependency
    boundaries are clearer.
 4. Refresh the flow-graph presentation so its visual design is closer to

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "antlr4ts": "^0.5.0-alpha.4",
         "assert": "^2.1.0",
         "classnames": "^2.5.1",
-        "flatted": "^3.3.3",
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
         "react": "^19.2.0",
@@ -5459,6 +5458,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/for-each": {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,6 @@
     "antlr4ts": "^0.5.0-alpha.4",
     "assert": "^2.1.0",
     "classnames": "^2.5.1",
-    "flatted": "^3.3.3",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "react": "^19.2.0",


### PR DESCRIPTION
## Summary
- remove the direct flatted dependency from package.json
- keep the npm lockfile aligned after uninstalling the unused direct dependency
- sync SDD docs to describe the current DTO-based webview transport and the runtime-boundaries ordering decision

## Validation
- npm run lint:md
- npm run qlty
- npm test
- npm run test:web
- npm run build

## Notes
- flatted still appears in package-lock.json as a transitive tooling dependency via flat-cache; this PR only removes the repository direct dependency and stale transport assumptions.
- npm run build still reports the existing webpack asset-size warnings for index.js and web.js.