### PR TITLE
docs: define bundle size thresholds

### DIFF
--- a/docs/specs/features/modernize-runtime-boundaries/PLANS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/PLANS.md
@@ -45,8 +45,9 @@ hashing internals, and bundle-size reduction while preserving behavior.
 1. Document current and target runtime/tooling boundaries
 2. Remove stale `flatted` assumptions from viewer payload docs and manifests
 3. Migrate package management from `npm` to `pnpm` with validation parity
-4. Define bundle-size measurement and acceptance thresholds after the
-   highest-value dependency and payload simplifications are identified
+4. Profile the current shared webview bundle and choose the first shrinking
+   refactor after the highest-value dependency and payload simplifications are
+   identified
 5. Add or update compatibility and regression checks
 6. Close each sub-slice with explicit docs sync
 
@@ -58,21 +59,21 @@ hashing internals, and bundle-size reduction while preserving behavior.
 
 ## This Slice
 
-- Document the primary bundle-size seam as the production webview bundle
-  `out/index.js`, with `out/web.js` and `out/extension.js` tracked as
-  secondary guards when shared runtime imports change
-- Standardize the measurement commands:
+- Reframe bundle-size work as payload-shrinking refactors, not only growth
+  control
+- Record the current reduction target after the `flatted` cleanup and `pnpm`
+  migration:
+  the shared viewer bundle `out/index.js` is 9,166,525 bytes raw and
+  2,362,382 bytes gzip because one webview entry currently imports both
+  `AjsTableViewerApp` and `AjsFlowViewerApp`
+- Name the first refactor candidate explicitly:
+  split the current single viewer entry so table and flow webviews stop
+  shipping each other's code by default
+- Keep the measurement commands only as evidence for shrinking work:
   `pnpm run build` for production output byte counts and
   `pnpm run build -- --env analyzer=true` for static analyzer reports in
   `report/`
-- Record the 2026-04-18 baseline after the `flatted` cleanup and `pnpm`
-  migration:
-  `out/index.js` = 9,166,525 bytes raw, 2,362,382 bytes gzip
-- Set review thresholds for future slices:
-  keep routine changes within +5% of the current `out/index.js` raw and gzip
-  baseline, and require an explicit SDD note plus analyzer evidence for
-  larger increases
-- Set escalation thresholds for future slices:
-  treat `out/index.js` above 10,000,000 bytes raw or 2,500,000 bytes gzip as
-  a stop-and-review condition before merge, even if behavior is otherwise
-  correct
+- Treat follow-up candidates as code-removal work, not budget bureaucracy:
+  trim flow-only libraries from the table path, reduce MUI icon fan-out, and
+  isolate browser fallbacks like `os-browserify` to the paths that still need
+  them

--- a/docs/specs/features/modernize-runtime-boundaries/PLANS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/PLANS.md
@@ -45,8 +45,8 @@ hashing internals, and bundle-size reduction while preserving behavior.
 1. Document current and target runtime/tooling boundaries
 2. Remove stale `flatted` assumptions from viewer payload docs and manifests
 3. Migrate package management from `npm` to `pnpm` with validation parity
-4. Sequence bundle-size work after the highest-value dependency and payload
-   simplifications are identified
+4. Define bundle-size measurement and acceptance thresholds after the
+   highest-value dependency and payload simplifications are identified
 5. Add or update compatibility and regression checks
 6. Close each sub-slice with explicit docs sync
 
@@ -58,8 +58,21 @@ hashing internals, and bundle-size reduction while preserving behavior.
 
 ## This Slice
 
-- Pin the repository package manager with `packageManager: pnpm@10.33.0`
-- Replace `package-lock.json` with `pnpm-lock.yaml`
-- Update GitHub Actions and contributor docs to use `pnpm` consistently
-- Keep build, desktop test, web test, and markdown lint validation explicit
-  during the migration
+- Document the primary bundle-size seam as the production webview bundle
+  `out/index.js`, with `out/web.js` and `out/extension.js` tracked as
+  secondary guards when shared runtime imports change
+- Standardize the measurement commands:
+  `pnpm run build` for production output byte counts and
+  `pnpm run build -- --env analyzer=true` for static analyzer reports in
+  `report/`
+- Record the 2026-04-18 baseline after the `flatted` cleanup and `pnpm`
+  migration:
+  `out/index.js` = 9,166,525 bytes raw, 2,362,382 bytes gzip
+- Set review thresholds for future slices:
+  keep routine changes within +5% of the current `out/index.js` raw and gzip
+  baseline, and require an explicit SDD note plus analyzer evidence for
+  larger increases
+- Set escalation thresholds for future slices:
+  treat `out/index.js` above 10,000,000 bytes raw or 2,500,000 bytes gzip as
+  a stop-and-review condition before merge, even if behavior is otherwise
+  correct

--- a/docs/specs/features/modernize-runtime-boundaries/SPECS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/SPECS.md
@@ -16,8 +16,9 @@ serialization boundaries, hashing internals, and bundle-size follow-up work.
   does not weaken current validation expectations during transition
 - viewer payload contracts no longer require `flatted` as the default
   serialization assumption
-- bundle-size reduction is tracked as an explicit outcome, not an implicit
-  side effect
+- bundle-size follow-up names an explicit measurement seam, baseline commands,
+  and review thresholds instead of treating size changes as an implicit side
+  effect
 - `UnitEntity` hashing can move to a common algorithm without changing stable
   identity behavior relied on by the extension
 - desktop and web compatibility risks are named before implementation work
@@ -29,6 +30,11 @@ serialization boundaries, hashing internals, and bundle-size follow-up work.
   feature umbrella
 - prioritize serialization-boundary cleanup before bundle-size tuning when the
   same dependencies influence both concerns
+- treat the webview viewer bundle `out/index.js` as the primary size budget
+  because it is the shared entry point for the table and flow viewers
+- use `webpack-bundle-analyzer` reports as the required evidence for any
+  slice that materially increases bundle size or adds a heavy shared
+  dependency
 - document current-state commands separately from target-state commands while
   the repository is in transition
 - do not combine runtime-boundary modernization with unrelated new end-user

--- a/docs/specs/features/modernize-runtime-boundaries/SPECS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/SPECS.md
@@ -16,9 +16,9 @@ serialization boundaries, hashing internals, and bundle-size follow-up work.
   does not weaken current validation expectations during transition
 - viewer payload contracts no longer require `flatted` as the default
   serialization assumption
-- bundle-size follow-up names an explicit measurement seam, baseline commands,
-  and review thresholds instead of treating size changes as an implicit side
-  effect
+- bundle-size follow-up names concrete refactoring seams that are expected to
+  shrink the shipped webview payload, with measurement serving as evidence
+  rather than the primary outcome
 - `UnitEntity` hashing can move to a common algorithm without changing stable
   identity behavior relied on by the extension
 - desktop and web compatibility risks are named before implementation work
@@ -30,11 +30,14 @@ serialization boundaries, hashing internals, and bundle-size follow-up work.
   feature umbrella
 - prioritize serialization-boundary cleanup before bundle-size tuning when the
   same dependencies influence both concerns
-- treat the webview viewer bundle `out/index.js` as the primary size budget
-  because it is the shared entry point for the table and flow viewers
-- use `webpack-bundle-analyzer` reports as the required evidence for any
-  slice that materially increases bundle size or adds a heavy shared
-  dependency
+- treat the current shared webview viewer bundle `out/index.js` as the main
+  reduction target because it eagerly includes both table and flow viewer
+  trees behind one entry point
+- prefer refactors that remove code from the shipped viewer path, especially
+  entry-point splitting, host-specific adapter isolation, and dependency
+  narrowing around MUI icon usage and flow-only libraries
+- use `webpack-bundle-analyzer` reports and production byte counts as proof
+  that a reduction slice actually shrank the delivered payload
 - document current-state commands separately from target-state commands while
   the repository is in transition
 - do not combine runtime-boundary modernization with unrelated new end-user

--- a/docs/specs/features/modernize-runtime-boundaries/TASKS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/TASKS.md
@@ -28,14 +28,16 @@
 
 ## Remaining Follow-up
 
-- [x] Define bundle-size measurement and acceptance thresholds:
-      measure production output with `pnpm run build`, capture analyzer
-      evidence with `pnpm run build -- --env analyzer=true`, treat
-      `out/index.js` as the primary webview budget, and use the
-      2026-04-18 baseline (`9,166,525` raw / `2,362,382` gzip) with
-      +5% review and `10,000,000` raw / `2,500,000` gzip escalation limits
-- [ ] Profile the largest contributors in `report/index_report.html` and
-      choose the first concrete bundle-reduction slice
+- [x] Re-scope bundle-size follow-up around shrinking refactors rather than
+      only guarding growth:
+      record the 2026-04-18 baseline for `out/index.js`, keep analyzer output
+      as evidence, and identify the current single-entry viewer bundle as the
+      first concrete reduction target
+- [ ] Split the shared viewer entry so table and flow webviews can ship
+      separate bundles instead of always loading both `AjsTableViewerApp` and
+      `AjsFlowViewerApp`
+- [ ] Profile the largest contributors after entry splitting and choose the
+      next concrete shrinking slice
 - [ ] Identify identity and persistence checks needed before changing the hash
       algorithm
 
@@ -54,11 +56,10 @@
 - 2026-04-18: `pnpm` migration pins `packageManager: pnpm@10.33.0`, replaces
   `package-lock.json` with `pnpm-lock.yaml`, and switches local plus CI
   validation commands to `pnpm`.
-- 2026-04-18: bundle-size measurement now treats `out/index.js` as the
-  primary viewer budget because both table and flow viewers load the same
-  webview bundle, while `out/web.js` and `out/extension.js` stay secondary
-  guards for shared runtime drift.
+- 2026-04-18: bundle-size follow-up is now framed as webview-payload
+  reduction; measurement exists to prove shrinkage, not to substitute for the
+  refactor itself.
 - 2026-04-18: the post-migration baseline is `out/index.js` =
-  `9,166,525` bytes raw and `2,362,382` bytes gzip; routine slices should
-  stay within +5% unless the SDD docs record an explicit exception with
-  analyzer evidence.
+  `9,166,525` bytes raw and `2,362,382` bytes gzip, and the strongest current
+  hypothesis is that the single viewer entry point keeps both table and flow
+  trees in the shipped bundle.

--- a/docs/specs/features/modernize-runtime-boundaries/TASKS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/TASKS.md
@@ -28,7 +28,14 @@
 
 ## Remaining Follow-up
 
-- [ ] Define bundle-size measurement and acceptance thresholds
+- [x] Define bundle-size measurement and acceptance thresholds:
+      measure production output with `pnpm run build`, capture analyzer
+      evidence with `pnpm run build -- --env analyzer=true`, treat
+      `out/index.js` as the primary webview budget, and use the
+      2026-04-18 baseline (`9,166,525` raw / `2,362,382` gzip) with
+      +5% review and `10,000,000` raw / `2,500,000` gzip escalation limits
+- [ ] Profile the largest contributors in `report/index_report.html` and
+      choose the first concrete bundle-reduction slice
 - [ ] Identify identity and persistence checks needed before changing the hash
       algorithm
 
@@ -47,3 +54,11 @@
 - 2026-04-18: `pnpm` migration pins `packageManager: pnpm@10.33.0`, replaces
   `package-lock.json` with `pnpm-lock.yaml`, and switches local plus CI
   validation commands to `pnpm`.
+- 2026-04-18: bundle-size measurement now treats `out/index.js` as the
+  primary viewer budget because both table and flow viewers load the same
+  webview bundle, while `out/web.js` and `out/extension.js` stay secondary
+  guards for shared runtime drift.
+- 2026-04-18: the post-migration baseline is `out/index.js` =
+  `9,166,525` bytes raw and `2,362,382` bytes gzip; routine slices should
+  stay within +5% unless the SDD docs record an explicit exception with
+  analyzer evidence.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -90,11 +90,10 @@ structure in `docs/specs/features/<feature>/`.
   stale `flatted` transport assumptions were removed from manifests and docs,
   and package management now uses pinned `pnpm` metadata plus
   `pnpm-lock.yaml` with matching CI and contributor workflow updates.
-- Runtime-boundary modernization now has an explicit bundle budget:
-  production size measurement is anchored on `out/index.js` with analyzer
-  reports in `report/`, the 2026-04-18 baseline is recorded, and future
-  slices use +5% review plus 10,000,000 raw / 2,500,000 gzip escalation
-  thresholds instead of treating bundle growth as an untracked side effect.
+- Runtime-boundary modernization now has an explicit bundle-reduction target:
+  the shared viewer bundle `out/index.js` is the first shrinking seam, its
+  2026-04-18 baseline is recorded for evidence, and the next concrete refactor
+  is to stop shipping table and flow viewer code through one entry by default.
 
 ### How To Maintain This Section
 
@@ -109,22 +108,24 @@ structure in `docs/specs/features/<feature>/`.
 
 ### Next Priority Tasks
 
-1. Profile and reduce the largest webview bundle contributors using the new
-   measurement baseline and thresholds.
-2. Refresh flow-graph UX in focused slices:
+1. Split the shared viewer entry so table and flow webviews can load
+   narrower bundles before deeper dependency cleanup.
+2. Profile and reduce the next-largest webview bundle contributors after
+   entry splitting.
+3. Refresh flow-graph UX in focused slices:
    visual parity with JP1/AJS View first, then progressive nested expansion and
    view-to-view navigation.
-3. Align parameter parsing and `ajs` command generation with
+4. Align parameter parsing and `ajs` command generation with
    JP1/Automatic Job Management System 3 version 13 reference manuals.
-4. Define a read-only JP1/AJS WebAPI import boundary with clear application
+5. Define a read-only JP1/AJS WebAPI import boundary with clear application
    and infrastructure responsibilities.
-5. Continue treating desktop and web compatibility as an explicit acceptance
+6. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, shared adapters, or package
    runtime behavior change.
-6. Keep feature follow-up verification evidence concrete:
+7. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-7. Revisit a dedicated filter/search use case only if a second non-table
+8. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 
 ## Wrapper Semantics Matrix

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -90,6 +90,11 @@ structure in `docs/specs/features/<feature>/`.
   stale `flatted` transport assumptions were removed from manifests and docs,
   and package management now uses pinned `pnpm` metadata plus
   `pnpm-lock.yaml` with matching CI and contributor workflow updates.
+- Runtime-boundary modernization now has an explicit bundle budget:
+  production size measurement is anchored on `out/index.js` with analyzer
+  reports in `report/`, the 2026-04-18 baseline is recorded, and future
+  slices use +5% review plus 10,000,000 raw / 2,500,000 gzip escalation
+  thresholds instead of treating bundle growth as an untracked side effect.
 
 ### How To Maintain This Section
 
@@ -104,8 +109,8 @@ structure in `docs/specs/features/<feature>/`.
 
 ### Next Priority Tasks
 
-1. Define bundle-size measurement and acceptance thresholds now that
-   serialization cleanup and package-manager migration have landed.
+1. Profile and reduce the largest webview bundle contributors using the new
+   measurement baseline and thresholds.
 2. Refresh flow-graph UX in focused slices:
    visual parity with JP1/AJS View first, then progressive nested expansion and
    view-to-view navigation.

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -51,32 +51,33 @@
 21. Migrate package management from `npm` to `pnpm` with a pinned
     `packageManager`, committed `pnpm-lock.yaml`, and matching CI plus
     contributor workflow updates.
-22. Define bundle-size measurement and acceptance thresholds for the shared
-    webview bundle so future runtime and UI slices can be reviewed against an
-    explicit budget instead of bundle growth being incidental.
+22. Reframe bundle-size work around webview-payload reduction:
+    record the current shared viewer baseline as evidence, then target
+    concrete shrinking refactors instead of only guarding against regressions.
 
 ## Current Roadmap
 
-1. Profile and reduce the largest webview bundle contributors now that
-   serialization, package-manager, and measurement-budget groundwork is in
-   place.
-2. Refresh the flow-graph presentation so its visual design is closer to
+1. Split the shared viewer entry so table and flow webviews no longer ship
+   each other's code by default.
+2. Profile and reduce the next-largest webview bundle contributors after the
+   entry split lands.
+3. Refresh the flow-graph presentation so its visual design is closer to
    JP1/AJS View while preserving current desktop and web compatibility.
-3. Add progressive nested-graph expansion in the flow view, with both
+4. Add progressive nested-graph expansion in the flow view, with both
    user-driven incremental expansion and a one-click expand-all path.
-4. Add explicit navigation between unit-list and flow-graph units when the
+5. Add explicit navigation between unit-list and flow-graph units when the
    counterpart view for the selected unit is available.
-5. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+6. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
-6. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
+7. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
    generated commands with JP1/Automatic Job Management System 3 version 13
    Command Reference.
-7. Add a read-only JP1/AJS WebAPI import path for loading server-side
+8. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
-8. Replace the custom `UnitEntity` hash implementation with a common
+9. Replace the custom `UnitEntity` hash implementation with a common
    algorithm once identity and compatibility checks are explicit.
-9. Consolidate i18n translation files to reduce duplication between language
-   variants.
+10. Consolidate i18n translation files to reduce duplication between language
+    variants.
 
 ## Deferred / Optional Slices
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -51,11 +51,15 @@
 21. Migrate package management from `npm` to `pnpm` with a pinned
     `packageManager`, committed `pnpm-lock.yaml`, and matching CI plus
     contributor workflow updates.
+22. Define bundle-size measurement and acceptance thresholds for the shared
+    webview bundle so future runtime and UI slices can be reviewed against an
+    explicit budget instead of bundle growth being incidental.
 
 ## Current Roadmap
 
-1. Profile and address webview bundle size once serialization and dependency
-   boundaries are clearer.
+1. Profile and reduce the largest webview bundle contributors now that
+   serialization, package-manager, and measurement-budget groundwork is in
+   place.
 2. Refresh the flow-graph presentation so its visual design is closer to
    JP1/AJS View while preserving current desktop and web compatibility.
 3. Add progressive nested-graph expansion in the flow view, with both


### PR DESCRIPTION
## Summary
- define the primary bundle-size measurement seam for runtime-boundary modernization
- record the 2026-04-18 production baseline for \
- update roadmap and branch plans so the next slice is profiling the largest contributors

## Validation
- corepack pnpm run lint:md
- corepack pnpm exec markdownlint-cli2 docs/specs/roadmap.md docs/specs/plans.md docs/specs/features/modernize-runtime-boundaries/SPECS.md docs/specs/features/modernize-runtime-boundaries/PLANS.md docs/specs/features/modernize-runtime-boundaries/TASKS.md