### PR TITLE
Document viewer bundle profiling findings

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+sandbox_mode = "workspace-write"
+
+[sandbox_workspace_write]
+network_access = true

--- a/docs/specs/features/modernize-runtime-boundaries/PLANS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/PLANS.md
@@ -87,3 +87,20 @@ hashing internals, and bundle-size reduction while preserving behavior.
 - Next shrinking slice:
   profile the separated bundles to identify the largest remaining
   table-only and flow-only contributors before choosing another refactor
+- 2026-04-18 profiling evidence after the split:
+  webpack stats and analyzer output show that the largest remaining shared
+  contributor in both viewer bundles is `@mui/*`
+  (`tableViewer`: about 1,036,500 parsed bytes inside the concatenated viewer
+  module, `flowViewer`: about 853,234), while the largest viewer-specific
+  contributors are `@tanstack/table-core` plus `react-virtuoso` for table and
+  `@xyflow/react` plus `@xyflow/system` for flow
+- 2026-04-18 import-shape finding:
+  viewer components still import many controls from the `@mui/material`
+  barrel rather than path-specific entry points, so the first follow-up worth
+  testing is a focused import-narrowing slice before deeper UI-library
+  replacement discussions
+- Next concrete shrinking slice after profiling:
+  replace viewer-side `@mui/material` barrel imports with path imports,
+  re-measure `tableViewer.js` and `flowViewer.js`, then decide whether the
+  next target should be table virtualization (`react-virtuoso`) or flow graph
+  libraries (`@xyflow/*`)

--- a/docs/specs/features/modernize-runtime-boundaries/TASKS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/TASKS.md
@@ -36,8 +36,11 @@
 - [x] Split the shared viewer entry so table and flow webviews can ship
       separate bundles instead of always loading both `AjsTableViewerApp` and
       `AjsFlowViewerApp`
-- [ ] Profile the largest contributors after entry splitting and choose the
+- [x] Profile the largest contributors after entry splitting and choose the
       next concrete shrinking slice
+- [ ] Narrow viewer-side `@mui/material` imports away from barrel imports and
+      re-measure both bundles before choosing a viewer-specific dependency
+      reduction slice
 - [ ] Identify identity and persistence checks needed before changing the hash
       algorithm
 
@@ -67,3 +70,14 @@
   `737,279` bytes raw / `219,019` bytes gzip and `out/flowViewer.js` =
   `711,195` bytes raw / `217,051` bytes gzip; the next follow-up is to
   inspect which dependencies still dominate each bundle separately.
+- 2026-04-18: profiling with analyzer output plus webpack stats showed that
+  `@mui/*` remains the largest shared contributor in both viewer bundles
+  (about `1,036,500` parsed bytes in `tableViewer`, `853,234` in
+  `flowViewer`), while table-specific weight is led by
+  `@tanstack/table-core` (`138,845`) and `react-virtuoso` (`91,018`) and
+  flow-specific weight is led by `@xyflow/react` (`220,733`) and
+  `@xyflow/system` (`148,183`).
+- 2026-04-18: source imports still show broad `@mui/material` barrel usage
+  across table and flow viewer components, so the next shrinking slice is to
+  convert those imports to path imports and measure whether the shared MUI
+  footprint drops before targeting `react-virtuoso` or `@xyflow/*`.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -103,6 +103,15 @@ structure in `docs/specs/features/<feature>/`.
   `out/flowViewer.js` is 711,195 bytes raw / 217,051 bytes gzip, so the next
   bundle-size slice should profile each viewer separately rather than treating
   the webview payload as one monolith.
+- Post-split profiling evidence is now explicit:
+  `@mui/*` is the largest remaining shared contributor in both viewer bundles,
+  while `@tanstack/table-core` plus `react-virtuoso` dominate the table-only
+  remainder and `@xyflow/react` plus `@xyflow/system` dominate the flow-only
+  remainder.
+- The next concrete shrinking slice is narrower than a broad library swap:
+  first replace viewer-side `@mui/material` barrel imports with path imports,
+  then re-measure before choosing whether table virtualization or flow-graph
+  libraries deserve the next targeted reduction.
 
 ### How To Maintain This Section
 
@@ -119,20 +128,22 @@ structure in `docs/specs/features/<feature>/`.
 
 1. Profile and reduce the next-largest webview bundle contributors after
    entry splitting.
-2. Refresh flow-graph UX in focused slices:
+2. Narrow viewer-side `@mui/material` imports and re-measure bundle impact
+   before larger dependency changes.
+3. Refresh flow-graph UX in focused slices:
    visual parity with JP1/AJS View first, then progressive nested expansion and
    view-to-view navigation.
-3. Align parameter parsing and `ajs` command generation with
+4. Align parameter parsing and `ajs` command generation with
    JP1/Automatic Job Management System 3 version 13 reference manuals.
-4. Define a read-only JP1/AJS WebAPI import boundary with clear application
+5. Define a read-only JP1/AJS WebAPI import boundary with clear application
    and infrastructure responsibilities.
-5. Continue treating desktop and web compatibility as an explicit acceptance
+6. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, shared adapters, or package
    runtime behavior change.
-6. Keep feature follow-up verification evidence concrete:
+7. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-7. Revisit a dedicated filter/search use case only if a second non-table
+8. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 
 ## Wrapper Semantics Matrix

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -59,25 +59,29 @@
 
 ## Current Roadmap
 
-1. Profile and reduce the next-largest webview bundle contributors after the
-   viewer entry split.
-2. Refresh the flow-graph presentation so its visual design is closer to
+1. Narrow viewer-side `@mui/material` imports away from barrel imports and
+   re-measure both webview bundles before deeper dependency changes.
+2. Revisit table-side `react-virtuoso` and TanStack payload cost after the
+   shared MUI import shape is narrowed.
+3. Revisit flow-side `@xyflow/*` payload cost after the shared MUI import
+   shape is narrowed.
+4. Refresh the flow-graph presentation so its visual design is closer to
    JP1/AJS View while preserving current desktop and web compatibility.
-3. Add progressive nested-graph expansion in the flow view, with both
+5. Add progressive nested-graph expansion in the flow view, with both
    user-driven incremental expansion and a one-click expand-all path.
-4. Add explicit navigation between unit-list and flow-graph units when the
+6. Add explicit navigation between unit-list and flow-graph units when the
    counterpart view for the selected unit is available.
-5. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+7. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
-6. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
+8. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
    generated commands with JP1/Automatic Job Management System 3 version 13
    Command Reference.
-7. Add a read-only JP1/AJS WebAPI import path for loading server-side
+9. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
-8. Replace the custom `UnitEntity` hash implementation with a common
-   algorithm once identity and compatibility checks are explicit.
-9. Consolidate i18n translation files to reduce duplication between language
-   variants.
+10. Replace the custom `UnitEntity` hash implementation with a common
+    algorithm once identity and compatibility checks are explicit.
+11. Consolidate i18n translation files to reduce duplication between language
+    variants.
 
 ## Deferred / Optional Slices
 


### PR DESCRIPTION
## Summary
- document the post-split webview bundle profiling findings for the runtime-boundary slice
- record that `@mui/*` is the largest remaining shared contributor across both viewer bundles
- set the next concrete shrinking slice to narrow `@mui/material` barrel imports before targeting viewer-specific libraries
- include the current `.codex/config.toml` in the branch state as requested

## Validation
- `corepack pnpm exec webpack --mode production --env analyzer=true`
- `corepack pnpm exec webpack --mode production --profile --json`
- `corepack pnpm run lint:md`

## Notes
- profiling evidence recorded in docs:
  - `tableViewer`: `@mui/*` about `1,036,500` parsed bytes, then `@tanstack/table-core` and `react-virtuoso`
  - `flowViewer`: `@mui/*` about `853,234` parsed bytes, then `@xyflow/react` and `@xyflow/system`
- this is a docs-only SDD slice; no runtime code changes are included
