### PR TITLE
Narrow viewer MUI imports

### DIFF
--- a/docs/specs/features/modernize-runtime-boundaries/TASKS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/TASKS.md
@@ -38,7 +38,7 @@
       `AjsFlowViewerApp`
 - [x] Profile the largest contributors after entry splitting and choose the
       next concrete shrinking slice
-- [ ] Narrow viewer-side `@mui/material` imports away from barrel imports and
+- [x] Narrow viewer-side `@mui/material` imports away from barrel imports and
       re-measure both bundles before choosing a viewer-specific dependency
       reduction slice
 - [ ] Identify identity and persistence checks needed before changing the hash
@@ -81,3 +81,14 @@
   across table and flow viewer components, so the next shrinking slice is to
   convert those imports to path imports and measure whether the shared MUI
   footprint drops before targeting `react-virtuoso` or `@xyflow/*`.
+- 2026-04-18: viewer-side `@mui/material` barrel imports were replaced with
+  path imports across table and flow components plus the focused flow-graph
+  regression test, and production re-measurement now reports
+  `out/tableViewer.js` = `737279` bytes raw / `218908` bytes gzip and
+  `out/flowViewer.js` = `711123` bytes raw / `216983` bytes gzip when built
+  through the current `corepack pnpm run build` pipeline.
+- 2026-04-18: path-import narrowing did not reduce emitted production bytes
+  under the current MUI and webpack setup, so the next bundle-size follow-up
+  should move to viewer-specific dependencies such as `react-virtuoso` on the
+  table side or `@xyflow/*` on the flow side rather than spending another
+  slice on the same import shape.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -112,6 +112,13 @@ structure in `docs/specs/features/<feature>/`.
   first replace viewer-side `@mui/material` barrel imports with path imports,
   then re-measure before choosing whether table virtualization or flow-graph
   libraries deserve the next targeted reduction.
+- Viewer-side `@mui/material` import narrowing is now complete:
+  table and flow components use path imports instead of the shared barrel, but
+  the resulting production build still measures `out/tableViewer.js` at
+  737,279 bytes raw / 218,908 bytes gzip and `out/flowViewer.js` at
+  711,123 bytes raw / 216,983 bytes gzip, so the next bundle-size slice
+  should target viewer-specific dependencies instead of more MUI import-shape
+  work.
 
 ### How To Maintain This Section
 
@@ -126,10 +133,10 @@ structure in `docs/specs/features/<feature>/`.
 
 ### Next Priority Tasks
 
-1. Profile and reduce the next-largest webview bundle contributors after
-   entry splitting.
-2. Narrow viewer-side `@mui/material` imports and re-measure bundle impact
-   before larger dependency changes.
+1. Reduce the next-largest viewer-specific webview bundle contributors now
+   that MUI import narrowing has been measured.
+2. Compare table-side `react-virtuoso` and TanStack cost against flow-side
+   `@xyflow/*` cost to choose the next shrinking slice.
 3. Refresh flow-graph UX in focused slices:
    visual parity with JP1/AJS View first, then progressive nested expansion and
    view-to-view navigation.

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -56,31 +56,32 @@
     concrete shrinking refactors instead of only guarding against regressions.
 23. Split the shared webview entry into dedicated table and flow bundles so
     each viewer stops shipping the other viewer tree by default.
+24. Re-measure viewer-side `@mui/material` path imports after bundle
+    splitting and use that evidence to decide whether the next reduction
+    target should move to table-only or flow-only dependencies.
 
 ## Current Roadmap
 
-1. Narrow viewer-side `@mui/material` imports away from barrel imports and
-   re-measure both webview bundles before deeper dependency changes.
-2. Revisit table-side `react-virtuoso` and TanStack payload cost after the
-   shared MUI import shape is narrowed.
-3. Revisit flow-side `@xyflow/*` payload cost after the shared MUI import
-   shape is narrowed.
-4. Refresh the flow-graph presentation so its visual design is closer to
+1. Revisit table-side `react-virtuoso` and TanStack payload cost now that the
+   shared MUI import-shape experiment is complete.
+2. Revisit flow-side `@xyflow/*` payload cost now that the shared MUI import
+   shape experiment is complete.
+3. Refresh the flow-graph presentation so its visual design is closer to
    JP1/AJS View while preserving current desktop and web compatibility.
-5. Add progressive nested-graph expansion in the flow view, with both
+4. Add progressive nested-graph expansion in the flow view, with both
    user-driven incremental expansion and a one-click expand-all path.
-6. Add explicit navigation between unit-list and flow-graph units when the
+5. Add explicit navigation between unit-list and flow-graph units when the
    counterpart view for the selected unit is available.
-7. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+6. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
-8. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
+7. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
    generated commands with JP1/Automatic Job Management System 3 version 13
    Command Reference.
-9. Add a read-only JP1/AJS WebAPI import path for loading server-side
+8. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
-10. Replace the custom `UnitEntity` hash implementation with a common
-    algorithm once identity and compatibility checks are explicit.
-11. Consolidate i18n translation files to reduce duplication between language
+9. Replace the custom `UnitEntity` hash implementation with a common
+   algorithm once identity and compatibility checks are explicit.
+10. Consolidate i18n translation files to reduce duplication between language
     variants.
 
 ## Deferred / Optional Slices

--- a/src/test/suite/flowGraphView.test.ts
+++ b/src/test/suite/flowGraphView.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { createTheme } from "@mui/material";
+import { createTheme } from "@mui/material/styles";
 import { FlowGraphDto } from "../../application/flow-graph/buildFlowGraphCore";
 import { UnitDefinitionDialogDto } from "../../application/unit-definition/buildUnitDefinition";
 import { createReactFlowData } from "../../ui-component/editor/ajsFlow/flowGraphView";

--- a/src/ui-component/editor/LogingMask.tsx
+++ b/src/ui-component/editor/LogingMask.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { Backdrop, CircularProgress, Container, Toolbar } from "@mui/material";
+import Backdrop from "@mui/material/Backdrop";
+import CircularProgress from "@mui/material/CircularProgress";
+import Container from "@mui/material/Container";
+import Toolbar from "@mui/material/Toolbar";
 
 /**
  * LoadingMask

--- a/src/ui-component/editor/UnitEntityDialog.tsx
+++ b/src/ui-component/editor/UnitEntityDialog.tsx
@@ -1,16 +1,14 @@
 import React, { FC, memo, MouseEvent, useState } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Stack,
-  Tab,
-  Tabs,
-  TextField,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 import CloseIcon from "@mui/icons-material/Close";
 import { UnitDefinitionDialogDto } from "../../application/unit-definition/buildUnitDefinition";
 

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -8,7 +8,9 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Box, Stack, ThemeProvider, createTheme } from "@mui/material";
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { useMyAppContext } from "../MyContexts";
 import {
   Background,

--- a/src/ui-component/editor/ajsFlow/FlowMenu.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowMenu.tsx
@@ -1,11 +1,9 @@
 import React, { FC, memo, useState } from "react";
-import {
-  IconButton,
-  ListItemIcon,
-  ListItemText,
-  Menu,
-  MenuItem,
-} from "@mui/material";
+import IconButton from "@mui/material/IconButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
 import MenuIcon from "@mui/icons-material/Menu";
 import ViewColumnIcon from "@mui/icons-material/ViewColumn";
 import { DrawerWidthStateType, FlowMenuStateType } from "./FlowContents";

--- a/src/ui-component/editor/ajsFlow/FlowSelector.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowSelector.tsx
@@ -1,17 +1,15 @@
 import React, { FC, memo, useEffect, useMemo, useRef } from "react";
-import {
-  Accordion as MuiAccordion,
-  AccordionActions as MuiAccordionActions,
-  AccordionSummary as MuiAccordionSummary,
-  Drawer,
-  IconButton,
-  Toolbar,
-  useTheme,
-  AccordionProps,
-  styled,
-  AccordionSummaryProps,
-  AccordionActionsProps,
-} from "@mui/material";
+import MuiAccordion, { type AccordionProps } from "@mui/material/Accordion";
+import MuiAccordionActions, {
+  type AccordionActionsProps,
+} from "@mui/material/AccordionActions";
+import MuiAccordionSummary, {
+  type AccordionSummaryProps,
+} from "@mui/material/AccordionSummary";
+import Drawer from "@mui/material/Drawer";
+import IconButton from "@mui/material/IconButton";
+import Toolbar from "@mui/material/Toolbar";
+import { styled, useTheme } from "@mui/material/styles";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp";

--- a/src/ui-component/editor/ajsFlow/Header.tsx
+++ b/src/ui-component/editor/ajsFlow/Header.tsx
@@ -1,13 +1,11 @@
 import React, { FC, memo, ReactElement, useCallback, useMemo } from "react";
-import {
-  AppBar,
-  Breadcrumbs,
-  IconButton,
-  Link,
-  Toolbar,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import AppBar from "@mui/material/AppBar";
+import Breadcrumbs from "@mui/material/Breadcrumbs";
+import IconButton from "@mui/material/IconButton";
+import Link from "@mui/material/Link";
+import Toolbar from "@mui/material/Toolbar";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 import ViewColumn from "@mui/icons-material/ViewColumn";
 import FlowMenu from "./FlowMenu";
 import {

--- a/src/ui-component/editor/ajsFlow/flowGraphView.ts
+++ b/src/ui-component/editor/ajsFlow/flowGraphView.ts
@@ -1,4 +1,4 @@
-import { Theme } from "@mui/material";
+import type { Theme } from "@mui/material/styles";
 import { Edge, MarkerType, Node } from "@xyflow/react";
 import {
   FlowGraphDto,

--- a/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
@@ -1,12 +1,9 @@
 import React, { FC } from "react";
-import {
-  Box,
-  IconButton,
-  SxProps,
-  Theme,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import type { SxProps, Theme } from "@mui/material/styles";
 import { UnitDefinitionDialogDto } from "../../../../application/unit-definition/buildUnitDefinition";
 import { CurrentUnitIdStateType, DialogDataStateType } from "../FlowContents";
 import { TySymbol } from "../../../../domain/values/AjsType";

--- a/src/ui-component/editor/ajsFlow/nodes/ConditionNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/ConditionNode.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from "react";
 import { Node, NodeProps } from "@xyflow/react";
-import { Box, Stack } from "@mui/material";
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
 import DescriptionIcon from "@mui/icons-material/Description";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import {

--- a/src/ui-component/editor/ajsFlow/nodes/JobGroupNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobGroupNode.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from "react";
 import { Node, NodeProps } from "@xyflow/react";
-import { Box, Stack } from "@mui/material";
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
 import DescriptionIcon from "@mui/icons-material/Description";
 import {
   ActionIcon,

--- a/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from "react";
 import { Handle, Node, NodeProps, Position } from "@xyflow/react";
-import { Box, Stack } from "@mui/material";
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
 import DescriptionIcon from "@mui/icons-material/Description";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import ScheduleIcon from "@mui/icons-material/Schedule";

--- a/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from "react";
 import { Handle, Node, NodeProps, Position } from "@xyflow/react";
-import { Box, Stack } from "@mui/material";
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
 import DescriptionIcon from "@mui/icons-material/Description";
 import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import {

--- a/src/ui-component/editor/ajsTable/DisplayColumnSelector.tsx
+++ b/src/ui-component/editor/ajsTable/DisplayColumnSelector.tsx
@@ -1,21 +1,19 @@
 import React, { FC, Fragment, memo, useEffect, useMemo, useRef } from "react";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Divider,
-  Drawer,
-  FormControlLabel,
-  IconButton,
-  List,
-  ListItem,
-  Stack,
-  Switch,
-  Toolbar,
-  Tooltip,
-  Typography,
-  useTheme,
-} from "@mui/material";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Divider from "@mui/material/Divider";
+import Drawer from "@mui/material/Drawer";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import IconButton from "@mui/material/IconButton";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
+import Toolbar from "@mui/material/Toolbar";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import { useTheme } from "@mui/material/styles";
 import {
   Column,
   Table as ReactTable,

--- a/src/ui-component/editor/ajsTable/Header.tsx
+++ b/src/ui-component/editor/ajsTable/Header.tsx
@@ -1,15 +1,13 @@
 import React, { FC, memo, ReactElement, useCallback, useState } from "react";
-import {
-  Alert,
-  AppBar,
-  IconButton,
-  Slide,
-  Snackbar,
-  Stack,
-  Toolbar,
-  Tooltip,
-  useScrollTrigger,
-} from "@mui/material";
+import Alert from "@mui/material/Alert";
+import AppBar from "@mui/material/AppBar";
+import IconButton from "@mui/material/IconButton";
+import Slide from "@mui/material/Slide";
+import Snackbar from "@mui/material/Snackbar";
+import Stack from "@mui/material/Stack";
+import Toolbar from "@mui/material/Toolbar";
+import Tooltip from "@mui/material/Tooltip";
+import useScrollTrigger from "@mui/material/useScrollTrigger";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import SaveIcon from "@mui/icons-material/Save";
 import DisplaySettingsIcon from "@mui/icons-material/DisplaySettings";

--- a/src/ui-component/editor/ajsTable/SearchBox.tsx
+++ b/src/ui-component/editor/ajsTable/SearchBox.tsx
@@ -7,7 +7,9 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { TextField, IconButton, Tooltip } from "@mui/material";
+import IconButton from "@mui/material/IconButton";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearAllIcon from "@mui/icons-material/ClearAll";
 import { Updater } from "@tanstack/table-core";

--- a/src/ui-component/editor/ajsTable/TableContents.tsx
+++ b/src/ui-component/editor/ajsTable/TableContents.tsx
@@ -8,16 +8,13 @@ import React, {
   useRef,
   useState,
 } from "react";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  CssBaseline,
-  Stack,
-  ThemeProvider,
-  Typography,
-  createTheme,
-} from "@mui/material";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import CssBaseline from "@mui/material/CssBaseline";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { useReactTable } from "@tanstack/react-table";
 import {
   FilterMeta,

--- a/src/ui-component/editor/ajsTable/TableHeader.tsx
+++ b/src/ui-component/editor/ajsTable/TableHeader.tsx
@@ -1,13 +1,10 @@
 import React, { FC, memo } from "react";
 import { HeaderGroup } from "@tanstack/table-core";
 import { flexRender } from "@tanstack/react-table";
-import {
-  SxProps,
-  TableCell,
-  TableRow,
-  TableSortLabel,
-  Theme,
-} from "@mui/material";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import TableSortLabel from "@mui/material/TableSortLabel";
+import type { SxProps, Theme } from "@mui/material/styles";
 import { UnitListRowView } from "../../../application/unit-list/buildUnitListView";
 
 const styleTableCell: SxProps<Theme> = {

--- a/src/ui-component/editor/ajsTable/TableMenu.tsx
+++ b/src/ui-component/editor/ajsTable/TableMenu.tsx
@@ -1,11 +1,9 @@
 import React, { FC, memo, useRef, useState } from "react";
-import {
-  IconButton,
-  ListItemIcon,
-  ListItemText,
-  Menu,
-  MenuItem,
-} from "@mui/material";
+import IconButton from "@mui/material/IconButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
 import MenuIcon from "@mui/icons-material/Menu";
 import Loop from "@mui/icons-material/Loop";
 import DisplaySettingsIcon from "@mui/icons-material/DisplaySettings";

--- a/src/ui-component/editor/ajsTable/VirtualizedTable.tsx
+++ b/src/ui-component/editor/ajsTable/VirtualizedTable.tsx
@@ -8,18 +8,15 @@ import React, {
 } from "react";
 import { flexRender, HeaderGroup, Row } from "@tanstack/react-table";
 import { ItemProps, TableVirtuoso, TableVirtuosoHandle } from "react-virtuoso";
-import {
-  Paper,
-  SxProps,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Theme,
-  useTheme,
-} from "@mui/material";
+import Paper from "@mui/material/Paper";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import { useTheme } from "@mui/material/styles";
+import type { SxProps, Theme } from "@mui/material/styles";
 import { UnitListRowView } from "../../../application/unit-list/buildUnitListView";
 import TableHeader from "./TableHeader";
 import type { MyAppResource } from "../../../shared/MyAppResource";

--- a/src/ui-component/editor/ajsTable/columnDefs/common.tsx
+++ b/src/ui-component/editor/ajsTable/columnDefs/common.tsx
@@ -1,5 +1,5 @@
 import React, { JSX } from "react";
-import { Box } from "@mui/material";
+import Box from "@mui/material/Box";
 import Parameter from "../../../../domain/models/parameters/Parameter";
 
 type PrimitiveType =

--- a/src/ui-component/editor/ajsTable/columnDefs/group11.tsx
+++ b/src/ui-component/editor/ajsTable/columnDefs/group11.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ColumnHelper, GroupColumnDef } from "@tanstack/table-core";
 import * as ajscolumn from "@resource/i18n/ajscolumn";
 import { UnitListRowView } from "../../../../application/unit-list/buildUnitListView";
-import { Rating } from "@mui/material";
+import Rating from "@mui/material/Rating";
 
 const group11 = (
   columnHelper: ColumnHelper<UnitListRowView>,

--- a/src/ui-component/editor/ajsTable/columnDefs/group3.tsx
+++ b/src/ui-component/editor/ajsTable/columnDefs/group3.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ColumnHelper, GroupColumnDef } from "@tanstack/table-core";
 import * as ajscolumn from "@resource/i18n/ajscolumn";
-import { Chip } from "@mui/material";
+import Chip from "@mui/material/Chip";
 import { UnitListRowView } from "../../../../application/unit-list/buildUnitListView";
 
 const group3 = (

--- a/src/ui-component/editor/ajsTable/columnDefs/group5.tsx
+++ b/src/ui-component/editor/ajsTable/columnDefs/group5.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ColumnHelper, GroupColumnDef } from "@tanstack/table-core";
 import * as ajscolumn from "@resource/i18n/ajscolumn";
 import { UnitListRowView } from "../../../../application/unit-list/buildUnitListView";
-import { Chip } from "@mui/material";
+import Chip from "@mui/material/Chip";
 
 const group5 = (
   columnHelper: ColumnHelper<UnitListRowView>,

--- a/src/ui-component/editor/ajsTable/columnDefs/group7.tsx
+++ b/src/ui-component/editor/ajsTable/columnDefs/group7.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ColumnHelper, GroupColumnDef } from "@tanstack/table-core";
 import * as ajscolumn from "@resource/i18n/ajscolumn";
 import { UnitListRowView } from "../../../../application/unit-list/buildUnitListView";
-import { Rating } from "@mui/material";
+import Rating from "@mui/material/Rating";
 
 const group7 = (
   columnHelper: ColumnHelper<UnitListRowView>,

--- a/src/ui-component/editor/ajsTable/tableColumnDef.tsx
+++ b/src/ui-component/editor/ajsTable/tableColumnDef.tsx
@@ -29,7 +29,9 @@ import group17 from "./columnDefs/group17";
 import group18 from "./columnDefs/group18";
 import group19 from "./columnDefs/group19";
 import group20 from "./columnDefs/group20";
-import { Box, IconButton, Tooltip } from "@mui/material";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
 
 // default setting of
 export const tableDefaultColumnDef = {


### PR DESCRIPTION
## Summary
- replace viewer-side `@mui/material` barrel imports with path imports across table and flow components
- update the focused flow-graph test import to match the new MUI styles entrypoint usage
- sync SDD docs with the completed import-narrowing slice and record the production re-measurement plus next bundle-size direction

## Validation
- `corepack pnpm run qlty`
- `corepack pnpm test -- --grep "Flow Graph View"`
- `corepack pnpm run build`

## Notes
- production re-measurement recorded in SDD docs shows only marginal bundle-size change after path-import narrowing
- full `corepack pnpm test` and `corepack pnpm run test:web` have not been run yet for this branch