### PR TITLE
[codex] prepare 1.12.0 release

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,8 +7,11 @@ antlr/
 # qlty
 .qlty/
 
-# code climate
-.codeclimate.yml
+# codex
+.codex/
+
+# github
+.github/
 
 # vscode
 .vscode/
@@ -19,16 +22,24 @@ antlr/
 # source code
 src/
 
+# SDD
+docs/
+.agent.md
+AGENTS.md
+PLANS.md
+
 # others
 report/
 sample/
 .browserslistrc
-.eslintrc.js
+eslint.config.mjs
 .gitattributes
 .gitignore
 .ncurc.json
 tsconfig.json
+tsconfig.test.json
 webpack.config.js
+pnpm-lock.yaml
 *.log
 *.tmp
 *.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.12.0]
+
+- Refreshed the flow viewer presentation so the current node, ancestor chain,
+  and root jobnet are easier to distinguish.
+- Fixed flow-view layout overflow so the webview fits the available panel area
+  without stray window scrollbars.
+- Restored table-view scrolling behavior after the webview layout changes and
+  corrected extra right-side whitespace in table-scroll mode.
+- Continued aligning the repository with Specification-Driven Development by
+  recording the remaining runtime-boundary and flow-graph follow-up decisions.
+
 ## [1.11.4]
 
 - Introduced Specification-Driven Development documents under `docs/specs/` and

--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ information for JP1/AJS3 from Hitachi in a human-readable format.
 - Save data in CSV format.
 - Switch the editor to enable a flow-style display of the information.
   ![unit-list](images/unit-flow.png)
+- Highlights the current node, ancestor path, and root jobnet more clearly in
+  the flow viewer.
 - Supports web extensions.
+
+## Recent Updates
+
+- Flow viewer visuals are more legible, with clearer emphasis on the current
+  node, ancestor chain, and root jobnet.
+- Flow webview sizing now stays within the available panel area instead of
+  showing stray browser-level scrollbars.
+- Table view scrolling behavior is preserved for both window-scroll and
+  table-scroll modes after the webview layout updates.
 
 ## Extension Settings
 

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -18,6 +18,24 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
 4. Add explicit list-to-flow and flow-to-list navigation actions
 5. Validate desktop and web viewer behavior
 
+## Current Slice
+
+- Define the first visual-refresh slice as a presentation-only pass that keeps
+  flow DTO construction and current selection semantics unchanged.
+- Prioritize a JP1/AJS View-like feel through clearer current-node emphasis,
+  stronger ancestor readability, more intentional graph chrome, and a minimap
+  or overview treatment that does not dominate the primary canvas.
+- Keep nested expansion and cross-view navigation as follow-up slices so the
+  visual refresh remains reviewable and compatibility-focused.
+- 2026-04-18 implementation result:
+  the flow viewer now gives the active node, ancestor chain, and root jobnet a
+  stronger visual hierarchy while keeping the existing graph DTOs, selection
+  state, and dialog-open actions unchanged.
+- 2026-04-18 validation focus:
+  preserve the DTO-to-node identity mapping in `flowGraphView.test.ts`, then
+  confirm both desktop and web preview hosts still open and render the updated
+  flow view through the standard serial quality baseline.
+
 ## Validation
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -14,15 +14,37 @@
 
 ## Remaining Follow-up
 
-- [ ] Define the visual cues that most matter for JP1/AJS View resemblance
+- [x] Define the visual cues that most matter for JP1/AJS View resemblance
 - [ ] Decide whether expand-all ships in the same slice as incremental
       expansion or immediately after
 - [ ] Document the target behavior when a counterpart list or flow view is not
       available
-- [ ] Add focused validation plans for selection, navigation, and nested
-      expansion state
+- [x] Add focused validation plans for selection, navigation, and nested
+      expansion state:
+      keep current-selection regression coverage at the flow-graph DTO mapping
+      seam, verify both desktop and web preview opening still succeed, and
+      reserve nested-expansion plus cross-view navigation behavior for the
+      follow-up slices that introduce those interactions
 
 ## Notes
 
 - 2026-04-18: user intent is visual resemblance first; full interaction parity
   is explicitly out of scope for the initial slice.
+- 2026-04-18: the first visual-refresh slice should prioritize recognizable
+  JP1/AJS View cues over broad interaction changes:
+  compact graph chrome, clearer current/ancestor emphasis, stronger root-jobnet
+  readability, minimap or overview treatment that feels secondary to the main
+  graph, and status indicators that stay legible in both desktop and web hosts.
+- 2026-04-18: the visual-refresh slice should keep the existing graph DTO
+  contract intact and focus on presentation concerns such as node silhouette,
+  spacing, contrast, and action affordances rather than reworking graph
+  semantics in the same change.
+- 2026-04-18: the first implemented visual-refresh pass now emphasizes the
+  current node, ancestor chain, and root jobnet more clearly while making the
+  selector drawer and canvas chrome feel more secondary to the main graph.
+- 2026-04-18: focused validation for this slice stays on identity-preserving
+  behavior rather than pixel snapshots:
+  `flowGraphView.test.ts` continues to assert current and ancestor metadata
+  mapping, desktop `pnpm test` still opens the viewers, and `pnpm run test:web`
+  confirms the web preview wiring remains intact after the presentation-only
+  restyle.

--- a/docs/specs/features/modernize-runtime-boundaries/PLANS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/PLANS.md
@@ -28,6 +28,14 @@ hashing internals, and bundle-size reduction while preserving behavior.
 - Resource and save events are already string- and object-based contracts:
   `MyAppResource`, operation names, and CSV save bodies do not require custom
   cyclic serialization.
+- `UnitEntity.id` is still derived from `absolutePath` through a local sync
+  hash helper and is consumed mostly as an in-memory UI identity for unit-list
+  row ids, flow-graph node ids, current selection, linked-unit references, and
+  DOM anchor ids.
+- Current extension and webview wiring does not persist that hashed id through
+  `workspaceState`, `globalState`, webview serializers, or `vscode.setState`;
+  the visible extension-to-webview document contract remains DTO-based and
+  rebuilds normalized units from posted data.
 
 ## Ordering Decision
 
@@ -104,3 +112,23 @@ hashing internals, and bundle-size reduction while preserving behavior.
   re-measure `tableViewer.js` and `flowViewer.js`, then decide whether the
   next target should be table virtualization (`react-virtuoso`) or flow graph
   libraries (`@xyflow/*`)
+- 2026-04-18 follow-up decision after re-measuring the MUI import-shape slice:
+  keep the next shrinking target on the flow side first because the current
+  analyzer evidence still shows `@xyflow/react` + `@xyflow/system`
+  outweighing table-side `react-virtuoso` + `@tanstack/table-core` by roughly
+  `139053` parsed bytes, while the emitted production bundle sizes remain too
+  close to make raw bundle bytes a better prioritization signal.
+- First flow-side implementation slice result:
+  deferring minimap-centered flow chrome behind an async seam did not produce
+  a meaningful reduction, so the experiment was reverted rather than kept as a
+  complexity-increasing baseline.
+- Current prioritization adjustment:
+  do not keep forcing viewer bundle-size work when the measured win is
+  marginal; shift the next branch-level attention to flow-graph UX and other
+  higher-value slices unless a stronger bundle constraint appears.
+- Hash-replacement readiness finding:
+  the required pre-change checks are now explicit rather than implicit.
+  Any future swap to a common hash algorithm should first re-verify that
+  hashed ids still do not cross persistence boundaries, keep webview DTOs on
+  stable normalized ids such as `absolutePath`, and refresh focused tests for
+  flow selection continuity plus table/graph anchor behavior.

--- a/docs/specs/features/modernize-runtime-boundaries/TASKS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/TASKS.md
@@ -41,8 +41,18 @@
 - [x] Narrow viewer-side `@mui/material` imports away from barrel imports and
       re-measure both bundles before choosing a viewer-specific dependency
       reduction slice
-- [ ] Identify identity and persistence checks needed before changing the hash
-      algorithm
+- [x] Compare table-side `react-virtuoso` and TanStack cost against flow-side
+      `@xyflow/*` cost and choose the next viewer-specific shrinking slice
+- [x] Evaluate whether deferring flow-only `@xyflow/react` auxiliary UI such
+      as minimap or controls is worth the added complexity:
+      attempted async flow chrome did not reduce the initial flow bundle
+      enough to justify keeping the source change
+- [x] Identify identity and persistence checks needed before changing the hash
+      algorithm:
+      current `UnitEntity.id` usage is limited to in-memory selection, graph
+      node keys, and DOM anchors; no `workspaceState`/`globalState`, webview
+      serializer, or extension-side DTO contract currently persists the hashed
+      value across sessions
 
 ## Notes
 
@@ -92,3 +102,30 @@
   should move to viewer-specific dependencies such as `react-virtuoso` on the
   table side or `@xyflow/*` on the flow side rather than spending another
   slice on the same import shape.
+- 2026-04-18: rerunning analyzer output after the MUI import-shape slice keeps
+  the production editor bundles at `out/tableViewer.js` = `737279` bytes raw /
+  `218908` bytes gzip and `out/flowViewer.js` = `711123` bytes raw /
+  `216983` bytes gzip, so the next decision still depends on viewer-specific
+  dependency cost rather than gross output size.
+- 2026-04-18: the current viewer-specific dependency comparison still favors a
+  flow-first shrinking slice: prior analyzer evidence put
+  `@xyflow/react` + `@xyflow/system` at about `368916` parsed bytes versus
+  `@tanstack/table-core` + `react-virtuoso` at about `229863`, so
+  `@xyflow/*` remains the larger removable seam.
+- 2026-04-18: a follow-up experiment moved minimap-centered flow chrome behind
+  an async seam, but the production result regressed slightly:
+  `out/flowViewer.js` moved to `714801` bytes raw / `218913` bytes gzip and
+  emitted only a tiny extra async chunk (`out/69.js` = `406` bytes raw /
+  `283` bytes gzip), so the source change was reverted and should not be
+  treated as a worthwhile reduction path.
+- 2026-04-18: current branch intent is not to force marginal viewer shrinking
+  work when the trade-off is extra complexity without meaningful payload
+  improvement; bundle follow-up should resume only when a clearer reduction
+  seam or stronger product need appears.
+- 2026-04-18: identity and persistence review for `UnitEntity.id` found three
+  concrete pre-change checks:
+  confirm no future extension storage or webview state serializer starts
+  persisting hashed ids, keep extension-to-webview DTO boundaries on
+  `absolutePath`/normalized ids rather than legacy wrapper hashes, and update
+  focused regression coverage around flow selection plus table jump anchors if
+  the hashing implementation changes.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -119,6 +119,21 @@ structure in `docs/specs/features/<feature>/`.
   711,123 bytes raw / 216,983 bytes gzip, so the next bundle-size slice
   should target viewer-specific dependencies instead of more MUI import-shape
   work.
+- Viewer-specific dependency comparison is now explicit:
+  despite the similar emitted bundle sizes, current analyzer evidence still
+  shows flow-side `@xyflow/react` + `@xyflow/system` outweighing table-side
+  `react-virtuoso` + `@tanstack/table-core`, so the next shrinking slice
+  should target flow dependencies first.
+- A concrete flow-side shrinking experiment has now been tried and rejected:
+  deferring minimap-centered flow chrome behind an async seam slightly
+  increased the initial flow bundle instead of shrinking it enough to justify
+  the extra complexity, so that source change was reverted and should be kept
+  only as recorded evidence, not as the new baseline.
+- Hash-replacement prerequisites are now explicit:
+  current `UnitEntity.id` usage stays inside in-memory UI identity paths
+  rather than persisted extension or webview state, and the next eventual hash
+  slice should preserve normalized `absolutePath`-based DTO contracts while
+  refreshing focused selection and anchor regressions.
 
 ### How To Maintain This Section
 
@@ -133,24 +148,22 @@ structure in `docs/specs/features/<feature>/`.
 
 ### Next Priority Tasks
 
-1. Reduce the next-largest viewer-specific webview bundle contributors now
-   that MUI import narrowing has been measured.
-2. Compare table-side `react-virtuoso` and TanStack cost against flow-side
-   `@xyflow/*` cost to choose the next shrinking slice.
-3. Refresh flow-graph UX in focused slices:
+1. Refresh flow-graph UX in focused slices:
    visual parity with JP1/AJS View first, then progressive nested expansion and
    view-to-view navigation.
-4. Align parameter parsing and `ajs` command generation with
+2. Align parameter parsing and `ajs` command generation with
    JP1/Automatic Job Management System 3 version 13 reference manuals.
-5. Define a read-only JP1/AJS WebAPI import boundary with clear application
+3. Define a read-only JP1/AJS WebAPI import boundary with clear application
    and infrastructure responsibilities.
-6. Continue treating desktop and web compatibility as an explicit acceptance
+4. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, shared adapters, or package
    runtime behavior change.
-7. Keep feature follow-up verification evidence concrete:
+5. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-8. Revisit a dedicated filter/search use case only if a second non-table
+6. Revisit viewer bundle-size work only when a clearer reduction seam or
+   stronger product need appears.
+7. Revisit a dedicated filter/search use case only if a second non-table
    consumer appears and needs the same matching semantics.
 
 ## Wrapper Semantics Matrix

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -59,30 +59,33 @@
 24. Re-measure viewer-side `@mui/material` path imports after bundle
     splitting and use that evidence to decide whether the next reduction
     target should move to table-only or flow-only dependencies.
+25. Compare viewer-specific dependency weight after the MUI import-shape slice
+    and choose the next shrinking target by removable parsed cost rather than
+    by raw emitted bundle size alone.
+26. Make the `UnitEntity` hash-change preconditions explicit:
+    confirm current hashed ids stay inside transient UI identity paths,
+    document the persistence boundaries that must stay clear, and name the
+    regression coverage to refresh before swapping algorithms.
 
 ## Current Roadmap
 
-1. Revisit table-side `react-virtuoso` and TanStack payload cost now that the
-   shared MUI import-shape experiment is complete.
-2. Revisit flow-side `@xyflow/*` payload cost now that the shared MUI import
-   shape experiment is complete.
-3. Refresh the flow-graph presentation so its visual design is closer to
+1. Refresh the flow-graph presentation so its visual design is closer to
    JP1/AJS View while preserving current desktop and web compatibility.
-4. Add progressive nested-graph expansion in the flow view, with both
+2. Add progressive nested-graph expansion in the flow view, with both
    user-driven incremental expansion and a one-click expand-all path.
-5. Add explicit navigation between unit-list and flow-graph units when the
+3. Add explicit navigation between unit-list and flow-graph units when the
    counterpart view for the selected unit is available.
-6. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+4. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
-7. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
+5. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
    generated commands with JP1/Automatic Job Management System 3 version 13
    Command Reference.
-8. Add a read-only JP1/AJS WebAPI import path for loading server-side
+6. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
-9. Replace the custom `UnitEntity` hash implementation with a common
+7. Replace the custom `UnitEntity` hash implementation with a common
    algorithm once identity and compatibility checks are explicit.
-10. Consolidate i18n translation files to reduce duplication between language
-    variants.
+8. Consolidate i18n translation files to reduce duplication between language
+   variants.
 
 ## Deferred / Optional Slices
 
@@ -94,6 +97,9 @@
    and nested expansion slices settle.
 4. Extend JP1/AJS WebAPI support beyond read-only import only after the
    initial boundary and authentication model are stable.
+5. Revisit viewer-specific bundle-size reductions only if a future
+   compatibility, startup, or payload target creates stronger pressure than
+   the current marginal gains justify.
 
 ## Done Criteria For A Slice
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-ajsbutler",
   "displayName": "vscode-ajsbutler",
   "description": "Support tool for JP1/AJS3",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-ajsbutler",
   "displayName": "vscode-ajsbutler",
   "description": "Support tool for JP1/AJS3",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",

--- a/src/extension/webview/reactPanel.tsx
+++ b/src/extension/webview/reactPanel.tsx
@@ -37,6 +37,23 @@ function _getHtmlForWebview(
                 child-src ${panel.webview.cspSource};
                 ">
     <base href='${panel.webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, "/"))}'>
+    <style>
+        html, body, #root {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            box-sizing: border-box;
+            background: transparent;
+        }
+
+        *, *::before, *::after {
+            box-sizing: inherit;
+        }
+    </style>
 </head>
 <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/test/suite/flowGraphView.test.ts
+++ b/src/test/suite/flowGraphView.test.ts
@@ -94,7 +94,11 @@ suite("Flow Graph View", () => {
       nodes[0].data.unitDefinition.absolutePath,
       "/root/jobnet",
     );
+    assert.strictEqual(nodes[0].data.isCurrent, true);
+    assert.strictEqual(nodes[0].data.isAncestor, true);
+    assert.strictEqual(nodes[0].data.isRootJobnet, true);
     assert.strictEqual(nodes[1].data.unitId, "/root/jobnet/job-a");
+    assert.strictEqual(nodes[1].data.hasWaitedFor, true);
     assert.strictEqual(edges[0].source, "/root/jobnet");
     assert.strictEqual(edges[0].target, "/root/jobnet/job-a");
   });

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -9,6 +9,7 @@ import React, {
   useState,
 } from "react";
 import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { useMyAppContext } from "../MyContexts";
@@ -178,6 +179,25 @@ const FlowContents: FC = () => {
     };
   }, []); // fire this when mount.
 
+  useEffect(() => {
+    const root = document.getElementById("root");
+    document.documentElement.style.overflow = "hidden";
+    document.body.style.overflow = "hidden";
+    if (root) {
+      root.style.overflow = "hidden";
+      root.style.height = "100%";
+    }
+
+    return () => {
+      document.documentElement.style.overflow = "";
+      document.body.style.overflow = "";
+      if (root) {
+        root.style.overflow = "";
+        root.style.height = "";
+      }
+    };
+  }, []);
+
   const flowMenuState = {
     menuStatus: menuStatus,
     setMenuStatus: setMenuStatus,
@@ -198,7 +218,15 @@ const FlowContents: FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <ReactFlowProvider>
-        <Stack direction="row" spacing={0}>
+        <Stack
+          direction="row"
+          spacing={0}
+          sx={{
+            width: "100%",
+            height: "100vh",
+            overflow: "hidden",
+          }}
+        >
           {menuStatus.menuItem1 && (
             <FlowSelector
               rootUnits={ajsDocument?.rootUnits ?? []}
@@ -210,8 +238,13 @@ const FlowContents: FC = () => {
           )}
           <Stack
             direction="column"
-            sx={{ marginLeft: `${drawerWidth}px` }}
-            flex={1}
+            sx={{
+              marginLeft: `${drawerWidth}px`,
+              width: `calc(100% - ${drawerWidth}px)`,
+              minWidth: 0,
+              height: "100%",
+              overflow: "hidden",
+            }}
           >
             <Header
               currentUnit={currentUnit}
@@ -222,22 +255,68 @@ const FlowContents: FC = () => {
             />
             <Box
               sx={{
-                width: "100vw",
-                height: (theme) =>
-                  `calc(100vh - ${theme.mixins.toolbar.minHeight}px)`,
+                width: "100%",
+                flex: 1,
+                minWidth: 0,
+                minHeight: 0,
+                overflow: "hidden",
+                padding: 1.25,
+                background: (theme) =>
+                  `radial-gradient(circle at top left, ${theme.palette.primary.light}12, transparent 28%), linear-gradient(180deg, ${theme.palette.background.default} 0%, ${theme.palette.background.paper} 100%)`,
+                boxSizing: "border-box",
               }}
             >
-              <ReactFlow
-                nodes={nodes}
-                edges={edges}
-                defaultViewport={defaultViewport}
-                colorMode={theme.palette.mode}
-                nodeTypes={nodeTypes}
+              <Paper
+                variant="outlined"
+                sx={{
+                  width: "100%",
+                  height: "100%",
+                  minWidth: 0,
+                  minHeight: 0,
+                  overflow: "hidden",
+                  borderRadius: 3,
+                  backgroundColor: "background.paper",
+                }}
               >
-                <Background variant={BackgroundVariant.Dots} />
-                <Controls position="bottom-left" showInteractive={false} />
-                <MiniMap pannable zoomable style={{ position: "fixed" }} />
-              </ReactFlow>
+                <ReactFlow
+                  nodes={nodes}
+                  edges={edges}
+                  defaultViewport={defaultViewport}
+                  colorMode={theme.palette.mode}
+                  nodeTypes={nodeTypes}
+                  fitView
+                  fitViewOptions={{ padding: 0.22 }}
+                >
+                  <Background
+                    variant={BackgroundVariant.Dots}
+                    gap={20}
+                    size={1}
+                    color={theme.palette.divider}
+                  />
+                  <Controls
+                    position="bottom-left"
+                    showInteractive={false}
+                    style={{
+                      borderRadius: 12,
+                      overflow: "hidden",
+                      boxShadow: theme.shadows[3],
+                    }}
+                  />
+                  <MiniMap
+                    pannable
+                    zoomable
+                    style={{
+                      position: "fixed",
+                      right: 16,
+                      bottom: 16,
+                      borderRadius: 12,
+                      overflow: "hidden",
+                      opacity: 0.88,
+                      boxShadow: theme.shadows[3],
+                    }}
+                  />
+                </ReactFlow>
+              </Paper>
               {dialogData && (
                 <UnitEntityDialog
                   dialogData={dialogData}

--- a/src/ui-component/editor/ajsFlow/FlowSelector.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowSelector.tsx
@@ -8,6 +8,7 @@ import MuiAccordionSummary, {
 } from "@mui/material/AccordionSummary";
 import Drawer from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
 import Toolbar from "@mui/material/Toolbar";
 import { styled, useTheme } from "@mui/material/styles";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
@@ -45,6 +46,7 @@ const Accordion = styled((props: AccordionProps) => (
   "&::before": {
     display: "none",
   },
+  boxShadow: "none",
 }));
 
 const AccordionSummary = styled((props: AccordionSummaryProps) => (
@@ -55,6 +57,7 @@ const AccordionSummary = styled((props: AccordionSummaryProps) => (
   />
 ))(({ theme }) => ({
   flexDirection: "row-reverse",
+  borderRadius: theme.spacing(1),
   "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
     transform: "rotate(90deg)",
   },
@@ -70,6 +73,8 @@ const AccordionActions = styled((props: AccordionActionsProps) => (
   <MuiAccordionActions {...props} />
 ))(() => ({
   justifyContent: "flex-start",
+  paddingLeft: 0,
+  paddingRight: 0,
 }));
 
 const FlowSelector: FC<FlowSelectorProps> = ({
@@ -114,7 +119,15 @@ const FlowSelector: FC<FlowSelectorProps> = ({
         return (
           <Accordion
             key={unit.id}
-            sx={{ marginLeft: `${unit.depth}em` }}
+            sx={{
+              marginLeft: `${unit.depth * 0.85}em`,
+              marginRight: "0.5em",
+              marginBottom: "0.3em",
+              border: (theme) => `1px solid ${theme.palette.divider}`,
+              backgroundColor: isAncestorOf(unit)
+                ? "action.selected"
+                : "background.paper",
+            }}
             expanded={isAncestorOf(unit)}
             onChange={() => setCurrentUnitId(unit.id)}
           >
@@ -129,7 +142,17 @@ const FlowSelector: FC<FlowSelectorProps> = ({
             key={unit.id}
             disableSpacing
             onClick={() => setCurrentUnitId(unit.id)}
-            sx={{ marginLeft: `${unit.depth}em` }}
+            sx={{
+              marginLeft: `${unit.depth * 0.85}em`,
+              marginRight: "0.75em",
+              marginBottom: "0.2em",
+              borderRadius: "999px",
+              border: (theme) => `1px solid ${theme.palette.divider}`,
+              backgroundColor: isAncestorOf(unit)
+                ? "action.selected"
+                : "background.paper",
+              paddingX: "0.75em",
+            }}
           >
             {isAncestorOf(unit) && (
               <CheckCircleOutlineIcon
@@ -166,6 +189,16 @@ const FlowSelector: FC<FlowSelectorProps> = ({
         variant="persistent"
         open={menuStatus.menuItem1}
         onClose={handleClose}
+        slotProps={{
+          paper: {
+            sx: {
+              width: "18rem",
+              borderRight: (theme) => `1px solid ${theme.palette.divider}`,
+              background: (theme) =>
+                `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`,
+            },
+          },
+        }}
       >
         <Toolbar
           ref={drawerRef}
@@ -174,8 +207,19 @@ const FlowSelector: FC<FlowSelectorProps> = ({
             display: "flex",
             alignItems: "center",
             justifyContent: "flex-end",
+            borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
           }}
         >
+          <Typography
+            variant="caption"
+            sx={{
+              marginRight: "auto",
+              fontWeight: 700,
+              letterSpacing: "0.08em",
+            }}
+          >
+            FLOW TREE
+          </Typography>
           <IconButton onClick={handleClose}>
             {theme.direction === "ltr" ? (
               <ChevronLeftIcon />

--- a/src/ui-component/editor/ajsFlow/Header.tsx
+++ b/src/ui-component/editor/ajsFlow/Header.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo, ReactElement, useCallback, useMemo } from "react";
 import AppBar from "@mui/material/AppBar";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
+import Chip from "@mui/material/Chip";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import Toolbar from "@mui/material/Toolbar";
@@ -74,6 +75,16 @@ const Header: FC<HeaderProps> = ({
     () => localeMap("flow.menu.menuItem1", lang),
     [lang],
   );
+  const currentUnitLabel = useMemo(() => {
+    if (!currentUnit) {
+      return undefined;
+    }
+    if (currentUnit.unitType === "n" && currentUnit.isRootJobnet) {
+      return "ROOT JOBNET";
+    }
+    return currentUnit.unitType.toUpperCase();
+  }, [currentUnit]);
+
   const handleToggleMenu1 = useCallback(() => {
     setDrawerWidth(0);
     setMenuStatus((prev) => ({ ...prev, menuItem1: !prev.menuItem1 }));
@@ -81,8 +92,17 @@ const Header: FC<HeaderProps> = ({
 
   return (
     <>
-      <AppBar position="sticky">
-        <Toolbar sx={{ gap: 1 }}>
+      <AppBar
+        position="sticky"
+        color="transparent"
+        elevation={0}
+        sx={{
+          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+          backgroundColor: (theme) => `${theme.palette.background.paper}f2`,
+          backdropFilter: "blur(10px)",
+        }}
+      >
+        <Toolbar sx={{ gap: 1.25, minHeight: "3.5rem" }}>
           <FlowMenu
             flowMenuState={flowMenuState}
             drawerWidthState={drawerWidthState}
@@ -96,9 +116,26 @@ const Header: FC<HeaderProps> = ({
               <ViewColumn fontSize="inherit" />
             </IconButton>
           </Tooltip>
-          <Breadcrumbs separator="›" aria-label="breadcrumb">
+          <Breadcrumbs
+            separator="›"
+            aria-label="breadcrumb"
+            sx={{
+              flex: 1,
+              "& .MuiBreadcrumbs-ol": {
+                flexWrap: "nowrap",
+              },
+            }}
+          >
             {breadcrumbs}
           </Breadcrumbs>
+          {currentUnitLabel && (
+            <Chip
+              size="small"
+              label={currentUnitLabel}
+              color={currentUnit?.isRootJobnet ? "primary" : "default"}
+              variant="outlined"
+            />
+          )}
         </Toolbar>
       </AppBar>
     </>

--- a/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
@@ -26,35 +26,87 @@ export type AjsNode = {
   CurrentUnitIdStateType &
   Record<string, unknown>;
 
-export const nodeSxProps: SxProps<Theme> = {
-  width: "6em",
-  height: "6em",
-  borderRadius: "50%",
-  backgroundColor: (theme) => theme.palette.background.default,
-  boxShadow: (theme) => theme.shadows[1],
+export const buildNodeSxProps = ({
+  isCurrent,
+  isAncestor,
+  isRootJobnet,
+}: Pick<
+  AjsNode,
+  "isCurrent" | "isAncestor" | "isRootJobnet"
+>): SxProps<Theme> => ({
+  width: "7.25em",
+  minHeight: "7.25em",
+  paddingX: "0.55em",
+  paddingY: "0.45em",
+  borderRadius: isAncestor ? "1.35em" : "50%",
+  borderWidth: isCurrent ? "3px" : isRootJobnet ? "2px" : "1px",
+  borderStyle: "solid",
+  borderColor: (theme) =>
+    isCurrent
+      ? theme.palette.info.main
+      : isRootJobnet
+        ? theme.palette.primary.main
+        : theme.palette.divider,
+  background: (theme) => {
+    if (isCurrent) {
+      return `linear-gradient(160deg, ${theme.palette.info.light}22 0%, ${theme.palette.background.paper} 58%, ${theme.palette.background.default} 100%)`;
+    }
+    if (isAncestor) {
+      return `linear-gradient(180deg, ${theme.palette.warning.light}1f 0%, ${theme.palette.background.paper} 100%)`;
+    }
+    if (isRootJobnet) {
+      return `linear-gradient(180deg, ${theme.palette.primary.light}18 0%, ${theme.palette.background.paper} 100%)`;
+    }
+    return theme.palette.background.paper;
+  },
+  boxShadow: (theme) =>
+    isCurrent
+      ? `0 0 0 4px ${theme.palette.info.light}30, ${theme.shadows[6]}`
+      : isAncestor
+        ? theme.shadows[4]
+        : theme.shadows[2],
   justifyContent: "center",
-  "&.current": {
-    borderStyle: "solid",
-    borderColor: (theme) => theme.palette.action.active,
+  alignItems: "center",
+  gap: "0.15em",
+  transition:
+    "border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease",
+  "&:hover": {
+    transform: "translateY(-1px)",
   },
-  "&.ancestor": {
-    borderRadius: "10%",
+  "& button": {
+    color: (theme) =>
+      isCurrent ? theme.palette.info.dark : theme.palette.text.secondary,
   },
+});
+
+export const nodeBadgeSxProps: SxProps<Theme> = {
+  minWidth: "3.8em",
+  paddingX: "0.55em",
+  paddingY: "0.15em",
+  borderRadius: "999px",
+  border: (theme) => `1px solid ${theme.palette.divider}`,
+  backgroundColor: (theme) => theme.palette.background.default,
+  fontSize: "0.68rem",
+  fontWeight: 700,
+  letterSpacing: "0.08em",
+  lineHeight: 1.2,
+  textAlign: "center",
 };
 
 export const handleStyle = {
-  top: "3em",
+  top: "3.6em",
 };
 
 const nodeTitleSxProps: SxProps<Theme> = {
-  height: "1em",
-  paddingTop: "0.25em",
+  minHeight: "1.6em",
+  paddingTop: "0.1em",
   paddingBottom: "0em",
   textAlign: "center",
 };
 
 export const nodeActionsSxProps: SxProps<Theme> = {
-  paddingTop: "0.25em",
+  minHeight: "1.8em",
+  paddingTop: "0.1em",
   paddingBottom: "0em",
   textAlign: "center",
 };
@@ -107,10 +159,11 @@ export const ActionIcon: FC<{
   </Tooltip>
 );
 const nameOrCommentSx: SxProps<Theme> = {
-  width: "6em",
+  width: "7.25em",
   overflow: "hidden",
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
+  textAlign: "center",
 };
 export const NameOrComment: React.FC<{
   value?: string;

--- a/src/ui-component/editor/ajsFlow/nodes/ConditionNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/ConditionNode.tsx
@@ -7,8 +7,8 @@ import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import {
   ActionIcon,
   AjsNode,
+  buildNodeSxProps,
   nodeActionsSxProps,
-  nodeSxProps,
   NameOrComment,
   TyTitle,
 } from "./AjsNode";
@@ -26,13 +26,13 @@ const ConditionNode: FC<ConditionNodeProps> = ({
 }: ConditionNodeProps) => {
   console.log("render ConditionNode.");
 
-  const { unitId, isCurrent, label, comment, ty } = data;
+  const { unitId, isAncestor, isCurrent, label, comment, ty } = data;
 
   return (
     <>
       <Stack
         id={unitId}
-        sx={nodeSxProps}
+        sx={buildNodeSxProps({ isCurrent, isAncestor, isRootJobnet: false })}
         className={isCurrent ? "current" : undefined}
       >
         <TyTitle ty={ty} />

--- a/src/ui-component/editor/ajsFlow/nodes/JobGroupNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobGroupNode.tsx
@@ -6,8 +6,8 @@ import DescriptionIcon from "@mui/icons-material/Description";
 import {
   ActionIcon,
   AjsNode,
+  buildNodeSxProps,
   nodeActionsSxProps,
-  nodeSxProps,
   NameOrComment,
   TyTitle,
 } from "./AjsNode";
@@ -24,7 +24,11 @@ const JobGroupNode: FC<JobGroupNodeProp> = ({ data }: JobGroupNodeProp) => {
     <>
       <Stack
         id={unitId}
-        sx={nodeSxProps}
+        sx={buildNodeSxProps({
+          isCurrent: false,
+          isAncestor,
+          isRootJobnet: false,
+        })}
         className={classNames({
           ancestor: isAncestor,
         })}

--- a/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
@@ -10,8 +10,9 @@ import classNames from "classnames";
 import {
   ActionIcon,
   AjsNode,
+  buildNodeSxProps,
+  nodeBadgeSxProps,
   nodeActionsSxProps,
-  nodeSxProps,
   NameOrComment,
   TyTitle,
   handleStyle,
@@ -45,12 +46,13 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
     <>
       <Stack
         id={unitId}
-        sx={nodeSxProps}
+        sx={buildNodeSxProps({ isCurrent, isAncestor, isRootJobnet })}
         className={classNames({
           current: isCurrent,
           ancestor: isAncestor,
         })}
       >
+        {isRootJobnet && <Box sx={nodeBadgeSxProps}>ROOT</Box>}
         <TyTitle ty={ty} />
         {/* action */}
         <Box sx={nodeActionsSxProps}>

--- a/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
@@ -7,8 +7,8 @@ import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import {
   ActionIcon,
   AjsNode,
+  buildNodeSxProps,
   nodeActionsSxProps,
-  nodeSxProps,
   NameOrComment,
   TyTitle,
   handleStyle,
@@ -20,11 +20,15 @@ type JobNodeProps = NodeProps<JobNode>;
 const JobNode: FC<JobNodeProps> = ({ data }: JobNodeProps) => {
   console.log("render JobNode.");
 
-  const { unitId, hasWaitedFor, label, comment, ty } = data;
+  const { unitId, hasWaitedFor, label, comment, ty, isAncestor, isCurrent } =
+    data;
 
   return (
     <>
-      <Stack id={unitId} sx={nodeSxProps}>
+      <Stack
+        id={unitId}
+        sx={buildNodeSxProps({ isCurrent, isAncestor, isRootJobnet: false })}
+      >
         <TyTitle ty={ty} />
         {/* action */}
         <Box sx={nodeActionsSxProps}>

--- a/src/ui-component/editor/ajsTable/TableContents.tsx
+++ b/src/ui-component/editor/ajsTable/TableContents.tsx
@@ -248,6 +248,8 @@ const TableContents = () => {
             spacing={0}
             sx={{
               marginLeft: `${drawerWidth}px`,
+              width: `calc(100% - ${drawerWidth}px)`,
+              minWidth: 0,
             }}
           >
             <Header

--- a/src/ui-component/editor/ajsTable/VirtualizedTable.tsx
+++ b/src/ui-component/editor/ajsTable/VirtualizedTable.tsx
@@ -115,15 +115,19 @@ const VirtualizedTable: FC<VirtualizedTableProps> = ({
     () =>
       scrollType === "table"
         ? {
-            width: `calc(100vw - 2em)`,
+            width: "100%",
+            minWidth: 0,
             height: `calc(100vh - ${toolbarHeight}px - 2em)`,
             maxHeight: `calc(100vh - ${toolbarHeight}px - 2em)`,
+            boxSizing: "border-box" as const,
           }
         : {
-            width: `calc(100vw - 2em)`,
+            width: "100%",
+            minWidth: 0,
             height: "auto",
             maxHeight: "none",
             overflow: "visible",
+            boxSizing: "border-box" as const,
           },
     [scrollType, toolbarHeight],
   );


### PR DESCRIPTION
## Summary

- refresh the flow viewer presentation to better emphasize the current node, ancestor path, and root jobnet
- fix flow webview sizing and table scrolling regressions across flow and table viewer modes
- prepare the 1.12.0 release by updating README.md, CHANGELOG.md, and package.json

## Why

The flow-view refresh introduced a series of layout fixes to keep the webview sized correctly inside VS Code panels. Those fixes also exposed table scrolling edge cases across window-scroll and table-scroll modes. This PR keeps the flow improvements, restores the table behavior, and rolls the release documentation and extension version forward together.

## Validation

- corepack pnpm run qlty
- corepack pnpm run lint:md
- corepack pnpm test
- corepack pnpm run test:web
- corepack pnpm run build
