### PR TITLE
[codex] add flow nested expansion slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [1.15.0]
+
+- Added inline nested expansion for direct child jobnets in the flow viewer.
+- Improved flow-view expansion layout and highlighting.
+
 ## [1.12.0]
 
 - Refreshed the flow viewer presentation so the current node, ancestor chain,

--- a/docs/specs/features/build-unit-list/TASKS.md
+++ b/docs/specs/features/build-unit-list/TASKS.md
@@ -18,6 +18,9 @@
 ## Remaining Follow-up
 
 - [x] Decide whether filtering/search should become a separate application use case
+- [ ] Add a future search enhancement on the current list presentation path:
+      support searching by parameter key and parameter value in addition to the
+      existing partial-match behavior over rendered row values
 
 ## Notes
 
@@ -25,6 +28,10 @@
   behavior depends on TanStack Table row access, presentation column accessors,
   and `rankItem`-based fuzzy matching over rendered row values rather than on a
   stable cross-surface application rule.
+- 2026-04-19: a future list-search slice should extend the presentation-local
+  matcher so users can search by parameter key/value pairs as well as today's
+  partial matches over rendered row text, while keeping the search behavior in
+  the table layer unless another consumer needs the same semantics.
 - Revisit a dedicated application use case only if filtering/search needs to be
   shared across table, CSV, commands, or another non-table consumer.
 - Fixture guidance and manual verification notes are maintenance concerns.

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -20,13 +20,6 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
 
 ## Current Slice
 
-- Define the first visual-refresh slice as a presentation-only pass that keeps
-  flow DTO construction and current selection semantics unchanged.
-- Prioritize a JP1/AJS View-like feel through clearer current-node emphasis,
-  stronger ancestor readability, more intentional graph chrome, and a minimap
-  or overview treatment that does not dominate the primary canvas.
-- Keep nested expansion and cross-view navigation as follow-up slices so the
-  visual refresh remains reviewable and compatibility-focused.
 - 2026-04-18 implementation result:
   the flow viewer now gives the active node, ancestor chain, and root jobnet a
   stronger visual hierarchy while keeping the existing graph DTOs, selection
@@ -35,6 +28,39 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
   preserve the DTO-to-node identity mapping in `flowGraphView.test.ts`, then
   confirm both desktop and web preview hosts still open and render the updated
   flow view through the standard serial quality baseline.
+- 2026-04-19 next slice decision:
+  move to progressive nested expansion while keeping flow DTO construction,
+  current-unit selection, and desktop/web host behavior unchanged until the
+  interaction seam is proven.
+- 2026-04-19 expand-all decision:
+  do not force one-click expand-all into the first incremental-expansion
+  implementation; instead, keep that control as the immediate follow-up so the
+  first behavior slice can validate identity, rendering, and host compatibility
+  with less UI and state-synchronization risk.
+- 2026-04-19 navigation fallback decision:
+  when a counterpart list or flow view is unavailable, keep the current viewer
+  state stable and make the jump action fail predictably through hidden or
+  disabled affordances plus a no-op command path, rather than changing
+  selection opportunistically.
+- 2026-04-19 implementation focus:
+  start with user-driven incremental reveal of nested jobnets in one screen,
+  preserve the existing `currentUnitId`-driven selection contract, and leave
+  cross-view jump actions as the next slice once nested expansion semantics are
+  established.
+- 2026-04-19 implementation result:
+  child jobnets in the flow canvas can now reveal their nested scope in place
+  without replacing the current viewer scope; the existing "open jobnet" action
+  still re-scopes the viewer, while a separate expand/collapse affordance adds
+  or removes nested children progressively.
+- 2026-04-19 validation result:
+  focused regression coverage now verifies that nested descendants appear only
+  after their visible parent jobnet is expanded, keyboard and click handling
+  toggle the nested reveal affordance predictably, and the standard desktop,
+  web, and production-build baseline still passes.
+- 2026-04-19 next slice:
+  keep one-click expand-all as the immediate follow-up before cross-view
+  navigation so the newly introduced nested-expansion state model can be reused
+  instead of replaced.
 
 ## Validation
 

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -11,13 +11,24 @@
 
 - [x] Record the new SDD scope for flow-graph visual refresh, nested expansion,
       and list/flow navigation
+- [x] Implement the first progressive nested-expansion slice without changing
+      the current viewer selection contract:
+      child jobnets can now expand or collapse nested content inline while the
+      existing scope-changing open action remains available
 
 ## Remaining Follow-up
 
+- [ ] Add a one-click expand-all path on top of the new nested-expansion state
+- [ ] Add a deeper nested-expansion slice after the direct-child path is stable:
+      reopen support for nested-in-nested jobnets only when the viewer can
+      render and re-layout those deeper scopes predictably instead of exposing
+      non-working controls
+- [ ] Add flow-view search that finds a target unit and opens the hierarchy
+      needed to reveal that unit in context before focusing it
 - [x] Define the visual cues that most matter for JP1/AJS View resemblance
-- [ ] Decide whether expand-all ships in the same slice as incremental
+- [x] Decide whether expand-all ships in the same slice as incremental
       expansion or immediately after
-- [ ] Document the target behavior when a counterpart list or flow view is not
+- [x] Document the target behavior when a counterpart list or flow view is not
       available
 - [x] Add focused validation plans for selection, navigation, and nested
       expansion state:
@@ -48,3 +59,23 @@
   mapping, desktop `pnpm test` still opens the viewers, and `pnpm run test:web`
   confirms the web preview wiring remains intact after the presentation-only
   restyle.
+- 2026-04-19: the next implementation slice is progressive nested expansion
+  first; one-click expand-all remains in scope but is intentionally sequenced
+  as the immediate follow-up so the first interaction change stays smaller and
+  easier to validate across desktop and web hosts.
+- 2026-04-19: when a counterpart view is unavailable, navigation must leave the
+  current view and selection unchanged; UI affordances should be hidden or
+  disabled when availability is known up front, and any remaining command path
+  should degrade to a predictable no-op instead of mutating local viewer state.
+- 2026-04-19: the first incremental nested-expansion implementation keeps
+  `currentUnitId` as the viewer's base scope and layers additional nested
+  content on top through separate expand/collapse state, so the follow-up
+  expand-all and later navigation slices can reuse the same scope model.
+- 2026-04-19: deeper nested expand/collapse remains intentionally deferred.
+  The current UI now hides those controls below the first nested level until
+  the viewer can reveal multi-level nested scopes with stable layout and
+  collision handling.
+- 2026-04-19: flow-view search is a planned usability follow-up. The desired
+  behavior is to search units from the flow surface, reveal any collapsed
+  ancestors needed to show the match, and then focus the matching unit without
+  requiring manual hierarchy expansion first.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -149,8 +149,11 @@ structure in `docs/specs/features/<feature>/`.
 ### Next Priority Tasks
 
 1. Refresh flow-graph UX in focused slices:
-   visual parity with JP1/AJS View first, then progressive nested expansion and
-   view-to-view navigation.
+   visual parity with JP1/AJS View and the first progressive nested-expansion
+   seam are now in place, so the next active follow-ups are one-click
+   expand-all, deeper nested expansion, flow-view search that can reveal a
+   target unit's hierarchy, and then explicit view-to-view navigation on top of
+   the same interaction model.
 2. Align parameter parsing and `ajs` command generation with
    JP1/Automatic Job Management System 3 version 13 reference manuals.
 3. Define a read-only JP1/AJS WebAPI import boundary with clear application
@@ -163,8 +166,10 @@ structure in `docs/specs/features/<feature>/`.
    manual smoke debt for behavior that still lacks a reliable test seam.
 6. Revisit viewer bundle-size work only when a clearer reduction seam or
    stronger product need appears.
-7. Revisit a dedicated filter/search use case only if a second non-table
-   consumer appears and needs the same matching semantics.
+7. Extend list-view search on the current presentation path so parameter key
+   and value queries can complement the existing partial-match behavior, while
+   still revisiting a dedicated application use case only if another
+   non-table consumer needs the same matching semantics.
 
 ## Wrapper Semantics Matrix
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -73,19 +73,26 @@
    JP1/AJS View while preserving current desktop and web compatibility.
 2. Add progressive nested-graph expansion in the flow view, with both
    user-driven incremental expansion and a one-click expand-all path.
-3. Add explicit navigation between unit-list and flow-graph units when the
+3. Extend nested-graph expansion beyond the first direct-child slice so deeper
+   nested jobnets can be revealed with stable layout and collision handling.
+4. Add flow-view search that locates a unit and reveals the hierarchy needed
+   to show that unit in context before focusing it.
+5. Add explicit navigation between unit-list and flow-graph units when the
    counterpart view for the selected unit is available.
-4. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+6. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
-5. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
+7. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
    generated commands with JP1/Automatic Job Management System 3 version 13
    Command Reference.
-6. Add a read-only JP1/AJS WebAPI import path for loading server-side
+8. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
-7. Replace the custom `UnitEntity` hash implementation with a common
+9. Replace the custom `UnitEntity` hash implementation with a common
    algorithm once identity and compatibility checks are explicit.
-8. Consolidate i18n translation files to reduce duplication between language
-   variants.
+10. Add richer unit-list search on top of the current presentation-local
+    matcher so parameter-key and parameter-value queries complement the current
+    partial-match behavior.
+11. Consolidate i18n translation files to reduce duplication between language
+    variants.
 
 ## Deferred / Optional Slices
 

--- a/src/test/suite/buildExpandedFlowGraph.test.ts
+++ b/src/test/suite/buildExpandedFlowGraph.test.ts
@@ -1,0 +1,249 @@
+import * as assert from "assert";
+import { parseAjs } from "../../domain/services/parser/AjsParser";
+import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
+import { buildExpandedFlowGraph } from "../../ui-component/editor/ajsFlow/buildExpandedFlowGraph";
+
+const nestedDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=child-net,n,+240+144;
+    el=job-b,j,+400+144;
+    ar=(f=child-net,t=job-b);
+    unit=child-net,,jp1admin,;
+    {
+      ty=n;
+      el=grand-net,n,+240+144;
+      el=nested-job,j,+400+144;
+      ar=(f=grand-net,t=nested-job);
+      unit=grand-net,,jp1admin,;
+      {
+        ty=n;
+        el=leaf,j,+240+144;
+        unit=leaf,,jp1admin,;
+        {
+          ty=j;
+        }
+      }
+      unit=nested-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=job-b,,jp1admin,;
+    {
+      ty=j;
+    }
+  }
+}
+`;
+
+const overlappingSiblingDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=child-net,n,+240+144;
+    el=flwj,j,+80+144;
+    el=orj,j,+400+240;
+    el=ntwj,j,+80+336;
+    ar=(f=flwj,t=orj);
+    ar=(f=ntwj,t=orj);
+    unit=child-net,,jp1admin,;
+    {
+      ty=n;
+      el=grand-net,n,+240+144;
+      el=nested-job,j,+400+144;
+      ar=(f=grand-net,t=nested-job);
+      unit=grand-net,,jp1admin,;
+      {
+        ty=n;
+      }
+      unit=nested-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=flwj,,jp1admin,;
+    {
+      ty=j;
+    }
+    unit=orj,,jp1admin,;
+    {
+      ty=j;
+    }
+    unit=ntwj,,jp1admin,;
+    {
+      ty=j;
+    }
+  }
+}
+`;
+
+suite("Build Expanded Flow Graph", () => {
+  test("reveals nested jobnets only after their parent scope is expanded", () => {
+    const result = parseAjs(nestedDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const childNetId = document.rootUnits[0].children[0].children[0].id;
+    const grandNetId =
+      document.rootUnits[0].children[0].children[0].children[0].id;
+    const leafId =
+      document.rootUnits[0].children[0].children[0].children[0].children[0].id;
+
+    const collapsed = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>(),
+      16,
+    );
+    const childExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([childNetId]),
+      16,
+    );
+    const grandOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([grandNetId]),
+      16,
+    );
+    const fullyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([childNetId, grandNetId]),
+      16,
+    );
+
+    assert.ok(collapsed.graph);
+    assert.ok(childExpanded.graph);
+    assert.ok(grandOnlyExpanded.graph);
+    assert.ok(fullyExpanded.graph);
+
+    assert.strictEqual(
+      collapsed.graph?.nodes.some((node) => node.id === grandNetId),
+      false,
+    );
+    assert.strictEqual(
+      childExpanded.graph?.nodes.some((node) => node.id === grandNetId),
+      true,
+    );
+    assert.strictEqual(
+      childExpanded.graph?.nodes.some((node) => node.id === leafId),
+      false,
+    );
+    assert.strictEqual(
+      grandOnlyExpanded.graph?.nodes.some((node) => node.id === leafId),
+      false,
+    );
+    assert.strictEqual(
+      fullyExpanded.graph?.nodes.some((node) => node.id === leafId),
+      true,
+    );
+    assert.deepStrictEqual(
+      childExpanded.graph?.edges.find(
+        (edge) =>
+          edge.source === grandNetId && edge.target.endsWith("/nested-job"),
+      ),
+      {
+        source: grandNetId,
+        target: `${childNetId}/nested-job`,
+        type: "seq",
+      },
+    );
+    const childNetPosition = childExpanded.positionOverrides.get(childNetId);
+    const siblingPosition = childExpanded.positionOverrides.get(
+      `${currentUnitId}/job-b`,
+    );
+    assert.ok(childNetPosition);
+    assert.ok(siblingPosition);
+    assert.ok(siblingPosition!.x > childNetPosition!.x + 96);
+    const childNetDecoration = childExpanded.nodeDecorations.get(childNetId);
+    assert.ok(childNetDecoration);
+    assert.ok(childNetDecoration!.panelWidthPx > 96);
+    assert.ok(childNetDecoration!.panelHeightPx > 96);
+    const fullyExpandedChildDecoration =
+      fullyExpanded.nodeDecorations.get(childNetId);
+    const fullyExpandedGrandDecoration =
+      fullyExpanded.nodeDecorations.get(grandNetId);
+    const fullyExpandedChildPosition =
+      fullyExpanded.positionOverrides.get(childNetId);
+    const fullyExpandedGrandPosition =
+      fullyExpanded.positionOverrides.get(grandNetId);
+    const fullyExpandedSiblingPosition = fullyExpanded.positionOverrides.get(
+      `${currentUnitId}/job-b`,
+    );
+    assert.ok(fullyExpandedChildDecoration);
+    assert.ok(fullyExpandedGrandDecoration);
+    assert.ok(fullyExpandedChildPosition);
+    assert.ok(fullyExpandedGrandPosition);
+    assert.ok(fullyExpandedSiblingPosition);
+    const childPanelRight =
+      fullyExpandedChildPosition!.x +
+      fullyExpandedChildDecoration!.panelOffsetXPx +
+      fullyExpandedChildDecoration!.panelWidthPx;
+    const grandPanelRight =
+      fullyExpandedGrandPosition!.x +
+      fullyExpandedGrandDecoration!.panelOffsetXPx +
+      fullyExpandedGrandDecoration!.panelWidthPx;
+    assert.ok(childPanelRight >= grandPanelRight);
+    assert.ok(fullyExpandedSiblingPosition!.x > childPanelRight);
+  });
+
+  test("moves colliding siblings and their nearby incoming sources below the expanded panel", () => {
+    const result = parseAjs(overlappingSiblingDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const childNetId = document.rootUnits[0].children[0].children[0].id;
+    const flwjId = document.rootUnits[0].children[0].children[1].id;
+    const orjId = document.rootUnits[0].children[0].children[2].id;
+    const ntwjId = document.rootUnits[0].children[0].children[3].id;
+
+    const collapsed = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>(),
+      16,
+    );
+    const expanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([childNetId]),
+      16,
+    );
+
+    const decoration = expanded.nodeDecorations.get(childNetId);
+    const orjCollapsed = collapsed.positionOverrides.get(orjId);
+    const orjExpanded = expanded.positionOverrides.get(orjId);
+    const flwjCollapsed = collapsed.positionOverrides.get(flwjId);
+    const flwjExpanded = expanded.positionOverrides.get(flwjId);
+    const ntwjCollapsed = collapsed.positionOverrides.get(ntwjId);
+    const ntwjExpanded = expanded.positionOverrides.get(ntwjId);
+    const childExpanded = expanded.positionOverrides.get(childNetId);
+
+    assert.ok(decoration);
+    assert.ok(orjCollapsed);
+    assert.ok(orjExpanded);
+    assert.ok(flwjCollapsed);
+    assert.ok(flwjExpanded);
+    assert.ok(ntwjCollapsed);
+    assert.ok(ntwjExpanded);
+    assert.ok(childExpanded);
+
+    const panelBottom =
+      childExpanded!.y + decoration!.panelOffsetYPx + decoration!.panelHeightPx;
+    assert.ok(orjExpanded!.y > panelBottom);
+    assert.ok(flwjExpanded!.y > flwjCollapsed!.y);
+    assert.ok(ntwjExpanded!.y > ntwjCollapsed!.y);
+  });
+});

--- a/src/test/suite/flowGraphView.test.ts
+++ b/src/test/suite/flowGraphView.test.ts
@@ -47,6 +47,46 @@ suite("Flow Graph View", () => {
             },
           },
         },
+        {
+          id: "/root/jobnet/child-net",
+          label: "child-net",
+          type: "jobnet",
+          metadata: {
+            absolutePath: "/root/jobnet/child-net",
+            ty: "n",
+            comment: "nested child",
+            isAncestor: false,
+            isCurrent: false,
+            isRootJobnet: false,
+            hasSchedule: false,
+            hasWaitedFor: false,
+            layout: {
+              kind: "grid",
+              h: 400,
+              v: 144,
+            },
+          },
+        },
+        {
+          id: "/root/jobnet/child-net/grand-net",
+          label: "grand-net",
+          type: "jobnet",
+          metadata: {
+            absolutePath: "/root/jobnet/child-net/grand-net",
+            ty: "n",
+            comment: "nested grandchild",
+            isAncestor: false,
+            isCurrent: false,
+            isRootJobnet: false,
+            hasSchedule: false,
+            hasWaitedFor: false,
+            layout: {
+              kind: "grid",
+              h: 560,
+              v: 240,
+            },
+          },
+        },
       ],
       edges: [
         {
@@ -73,6 +113,22 @@ suite("Flow Graph View", () => {
           commands: [],
         },
       ],
+      [
+        "/root/jobnet/child-net",
+        {
+          absolutePath: "/root/jobnet/child-net",
+          rawData: "ty=n",
+          commands: [],
+        },
+      ],
+      [
+        "/root/jobnet/child-net/grand-net",
+        {
+          absolutePath: "/root/jobnet/child-net/grand-net",
+          rawData: "ty=n",
+          commands: [],
+        },
+      ],
     ]);
 
     const { nodes, edges } = createReactFlowData(
@@ -87,6 +143,74 @@ suite("Flow Graph View", () => {
         currentUnitId: "/root/jobnet",
         setCurrentUnitId: () => undefined,
       },
+      {
+        nodeDecorations: new Map(),
+        unitById: new Map([
+          [
+            "/root/jobnet/child-net",
+            {
+              id: "/root/jobnet/child-net",
+              name: "child-net",
+              unitAttribute: "",
+              unitType: "n",
+              absolutePath: "/root/jobnet/child-net",
+              depth: 2,
+              parentId: "/root/jobnet",
+              isRoot: false,
+              isRootJobnet: false,
+              hasSchedule: false,
+              hasWaitedFor: false,
+              layout: { h: 400, v: 144 },
+              parameters: [],
+              relations: [],
+              children: [
+                {
+                  id: "/root/jobnet/child-net/grand-net",
+                  name: "grand-net",
+                  unitAttribute: "",
+                  unitType: "n",
+                  absolutePath: "/root/jobnet/child-net/grand-net",
+                  depth: 3,
+                  parentId: "/root/jobnet/child-net",
+                  isRoot: false,
+                  isRootJobnet: false,
+                  hasSchedule: false,
+                  hasWaitedFor: false,
+                  layout: { h: 560, v: 240 },
+                  parameters: [],
+                  relations: [],
+                  children: [],
+                },
+              ],
+            },
+          ],
+          [
+            "/root/jobnet/child-net/grand-net",
+            {
+              id: "/root/jobnet/child-net/grand-net",
+              name: "grand-net",
+              unitAttribute: "",
+              unitType: "n",
+              absolutePath: "/root/jobnet/child-net/grand-net",
+              depth: 3,
+              parentId: "/root/jobnet/child-net",
+              isRoot: false,
+              isRootJobnet: false,
+              hasSchedule: false,
+              hasWaitedFor: false,
+              layout: { h: 560, v: 240 },
+              parameters: [],
+              relations: [],
+              children: [],
+            },
+          ],
+        ]),
+        nestedExpansionState: {
+          expandedUnitIds: new Set<string>(),
+          toggleExpandedUnitId: () => undefined,
+        },
+        positionOverrides: new Map(),
+      },
     );
 
     assert.strictEqual(nodes[0].data.unitId, "/root/jobnet");
@@ -97,8 +221,11 @@ suite("Flow Graph View", () => {
     assert.strictEqual(nodes[0].data.isCurrent, true);
     assert.strictEqual(nodes[0].data.isAncestor, true);
     assert.strictEqual(nodes[0].data.isRootJobnet, true);
+    assert.strictEqual(nodes[0].data.canExpandNested, false);
     assert.strictEqual(nodes[1].data.unitId, "/root/jobnet/job-a");
     assert.strictEqual(nodes[1].data.hasWaitedFor, true);
+    assert.strictEqual(nodes[2].data.canExpandNested, true);
+    assert.strictEqual(nodes[3].data.canExpandNested, false);
     assert.strictEqual(edges[0].source, "/root/jobnet");
     assert.strictEqual(edges[0].target, "/root/jobnet/job-a");
   });

--- a/src/test/suite/showUnitDefinitionInteraction.test.ts
+++ b/src/test/suite/showUnitDefinitionInteraction.test.ts
@@ -2,7 +2,9 @@ import * as assert from "assert";
 import type { KeyboardEvent } from "react";
 import { UnitDefinitionDialogDto } from "../../application/unit-definition/buildUnitDefinition";
 import {
+  handleClickNestedToggle,
   handleClickDialogOpen,
+  handleKeyDownNestedToggle,
   handleKeyDownDialogOpen,
 } from "../../ui-component/editor/ajsFlow/nodes/Utils";
 import { AjsNode } from "../../ui-component/editor/ajsFlow/nodes/AjsNode";
@@ -87,5 +89,28 @@ suite("Show Unit Definition interaction", () => {
       key: "Enter",
     } as KeyboardEvent<HTMLElement>);
     assert.deepStrictEqual(received, dialogData);
+  });
+
+  test("flow nested toggle action expands only on click or Enter key", () => {
+    const toggled: string[] = [];
+    const node = createNode({
+      unitId: "/root/jobnet/child-net",
+      toggleExpandedUnitId: (unitId) => {
+        toggled.push(unitId);
+      },
+    });
+
+    handleClickNestedToggle(node)();
+    handleKeyDownNestedToggle(node)({
+      key: "Space",
+    } as KeyboardEvent<HTMLElement>);
+    handleKeyDownNestedToggle(node)({
+      key: "Enter",
+    } as KeyboardEvent<HTMLElement>);
+
+    assert.deepStrictEqual(toggled, [
+      "/root/jobnet/child-net",
+      "/root/jobnet/child-net",
+    ]);
   });
 });

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   Dispatch,
   FC,
   memo,
@@ -25,7 +26,6 @@ import {
   ReactFlowProvider,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { buildFlowGraph } from "../../../application/flow-graph/buildFlowGraph";
 import {
   AjsDocument,
   flattenAjsUnits,
@@ -44,6 +44,7 @@ import JobGroupNode from "./nodes/JobGroupNode";
 import ConditionNode from "./nodes/ConditionNode";
 import Header from "./Header";
 import FlowSelector from "./FlowSelector";
+import { buildExpandedFlowGraph } from "./buildExpandedFlowGraph";
 import { createReactFlowData } from "./flowGraphView";
 
 const defaultViewport = { x: 0, y: 0, zoom: 1.0 };
@@ -75,6 +76,10 @@ export type CurrentUnitIdStateType = {
   currentUnitId?: string;
   setCurrentUnitId: Dispatch<SetStateAction<string | undefined>>;
 };
+export type NestedExpansionStateType = {
+  expandedUnitIds: ReadonlySet<string>;
+  toggleExpandedUnitId: (unitId: string) => void;
+};
 
 const FlowContents: FC = () => {
   console.log("render FlowContents.");
@@ -88,6 +93,7 @@ const FlowContents: FC = () => {
 
   const [ajsDocument, setAjsDocument] = useState<AjsDocument>();
   const [currentUnitId, setCurrentUnitId] = useState<string>();
+  const [expandedUnitIds, setExpandedUnitIds] = useState<string[]>([]);
   const prevUnitEntityId = useRef<string | undefined>(undefined);
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
@@ -113,6 +119,39 @@ const FlowContents: FC = () => {
     () => (currentUnitId ? unitById.get(currentUnitId) : undefined),
     [currentUnitId, unitById],
   );
+  const toggleExpandedUnitId = useCallback((unitId: string) => {
+    setExpandedUnitIds((prev) =>
+      prev.includes(unitId)
+        ? prev.filter((id) => id !== unitId)
+        : [...prev, unitId],
+    );
+  }, []);
+  const expandedUnitIdSet = useMemo(
+    () => new Set(expandedUnitIds),
+    [expandedUnitIds],
+  );
+  const nestedExpansionState = useMemo<NestedExpansionStateType>(
+    () => ({
+      expandedUnitIds: expandedUnitIdSet,
+      toggleExpandedUnitId,
+    }),
+    [expandedUnitIdSet, toggleExpandedUnitId],
+  );
+
+  const currentUnitIdState = useMemo<CurrentUnitIdStateType>(
+    () => ({
+      currentUnitId,
+      setCurrentUnitId,
+    }),
+    [currentUnitId],
+  );
+  const dialogDataState = useMemo<DialogDataStateType>(
+    () => ({
+      dialogData,
+      setDialogData,
+    }),
+    [dialogData],
+  );
 
   const theme = useMemo(
     () =>
@@ -124,38 +163,65 @@ const FlowContents: FC = () => {
     [isDarkMode],
   );
 
-  const updateNodesAndEdges = (selectedUnitId?: string) => {
-    if (!selectedUnitId) {
-      setNodes(() => []);
-      setEdges(() => []);
-      return;
-    }
-    if (!ajsDocument) {
-      setNodes(() => []);
-      setEdges(() => []);
-      return;
-    }
-    const graph = buildFlowGraph(ajsDocument, selectedUnitId);
-    if (!graph) {
-      setNodes(() => []);
-      setEdges(() => []);
-      return;
-    }
-    const { nodes, edges } = createReactFlowData(
-      graph,
-      unitDefinitionByPath,
-      theme,
-      dialogDataState,
+  const updateNodesAndEdges = useCallback(
+    (selectedUnitId?: string) => {
+      if (!selectedUnitId) {
+        setNodes(() => []);
+        setEdges(() => []);
+        return;
+      }
+      if (!ajsDocument) {
+        setNodes(() => []);
+        setEdges(() => []);
+        return;
+      }
+      const { graph, positionOverrides, nodeDecorations } =
+        buildExpandedFlowGraph(
+          ajsDocument,
+          selectedUnitId,
+          nestedExpansionState.expandedUnitIds,
+          theme.typography.htmlFontSize,
+        );
+      if (!graph) {
+        setNodes(() => []);
+        setEdges(() => []);
+        return;
+      }
+      const { nodes, edges } = createReactFlowData(
+        graph,
+        unitDefinitionByPath,
+        theme,
+        dialogDataState,
+        currentUnitIdState,
+        {
+          nodeDecorations,
+          unitById,
+          nestedExpansionState,
+          positionOverrides,
+        },
+      );
+      setNodes(() => nodes);
+      setEdges(() => edges);
+    },
+    [
+      ajsDocument,
       currentUnitIdState,
-    );
-    setNodes(() => nodes);
-    setEdges(() => edges);
-  };
+      dialogDataState,
+      nestedExpansionState,
+      theme,
+      unitDefinitionByPath,
+      unitById,
+    ],
+  );
 
   useEffect(() => {
     updateNodesAndEdges(currentUnitId);
     prevUnitEntityId.current = currentUnitId;
-  }, [ajsDocument, currentUnitId, unitDefinitionByPath, theme, dialogData]);
+  }, [currentUnitId, updateNodesAndEdges]);
+
+  useEffect(() => {
+    setExpandedUnitIds((prev) => (prev.length === 0 ? prev : []));
+  }, [ajsDocument, currentUnitId]);
 
   useEffect(() => {
     const changeDocumentFn = (type: string, data: unknown) => {
@@ -205,14 +271,6 @@ const FlowContents: FC = () => {
   const drawerWidthState = {
     drawerWidth: drawerWidth,
     setDrawerWidth: setDrawerWidth,
-  };
-  const currentUnitIdState = {
-    currentUnitId: currentUnitId,
-    setCurrentUnitId: setCurrentUnitId,
-  };
-  const dialogDataState = {
-    dialogData: dialogData,
-    setDialogData: setDialogData,
   };
 
   return (

--- a/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
+++ b/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
@@ -1,0 +1,467 @@
+import {
+  AjsDocument,
+  AjsUnit,
+  findAjsUnitById,
+  flattenAjsUnits,
+} from "../../../domain/models/ajs/AjsDocument";
+import { buildFlowGraph } from "../../../application/flow-graph/buildFlowGraph";
+import {
+  FlowGraphDto,
+  FlowGraphEdgeDto,
+  FlowGraphNodeDto,
+  FlowGraphNodeType,
+} from "../../../application/flow-graph/buildFlowGraphCore";
+import {
+  calculateFlowGraphNodePosition,
+  calculateNestedChildPosition,
+  calculateNestedConditionPosition,
+  createFlowGraphMetrics,
+  FlowGraphPosition,
+} from "./flowGraphPosition";
+
+export type ExpandedNodeDecoration = {
+  panelOffsetXPx: number;
+  panelOffsetYPx: number;
+  panelWidthPx: number;
+  panelHeightPx: number;
+};
+
+type ExpandedFlowGraphResult = {
+  graph?: FlowGraphDto;
+  positionOverrides: ReadonlyMap<string, FlowGraphPosition>;
+  nodeDecorations: ReadonlyMap<string, ExpandedNodeDecoration>;
+};
+
+type FlowGraphBounds = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+};
+
+const toNodeType = (unit: AjsUnit): FlowGraphNodeType => {
+  switch (unit.unitType) {
+    case "g":
+      return "jobgroup";
+    case "n":
+    case "rn":
+    case "rm":
+    case "rr":
+      return "jobnet";
+    case "rc":
+      return "condition";
+    default:
+      return "job";
+  }
+};
+
+const toGridNode = (unit: AjsUnit): FlowGraphNodeDto => ({
+  id: unit.id,
+  label: unit.name,
+  type: toNodeType(unit),
+  metadata: {
+    absolutePath: unit.absolutePath,
+    ty: unit.unitType,
+    gty: unit.groupType,
+    comment: unit.comment,
+    isAncestor: false,
+    isCurrent: false,
+    isRootJobnet: unit.isRootJobnet,
+    hasSchedule: unit.hasSchedule,
+    hasWaitedFor: unit.hasWaitedFor,
+    layout: {
+      kind: "grid",
+      h: unit.layout.h,
+      v: unit.layout.v,
+    },
+  },
+});
+
+const toConditionNode = (unit: AjsUnit): FlowGraphNodeDto => ({
+  id: unit.id,
+  label: unit.name,
+  type: "condition",
+  metadata: {
+    absolutePath: unit.absolutePath,
+    ty: unit.unitType,
+    gty: unit.groupType,
+    comment: unit.comment,
+    isAncestor: false,
+    isCurrent: false,
+    isRootJobnet: unit.isRootJobnet,
+    hasSchedule: unit.hasSchedule,
+    hasWaitedFor: unit.hasWaitedFor,
+    layout: {
+      kind: "ancestor",
+      depth: unit.depth,
+    },
+  },
+});
+
+const toEdgeDtos = (unit: AjsUnit): FlowGraphEdgeDto[] =>
+  unit.relations.map((relation) => ({
+    source: relation.sourceUnitId,
+    target: relation.targetUnitId,
+    type: relation.type,
+  }));
+
+const isDescendantOf = (
+  unit: AjsUnit,
+  ancestorId: string,
+  unitById: ReadonlyMap<string, AjsUnit>,
+): boolean => {
+  let current = unit.parentId ? unitById.get(unit.parentId) : undefined;
+  while (current) {
+    if (current.id === ancestorId) {
+      return true;
+    }
+    current = current.parentId ? unitById.get(current.parentId) : undefined;
+  }
+  return false;
+};
+
+const includeNodeBounds = (
+  bounds: FlowGraphBounds,
+  position: FlowGraphPosition,
+  width: number,
+  height: number,
+) => {
+  bounds.minX = Math.min(bounds.minX, position.x);
+  bounds.maxX = Math.max(bounds.maxX, position.x + width);
+  bounds.minY = Math.min(bounds.minY, position.y);
+  bounds.maxY = Math.max(bounds.maxY, position.y + height);
+};
+
+const includeDecorationBounds = (
+  bounds: FlowGraphBounds,
+  position: FlowGraphPosition,
+  decoration: ExpandedNodeDecoration,
+) => {
+  bounds.minX = Math.min(bounds.minX, position.x + decoration.panelOffsetXPx);
+  bounds.maxX = Math.max(
+    bounds.maxX,
+    position.x + decoration.panelOffsetXPx + decoration.panelWidthPx,
+  );
+  bounds.minY = Math.min(bounds.minY, position.y + decoration.panelOffsetYPx);
+  bounds.maxY = Math.max(
+    bounds.maxY,
+    position.y + decoration.panelOffsetYPx + decoration.panelHeightPx,
+  );
+};
+
+const intersectsBounds = (
+  position: FlowGraphPosition,
+  width: number,
+  height: number,
+  bounds: FlowGraphBounds,
+): boolean =>
+  position.x < bounds.maxX &&
+  position.x + width > bounds.minX &&
+  position.y < bounds.maxY &&
+  position.y + height > bounds.minY;
+
+export const buildExpandedFlowGraph = (
+  document: AjsDocument,
+  currentUnitId: string,
+  expandedUnitIds: ReadonlySet<string>,
+  basePx: number,
+): ExpandedFlowGraphResult => {
+  const baseGraph = buildFlowGraph(document, currentUnitId);
+  if (!baseGraph) {
+    return {
+      graph: undefined,
+      positionOverrides: new Map<string, FlowGraphPosition>(),
+      nodeDecorations: new Map<string, ExpandedNodeDecoration>(),
+    };
+  }
+
+  const metrics = createFlowGraphMetrics(basePx);
+  const nodes = [...baseGraph.nodes];
+  const edges = [...baseGraph.edges];
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const edgeIds = new Set(edges.map((edge) => `${edge.source}-${edge.target}`));
+  const positionOverrides = new Map<string, FlowGraphPosition>();
+  const nodeDecorations = new Map<string, ExpandedNodeDecoration>();
+
+  for (const node of baseGraph.nodes) {
+    positionOverrides.set(
+      node.id,
+      calculateFlowGraphNodePosition(node, basePx),
+    );
+  }
+
+  const allUnits = flattenAjsUnits(document.rootUnits);
+  const unitById = new Map(allUnits.map((unit) => [unit.id, unit]));
+  const currentUnit = findAjsUnitById(document, currentUnitId);
+  if (!currentUnit) {
+    return { graph: baseGraph, positionOverrides, nodeDecorations };
+  }
+
+  const visibleUnitIds = new Set(nodes.map((node) => node.id));
+  const incomingSourcesByTarget = new Map<string, string[]>();
+  for (const edge of edges) {
+    const sources = incomingSourcesByTarget.get(edge.target) ?? [];
+    sources.push(edge.source);
+    incomingSourcesByTarget.set(edge.target, sources);
+  }
+
+  const shiftVisibleNodes = (
+    targetUnit: AjsUnit,
+    targetMinX: number,
+    excludes: ReadonlySet<string>,
+  ) => {
+    let minSiblingX = Number.POSITIVE_INFINITY;
+    for (const unitId of visibleUnitIds) {
+      if (excludes.has(unitId)) {
+        continue;
+      }
+      const unit = unitById.get(unitId);
+      const position = positionOverrides.get(unitId);
+      if (!unit || !position) {
+        continue;
+      }
+      if (unit.parentId !== targetUnit.parentId) {
+        continue;
+      }
+      if (position.x <= (positionOverrides.get(targetUnit.id)?.x ?? 0)) {
+        continue;
+      }
+      minSiblingX = Math.min(minSiblingX, position.x);
+    }
+
+    const dx = Number.isFinite(minSiblingX)
+      ? Math.max(0, targetMinX - minSiblingX)
+      : 0;
+    if (dx <= 0) {
+      return;
+    }
+
+    for (const unitId of visibleUnitIds) {
+      if (excludes.has(unitId)) {
+        continue;
+      }
+      const unit = unitById.get(unitId);
+      const position = positionOverrides.get(unitId);
+      if (!unit || !position) {
+        continue;
+      }
+      if (unit.parentId !== targetUnit.parentId) {
+        continue;
+      }
+      if (position.x <= (positionOverrides.get(targetUnit.id)?.x ?? 0)) {
+        continue;
+      }
+      positionOverrides.set(unitId, { x: position.x + dx, y: position.y });
+    }
+  };
+
+  const shiftNodeByDelta = (unitId: string, dy: number) => {
+    const position = positionOverrides.get(unitId);
+    if (!position || dy <= 0) {
+      return;
+    }
+    positionOverrides.set(unitId, {
+      x: position.x,
+      y: position.y + dy,
+    });
+  };
+
+  const cascadeShiftToIncomingSources = (
+    unitId: string,
+    dy: number,
+    subtreeUnitIds: ReadonlySet<string>,
+    panelBounds: FlowGraphBounds,
+    visited: Set<string>,
+  ) => {
+    if (visited.has(unitId)) {
+      return;
+    }
+    visited.add(unitId);
+    const incomingSources = incomingSourcesByTarget.get(unitId) ?? [];
+    for (const sourceUnitId of incomingSources) {
+      if (subtreeUnitIds.has(sourceUnitId)) {
+        continue;
+      }
+      const sourcePosition = positionOverrides.get(sourceUnitId);
+      const targetPosition = positionOverrides.get(unitId);
+      if (!sourcePosition || !targetPosition) {
+        continue;
+      }
+      if (sourcePosition.x >= targetPosition.x) {
+        continue;
+      }
+      if (sourcePosition.y + metrics.height < panelBounds.minY) {
+        continue;
+      }
+      shiftNodeByDelta(sourceUnitId, dy);
+      cascadeShiftToIncomingSources(
+        sourceUnitId,
+        dy,
+        subtreeUnitIds,
+        panelBounds,
+        visited,
+      );
+    }
+  };
+
+  const sortedExpandedUnits = [...expandedUnitIds]
+    .map((unitId) => unitById.get(unitId))
+    .filter(
+      (unit): unit is AjsUnit =>
+        !!unit &&
+        unit.id !== currentUnitId &&
+        unit.unitType === "n" &&
+        isDescendantOf(unit, currentUnitId, unitById),
+    )
+    .sort((left, right) => right.depth - left.depth);
+
+  for (const expandedUnit of sortedExpandedUnits) {
+    const parentPosition = positionOverrides.get(expandedUnit.id);
+    if (!parentPosition) {
+      continue;
+    }
+    const subtreeUnitIds = new Set<string>([expandedUnit.id]);
+    const bounds: FlowGraphBounds = {
+      minX: parentPosition.x,
+      maxX: parentPosition.x + metrics.width,
+      minY: parentPosition.y,
+      maxY: parentPosition.y + metrics.height,
+    };
+
+    for (const child of expandedUnit.children.filter(
+      (unit) => unit.unitType !== "rc",
+    )) {
+      subtreeUnitIds.add(child.id);
+      let childPosition = positionOverrides.get(child.id);
+      if (!nodeIds.has(child.id)) {
+        nodes.push(toGridNode(child));
+        nodeIds.add(child.id);
+        visibleUnitIds.add(child.id);
+        childPosition = calculateNestedChildPosition(
+          parentPosition,
+          child.layout.h,
+          child.layout.v,
+          basePx,
+        );
+        positionOverrides.set(child.id, childPosition);
+      }
+      if (!childPosition) {
+        continue;
+      }
+      includeNodeBounds(bounds, childPosition, metrics.width, metrics.height);
+      const childDecoration = nodeDecorations.get(child.id);
+      if (childDecoration) {
+        includeDecorationBounds(bounds, childPosition, childDecoration);
+      }
+    }
+
+    const conditionUnit = expandedUnit.children.find(
+      (child) => child.unitType === "rc",
+    );
+    if (conditionUnit) {
+      subtreeUnitIds.add(conditionUnit.id);
+      let conditionPosition = positionOverrides.get(conditionUnit.id);
+      if (!nodeIds.has(conditionUnit.id)) {
+        nodes.push(toConditionNode(conditionUnit));
+        nodeIds.add(conditionUnit.id);
+        visibleUnitIds.add(conditionUnit.id);
+        conditionPosition = calculateNestedConditionPosition(
+          parentPosition,
+          basePx,
+        );
+        positionOverrides.set(conditionUnit.id, conditionPosition);
+      }
+      if (conditionPosition) {
+        includeNodeBounds(
+          bounds,
+          conditionPosition,
+          metrics.width,
+          metrics.height,
+        );
+      }
+    }
+
+    for (const edge of toEdgeDtos(expandedUnit)) {
+      const edgeId = `${edge.source}-${edge.target}`;
+      if (edgeIds.has(edgeId)) {
+        continue;
+      }
+      edges.push(edge);
+      edgeIds.add(edgeId);
+    }
+
+    const panelPaddingX = metrics.width * 0.3;
+    const panelPaddingTop = metrics.height * 0.2;
+    const panelPaddingBottom = metrics.height * 0.35;
+    const panelMinX = bounds.minX - panelPaddingX;
+    const panelMaxX = bounds.maxX + panelPaddingX;
+    const panelBounds: FlowGraphBounds = {
+      minX: panelMinX,
+      maxX: panelMaxX,
+      minY: bounds.minY - panelPaddingTop,
+      maxY: bounds.maxY + panelPaddingBottom,
+    };
+    shiftVisibleNodes(
+      expandedUnit,
+      panelMaxX + metrics.marginX,
+      subtreeUnitIds,
+    );
+
+    const collidingSiblingIds = [...visibleUnitIds]
+      .filter((unitId) => !subtreeUnitIds.has(unitId))
+      .filter((unitId) => {
+        const position = positionOverrides.get(unitId);
+        return (
+          !!position &&
+          intersectsBounds(position, metrics.width, metrics.height, panelBounds)
+        );
+      })
+      .sort(
+        (left, right) =>
+          (positionOverrides.get(left)?.y ?? 0) -
+          (positionOverrides.get(right)?.y ?? 0),
+      );
+
+    let nextAvailableY = panelBounds.maxY + metrics.marginY;
+    for (const siblingId of collidingSiblingIds) {
+      const siblingPosition = positionOverrides.get(siblingId);
+      if (!siblingPosition) {
+        continue;
+      }
+      const dy = Math.max(0, nextAvailableY - siblingPosition.y);
+      if (dy <= 0) {
+        nextAvailableY = siblingPosition.y + metrics.height + metrics.marginY;
+        continue;
+      }
+      shiftNodeByDelta(siblingId, dy);
+      cascadeShiftToIncomingSources(
+        siblingId,
+        dy,
+        subtreeUnitIds,
+        panelBounds,
+        new Set<string>(),
+      );
+      nextAvailableY =
+        (positionOverrides.get(siblingId)?.y ?? siblingPosition.y) +
+        metrics.height +
+        metrics.marginY;
+    }
+
+    nodeDecorations.set(expandedUnit.id, {
+      panelOffsetXPx: panelMinX - parentPosition.x,
+      panelOffsetYPx: -panelPaddingTop,
+      panelWidthPx: panelMaxX - panelMinX,
+      panelHeightPx:
+        bounds.maxY - parentPosition.y + panelPaddingTop + panelPaddingBottom,
+    });
+  }
+
+  return {
+    graph: {
+      nodes,
+      edges,
+    },
+    positionOverrides,
+    nodeDecorations,
+  };
+};

--- a/src/ui-component/editor/ajsFlow/flowGraphPosition.ts
+++ b/src/ui-component/editor/ajsFlow/flowGraphPosition.ts
@@ -1,0 +1,84 @@
+import { FlowGraphNodeDto } from "../../../application/flow-graph/buildFlowGraphCore";
+
+export type FlowGraphPosition = {
+  x: number;
+  y: number;
+};
+
+type FlowGraphMetrics = {
+  width: number;
+  height: number;
+  ancestorMarginX: number;
+  marginX: number;
+  marginY: number;
+  offsetX: number;
+  ancestorOffsetY: number;
+  gridOffsetY: number;
+};
+
+export const createFlowGraphMetrics = (basePx: number): FlowGraphMetrics => {
+  const width = basePx * 6;
+  const height = basePx * 6;
+  return {
+    width,
+    height,
+    ancestorMarginX: width / 5,
+    marginX: width / 4,
+    marginY: height / 4,
+    offsetX: width / 3,
+    ancestorOffsetY: height / 2,
+    gridOffsetY: height * 2,
+  };
+};
+
+export const calculateFlowGraphNodePosition = (
+  node: FlowGraphNodeDto,
+  basePx: number,
+): FlowGraphPosition => {
+  const metrics = createFlowGraphMetrics(basePx);
+  if (node.metadata.layout.kind === "ancestor") {
+    return {
+      x:
+        metrics.offsetX +
+        (metrics.width + metrics.ancestorMarginX) * node.metadata.layout.depth,
+      y: metrics.ancestorOffsetY,
+    };
+  }
+
+  const { h, v } = node.metadata.layout;
+  return {
+    x:
+      metrics.offsetX +
+      (metrics.width + metrics.marginX) * ((h - 80) / 160 - 1),
+    y:
+      metrics.gridOffsetY +
+      (metrics.height + metrics.marginY) * ((v - 48) / 96),
+  };
+};
+
+export const calculateNestedChildPosition = (
+  parentPosition: FlowGraphPosition,
+  h: number,
+  v: number,
+  basePx: number,
+): FlowGraphPosition => {
+  const metrics = createFlowGraphMetrics(basePx);
+  return {
+    x: parentPosition.x + (metrics.width + metrics.marginX) * ((h - 240) / 160),
+    y:
+      parentPosition.y +
+      metrics.height * 2.5 +
+      (metrics.height + metrics.marginY) * ((v - 144) / 96),
+  };
+};
+
+export const calculateNestedConditionPosition = (
+  parentPosition: FlowGraphPosition,
+  basePx: number,
+): FlowGraphPosition => {
+  const metrics = createFlowGraphMetrics(basePx);
+  return {
+    x: parentPosition.x - metrics.width - metrics.marginX,
+    y: parentPosition.y + metrics.height * 1.4,
+  };
+};

--- a/src/ui-component/editor/ajsFlow/flowGraphView.ts
+++ b/src/ui-component/editor/ajsFlow/flowGraphView.ts
@@ -1,47 +1,42 @@
 import type { Theme } from "@mui/material/styles";
 import { Edge, MarkerType, Node } from "@xyflow/react";
+import { AjsUnit } from "../../../domain/models/ajs/AjsDocument";
 import {
   FlowGraphDto,
+  FlowGraphEdgeDto,
   FlowGraphNodeDto,
 } from "../../../application/flow-graph/buildFlowGraphCore";
 import { UnitDefinitionDialogDto } from "../../../application/unit-definition/buildUnitDefinition";
-import { CurrentUnitIdStateType, DialogDataStateType } from "./FlowContents";
+import {
+  CurrentUnitIdStateType,
+  DialogDataStateType,
+  NestedExpansionStateType,
+} from "./FlowContents";
+import { ExpandedNodeDecoration } from "./buildExpandedFlowGraph";
 import { AjsNode } from "./nodes/AjsNode";
+import { calculateFlowGraphNodePosition } from "./flowGraphPosition";
 
-const calcPosition = (node: FlowGraphNodeDto, theme: Theme) => {
-  if (node.metadata.layout.kind === "ancestor") {
-    const basePx = theme.typography.htmlFontSize;
-    const width = basePx * 6;
-    const height = basePx * 6;
-    const marginX = width / 5;
-    const offsetX = width / 3;
-    const offsetY = height / 2;
-    return {
-      x: offsetX + (width + marginX) * node.metadata.layout.depth,
-      y: offsetY,
-    };
-  }
-
-  const { h, v } = node.metadata.layout;
-  const basePx = theme.typography.htmlFontSize;
-  const width = basePx * 6;
-  const height = basePx * 6;
-  const marginX = width / 4;
-  const marginY = height / 4;
-  const offsetX = width / 3;
-  const offsetY = height * 2;
-
-  return {
-    x: offsetX + (width + marginX) * ((h - 80) / 160 - 1),
-    y: offsetY + (height + marginY) * ((v - 48) / 96),
-  };
+type CreateReactFlowDataOptions = {
+  unitById?: ReadonlyMap<string, AjsUnit>;
+  nestedExpansionState?: NestedExpansionStateType;
+  nodeDecorations?: ReadonlyMap<string, ExpandedNodeDecoration>;
+  positionOverrides?: ReadonlyMap<string, { x: number; y: number }>;
 };
+
+const hasExpandableChildren = (unit?: AjsUnit): boolean =>
+  !!unit && unit.unitType === "n" && unit.children.length > 0;
+
+const isDirectNestedExpansionTarget = (
+  unit: AjsUnit | undefined,
+  currentUnitId: string | undefined,
+): boolean => !!unit && !!currentUnitId && unit.parentId === currentUnitId;
 
 const toNodeData = (
   node: FlowGraphNodeDto,
   unitDefinitionByPath: ReadonlyMap<string, UnitDefinitionDialogDto>,
   dialogDataState: DialogDataStateType,
   currentUnitIdState: CurrentUnitIdStateType,
+  options?: CreateReactFlowDataOptions,
 ): AjsNode => {
   const unitDefinition = unitDefinitionByPath.get(node.metadata.absolutePath);
   if (!unitDefinition) {
@@ -50,7 +45,9 @@ const toNodeData = (
     );
   }
 
+  const unit = options?.unitById?.get(node.id);
   return {
+    nestedPanel: options?.nodeDecorations?.get(node.id),
     unitId: node.id,
     unitDefinition,
     label: node.label,
@@ -62,10 +59,40 @@ const toNodeData = (
     isRootJobnet: node.metadata.isRootJobnet,
     hasSchedule: node.metadata.hasSchedule,
     hasWaitedFor: node.metadata.hasWaitedFor,
+    canExpandNested:
+      !node.metadata.isCurrent &&
+      !node.metadata.isAncestor &&
+      hasExpandableChildren(unit) &&
+      isDirectNestedExpansionTarget(unit, currentUnitIdState.currentUnitId),
+    isExpandedNested: options?.nestedExpansionState?.expandedUnitIds.has(
+      node.id,
+    ),
+    toggleExpandedUnitId: options?.nestedExpansionState?.toggleExpandedUnitId,
     ...dialogDataState,
     ...currentUnitIdState,
   };
 };
+
+const toEdge = (edge: FlowGraphEdgeDto): Edge => ({
+  id: `${edge.source}-${edge.target}`,
+  type: "smoothstep",
+  source: edge.source,
+  target: edge.target,
+  markerStart:
+    edge.type === "con"
+      ? {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        }
+      : undefined,
+  markerEnd: {
+    type: MarkerType.ArrowClosed,
+    width: 20,
+    height: 20,
+  },
+  animated: edge.type === "con",
+});
 
 export const createReactFlowData = (
   graph: FlowGraphDto,
@@ -73,6 +100,7 @@ export const createReactFlowData = (
   theme: Theme,
   dialogDataState: DialogDataStateType,
   currentUnitIdState: CurrentUnitIdStateType,
+  options?: CreateReactFlowDataOptions,
 ): { nodes: Node<AjsNode>[]; edges: Edge[] } => {
   const nodes: Node<AjsNode>[] = graph.nodes.map((node) => ({
     id: node.id,
@@ -82,30 +110,14 @@ export const createReactFlowData = (
       unitDefinitionByPath,
       dialogDataState,
       currentUnitIdState,
+      options,
     ),
-    position: calcPosition(node, theme),
+    position:
+      options?.positionOverrides?.get(node.id) ??
+      calculateFlowGraphNodePosition(node, theme.typography.htmlFontSize),
   }));
 
-  const edges: Edge[] = graph.edges.map((edge) => ({
-    id: `${edge.source}-${edge.target}`,
-    type: "smoothstep",
-    source: edge.source,
-    target: edge.target,
-    markerStart:
-      edge.type === "con"
-        ? {
-            type: MarkerType.ArrowClosed,
-            width: 20,
-            height: 20,
-          }
-        : undefined,
-    markerEnd: {
-      type: MarkerType.ArrowClosed,
-      width: 20,
-      height: 20,
-    },
-    animated: edge.type === "con",
-  }));
+  const edges: Edge[] = graph.edges.map(toEdge);
 
   return { nodes, edges };
 };

--- a/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
@@ -11,6 +11,12 @@ import { tyDefinitionLang } from "../../../../domain/services/i18n/nls";
 import { useMyAppContext } from "../../MyContexts";
 
 export type AjsNode = {
+  nestedPanel?: {
+    panelOffsetXPx: number;
+    panelOffsetYPx: number;
+    panelWidthPx: number;
+    panelHeightPx: number;
+  };
   unitId: string;
   unitDefinition: UnitDefinitionDialogDto;
   label: string;
@@ -22,6 +28,9 @@ export type AjsNode = {
   isRootJobnet: boolean;
   hasSchedule: boolean;
   hasWaitedFor: boolean;
+  canExpandNested?: boolean;
+  isExpandedNested?: boolean;
+  toggleExpandedUnitId?: (unitId: string) => void;
 } & DialogDataStateType &
   CurrentUnitIdStateType &
   Record<string, unknown>;
@@ -30,10 +39,14 @@ export const buildNodeSxProps = ({
   isCurrent,
   isAncestor,
   isRootJobnet,
+  nestedPanel,
 }: Pick<
   AjsNode,
-  "isCurrent" | "isAncestor" | "isRootJobnet"
+  "isCurrent" | "isAncestor" | "isRootJobnet" | "nestedPanel"
 >): SxProps<Theme> => ({
+  position: "relative",
+  zIndex: 1,
+  overflow: "visible",
   width: "7.25em",
   minHeight: "7.25em",
   paddingX: "0.55em",
@@ -73,6 +86,23 @@ export const buildNodeSxProps = ({
   "&:hover": {
     transform: "translateY(-1px)",
   },
+  "&::after": nestedPanel
+    ? {
+        content: '""',
+        position: "absolute",
+        left: `${nestedPanel.panelOffsetXPx}px`,
+        top: `${nestedPanel.panelOffsetYPx}px`,
+        width: `${nestedPanel.panelWidthPx}px`,
+        height: `${nestedPanel.panelHeightPx}px`,
+        borderRadius: "1.5em",
+        border: (theme) => `1px solid ${theme.palette.primary.light}`,
+        background: (theme) =>
+          `linear-gradient(180deg, ${theme.palette.primary.light}10 0%, ${theme.palette.background.paper}cc 100%)`,
+        boxShadow: (theme) => `inset 0 0 0 1px ${theme.palette.divider}`,
+        pointerEvents: "none",
+        zIndex: -1,
+      }
+    : undefined,
   "& button": {
     color: (theme) =>
       isCurrent ? theme.palette.info.dark : theme.palette.text.secondary,

--- a/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
@@ -6,6 +6,8 @@ import DescriptionIcon from "@mui/icons-material/Description";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import ScheduleIcon from "@mui/icons-material/Schedule";
 import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
+import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 import classNames from "classnames";
 import {
   ActionIcon,
@@ -20,8 +22,10 @@ import {
 import {
   handleClickChildOpen,
   handleClickDialogOpen,
+  handleClickNestedToggle,
   handleKeyDownChildOpen,
   handleKeyDownDialogOpen,
+  handleKeyDownNestedToggle,
 } from "./Utils";
 
 export type JobNetNode = Node<AjsNode, "jobnet">;
@@ -37,6 +41,8 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
     hasSchedule,
     hasWaitedFor,
     isRootJobnet,
+    canExpandNested,
+    isExpandedNested,
     label,
     comment,
     ty,
@@ -46,7 +52,12 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
     <>
       <Stack
         id={unitId}
-        sx={buildNodeSxProps({ isCurrent, isAncestor, isRootJobnet })}
+        sx={buildNodeSxProps({
+          isCurrent,
+          isAncestor,
+          isRootJobnet,
+          nestedPanel: data.nestedPanel,
+        })}
         className={classNames({
           current: isCurrent,
           ancestor: isAncestor,
@@ -70,6 +81,29 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
               onClick={handleClickChildOpen(data)}
               onKeyDown={handleKeyDownChildOpen(data)}
               icon={<FolderOpenIcon fontSize="inherit" />}
+            />
+          )}
+          {!isCurrent && canExpandNested && (
+            <ActionIcon
+              title={
+                isExpandedNested
+                  ? "Collapse the nested jobnet."
+                  : "Expand the nested jobnet."
+              }
+              ariaLabel={
+                isExpandedNested
+                  ? "Collapse the nested jobnet."
+                  : "Expand the nested jobnet."
+              }
+              onClick={handleClickNestedToggle(data)}
+              onKeyDown={handleKeyDownNestedToggle(data)}
+              icon={
+                isExpandedNested ? (
+                  <UnfoldLessIcon fontSize="inherit" />
+                ) : (
+                  <UnfoldMoreIcon fontSize="inherit" />
+                )
+              }
             />
           )}
           {hasSchedule && (

--- a/src/ui-component/editor/ajsFlow/nodes/Utils.ts
+++ b/src/ui-component/editor/ajsFlow/nodes/Utils.ts
@@ -21,3 +21,16 @@ export const handleKeyDownChildOpen =
     const { unitId, setCurrentUnitId } = data;
     event.key === "Enter" && setCurrentUnitId(() => unitId);
   };
+
+export const handleClickNestedToggle = (data: AjsNode) => () => {
+  const { unitId, toggleExpandedUnitId } = data;
+  toggleExpandedUnitId?.(unitId);
+};
+
+export const handleKeyDownNestedToggle =
+  (data: AjsNode) => (event: React.KeyboardEvent<HTMLElement>) => {
+    const { unitId, toggleExpandedUnitId } = data;
+    if (event.key === "Enter") {
+      toggleExpandedUnitId?.(unitId);
+    }
+  };


### PR DESCRIPTION
## Summary

- add the first flow nested-expansion slice so direct child jobnets can expand inline without changing the current flow scope
- improve flow expansion presentation with highlighted frames, sibling collision handling, and safer control visibility
- update changelog and SDD roadmap items for future deeper nested expansion, flow search, and richer list search

## Why

The flow viewer needed a first step toward JP1/AJS View-like nested exploration, but the initial implementation also uncovered layout and UX gaps around nested frames, overlapping siblings, and unsupported deeper nested toggles. This PR lands the initial slice while documenting the remaining roadmap explicitly.

## User Impact

- flow users can expand direct child jobnets inline
- expanded regions are visually grouped and nearby colliding nodes are repositioned more predictably
- unsupported deeper nested expand/collapse controls are hidden instead of appearing broken
- `CHANGELOG.md` now records the work under the planned `1.15.0` release section

## Validation

- `pnpm run qlty`
- `pnpm test`
- `pnpm run build`
- `pnpm run lint:md`
