### PR TITLE
[codex] add flow expand-all control

### DIFF
--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -61,6 +61,20 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
   keep one-click expand-all as the immediate follow-up before cross-view
   navigation so the newly introduced nested-expansion state model can be reused
   instead of replaced.
+- 2026-04-19 implementation result:
+  the flow header now exposes a one-click nested-scope control that expands
+  every expandable descendant jobnet in the current scope and collapses the
+  same scope back to baseline once everything is open, while keeping the
+  existing `currentUnitId`-driven selection contract unchanged.
+- 2026-04-19 validation result:
+  focused helper coverage now verifies which nested jobnets qualify for the
+  scope-wide action and when the current scope should be treated as fully
+  expanded, alongside the existing graph expansion regression coverage and the
+  standard desktop, web, and build baseline.
+- 2026-04-19 next slice:
+  move from scope-wide expansion to deeper nested reveal and search behavior,
+  reusing the same expansion-state model rather than replacing it for each
+  follow-up interaction.
 
 ## Validation
 

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -18,7 +18,7 @@
 
 ## Remaining Follow-up
 
-- [ ] Add a one-click expand-all path on top of the new nested-expansion state
+- [x] Add a one-click expand-all path on top of the new nested-expansion state
 - [ ] Add a deeper nested-expansion slice after the direct-child path is stable:
       reopen support for nested-in-nested jobnets only when the viewer can
       render and re-layout those deeper scopes predictably instead of exposing
@@ -71,6 +71,10 @@
   `currentUnitId` as the viewer's base scope and layers additional nested
   content on top through separate expand/collapse state, so the follow-up
   expand-all and later navigation slices can reuse the same scope model.
+- 2026-04-19: one-click expand-all now reuses the same nested-expansion state
+  model instead of introducing a separate graph mode; when every expandable
+  nested jobnet in the current scope is already open, the same control
+  collapses that scope back to the current baseline.
 - 2026-04-19: deeper nested expand/collapse remains intentionally deferred.
   The current UI now hides those controls below the first nested level until
   the viewer can reveal multi-level nested scopes with stable layout and

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -149,11 +149,10 @@ structure in `docs/specs/features/<feature>/`.
 ### Next Priority Tasks
 
 1. Refresh flow-graph UX in focused slices:
-   visual parity with JP1/AJS View and the first progressive nested-expansion
-   seam are now in place, so the next active follow-ups are one-click
-   expand-all, deeper nested expansion, flow-view search that can reveal a
-   target unit's hierarchy, and then explicit view-to-view navigation on top of
-   the same interaction model.
+   visual parity with JP1/AJS View plus both incremental and one-click nested
+   expansion are now in place, so the next active follow-ups are deeper nested
+   expansion, flow-view search that can reveal a target unit's hierarchy, and
+   then explicit view-to-view navigation on top of the same interaction model.
 2. Align parameter parsing and `ajs` command generation with
    JP1/Automatic Job Management System 3 version 13 reference manuals.
 3. Define a read-only JP1/AJS WebAPI import boundary with clear application

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -66,32 +66,33 @@
     confirm current hashed ids stay inside transient UI identity paths,
     document the persistence boundaries that must stay clear, and name the
     regression coverage to refresh before swapping algorithms.
+27. Add a one-click expand-all path on top of the flow viewer's new
+    nested-expansion state so users can reveal the current scope in one step
+    without changing the existing selection contract.
 
 ## Current Roadmap
 
 1. Refresh the flow-graph presentation so its visual design is closer to
    JP1/AJS View while preserving current desktop and web compatibility.
-2. Add progressive nested-graph expansion in the flow view, with both
-   user-driven incremental expansion and a one-click expand-all path.
-3. Extend nested-graph expansion beyond the first direct-child slice so deeper
+2. Extend nested-graph expansion beyond the first direct-child slice so deeper
    nested jobnets can be revealed with stable layout and collision handling.
-4. Add flow-view search that locates a unit and reveals the hierarchy needed
+3. Add flow-view search that locates a unit and reveals the hierarchy needed
    to show that unit in context before focusing it.
-5. Add explicit navigation between unit-list and flow-graph units when the
+4. Add explicit navigation between unit-list and flow-graph units when the
    counterpart view for the selected unit is available.
-6. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+5. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
-7. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
+6. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
    generated commands with JP1/Automatic Job Management System 3 version 13
    Command Reference.
-8. Add a read-only JP1/AJS WebAPI import path for loading server-side
+7. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
-9. Replace the custom `UnitEntity` hash implementation with a common
+8. Replace the custom `UnitEntity` hash implementation with a common
    algorithm once identity and compatibility checks are explicit.
-10. Add richer unit-list search on top of the current presentation-local
-    matcher so parameter-key and parameter-value queries complement the current
-    partial-match behavior.
-11. Consolidate i18n translation files to reduce duplication between language
+9. Add richer unit-list search on top of the current presentation-local
+   matcher so parameter-key and parameter-value queries complement the current
+   partial-match behavior.
+10. Consolidate i18n translation files to reduce duplication between language
     variants.
 
 ## Deferred / Optional Slices

--- a/src/test/suite/nestedExpansion.test.ts
+++ b/src/test/suite/nestedExpansion.test.ts
@@ -1,0 +1,88 @@
+import * as assert from "assert";
+import { parseAjs } from "../../domain/services/parser/AjsParser";
+import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
+import {
+  collectExpandableNestedUnitIds,
+  hasExpandedAllNestedUnitIds,
+} from "../../ui-component/editor/ajsFlow/nestedExpansion";
+
+const nestedDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=child-net,n,+240+144;
+    el=job-b,j,+400+144;
+    ar=(f=child-net,t=job-b);
+    unit=child-net,,jp1admin,;
+    {
+      ty=n;
+      el=grand-net,n,+240+144;
+      el=nested-job,j,+400+144;
+      ar=(f=grand-net,t=nested-job);
+      unit=grand-net,,jp1admin,;
+      {
+        ty=n;
+        el=leaf,j,+240+144;
+        unit=leaf,,jp1admin,;
+        {
+          ty=j;
+        }
+      }
+      unit=nested-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=job-b,,jp1admin,;
+    {
+      ty=j;
+    }
+  }
+}
+`;
+
+suite("Nested Expansion", () => {
+  test("collects every expandable nested jobnet in the current scope", () => {
+    const result = parseAjs(nestedDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnit = document.rootUnits[0].children[0];
+    const childNetId = currentUnit.children[0].id;
+    const grandNetId = currentUnit.children[0].children[0].id;
+
+    assert.deepStrictEqual(collectExpandableNestedUnitIds(currentUnit), [
+      childNetId,
+      grandNetId,
+    ]);
+  });
+
+  test("detects when the current scope is already fully expanded", () => {
+    const expandableUnitIds = [
+      "/root/jobnet/child-net",
+      "/root/jobnet/grand-net",
+    ];
+
+    assert.strictEqual(
+      hasExpandedAllNestedUnitIds(expandableUnitIds, new Set<string>()),
+      false,
+    );
+    assert.strictEqual(
+      hasExpandedAllNestedUnitIds(
+        expandableUnitIds,
+        new Set<string>(["/root/jobnet/child-net"]),
+      ),
+      false,
+    );
+    assert.strictEqual(
+      hasExpandedAllNestedUnitIds(
+        expandableUnitIds,
+        new Set<string>(expandableUnitIds),
+      ),
+      true,
+    );
+  });
+});

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -46,6 +46,10 @@ import Header from "./Header";
 import FlowSelector from "./FlowSelector";
 import { buildExpandedFlowGraph } from "./buildExpandedFlowGraph";
 import { createReactFlowData } from "./flowGraphView";
+import {
+  collectExpandableNestedUnitIds,
+  hasExpandedAllNestedUnitIds,
+} from "./nestedExpansion";
 
 const defaultViewport = { x: 0, y: 0, zoom: 1.0 };
 
@@ -130,6 +134,33 @@ const FlowContents: FC = () => {
     () => new Set(expandedUnitIds),
     [expandedUnitIds],
   );
+  const expandableNestedUnitIds = useMemo(
+    () => collectExpandableNestedUnitIds(currentUnit),
+    [currentUnit],
+  );
+  const hasExpandedAllNestedUnits = useMemo(
+    () =>
+      hasExpandedAllNestedUnitIds(expandableNestedUnitIds, expandedUnitIdSet),
+    [expandableNestedUnitIds, expandedUnitIdSet],
+  );
+  const toggleExpandAllNestedUnits = useCallback(() => {
+    if (expandableNestedUnitIds.length === 0) {
+      return;
+    }
+    setExpandedUnitIds((prev) => {
+      const prevSet = new Set(prev);
+      if (hasExpandedAllNestedUnitIds(expandableNestedUnitIds, prevSet)) {
+        return prev.filter(
+          (unitId) => !expandableNestedUnitIds.includes(unitId),
+        );
+      }
+      const next = new Set(prev);
+      for (const unitId of expandableNestedUnitIds) {
+        next.add(unitId);
+      }
+      return [...next];
+    });
+  }, [expandableNestedUnitIds]);
   const nestedExpansionState = useMemo<NestedExpansionStateType>(
     () => ({
       expandedUnitIds: expandedUnitIdSet,
@@ -310,6 +341,9 @@ const FlowContents: FC = () => {
               currentUnitIdState={currentUnitIdState}
               flowMenuState={flowMenuState}
               drawerWidthState={drawerWidthState}
+              canToggleExpandAllNestedUnits={expandableNestedUnitIds.length > 0}
+              hasExpandedAllNestedUnits={hasExpandedAllNestedUnits}
+              toggleExpandAllNestedUnits={toggleExpandAllNestedUnits}
             />
             <Box
               sx={{

--- a/src/ui-component/editor/ajsFlow/Header.tsx
+++ b/src/ui-component/editor/ajsFlow/Header.tsx
@@ -7,6 +7,8 @@ import Link from "@mui/material/Link";
 import Toolbar from "@mui/material/Toolbar";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import UnfoldLess from "@mui/icons-material/UnfoldLess";
+import UnfoldMore from "@mui/icons-material/UnfoldMore";
 import ViewColumn from "@mui/icons-material/ViewColumn";
 import FlowMenu from "./FlowMenu";
 import {
@@ -24,6 +26,9 @@ type HeaderProps = {
   currentUnit?: AjsUnit;
   unitById: ReadonlyMap<string, AjsUnit>;
   currentUnitIdState: CurrentUnitIdStateType;
+  canToggleExpandAllNestedUnits: boolean;
+  hasExpandedAllNestedUnits: boolean;
+  toggleExpandAllNestedUnits: () => void;
 };
 
 const Header: FC<HeaderProps> = ({
@@ -32,6 +37,9 @@ const Header: FC<HeaderProps> = ({
   currentUnit,
   unitById,
   currentUnitIdState,
+  canToggleExpandAllNestedUnits,
+  hasExpandedAllNestedUnits,
+  toggleExpandAllNestedUnits,
 }) => {
   console.log("render Header.");
 
@@ -89,6 +97,9 @@ const Header: FC<HeaderProps> = ({
     setDrawerWidth(0);
     setMenuStatus((prev) => ({ ...prev, menuItem1: !prev.menuItem1 }));
   }, [setDrawerWidth, setMenuStatus]);
+  const expandAllLabel = hasExpandedAllNestedUnits
+    ? "Collapse all nested jobnets."
+    : "Expand all nested jobnets.";
 
   return (
     <>
@@ -115,6 +126,22 @@ const Header: FC<HeaderProps> = ({
             >
               <ViewColumn fontSize="inherit" />
             </IconButton>
+          </Tooltip>
+          <Tooltip title={expandAllLabel}>
+            <span>
+              <IconButton
+                size="small"
+                aria-label="toggleExpandAllNestedJobnets"
+                onClick={toggleExpandAllNestedUnits}
+                disabled={!canToggleExpandAllNestedUnits}
+              >
+                {hasExpandedAllNestedUnits ? (
+                  <UnfoldLess fontSize="inherit" />
+                ) : (
+                  <UnfoldMore fontSize="inherit" />
+                )}
+              </IconButton>
+            </span>
           </Tooltip>
           <Breadcrumbs
             separator="›"

--- a/src/ui-component/editor/ajsFlow/nestedExpansion.ts
+++ b/src/ui-component/editor/ajsFlow/nestedExpansion.ts
@@ -1,0 +1,33 @@
+import { AjsUnit } from "../../../domain/models/ajs/AjsDocument";
+
+const appendExpandableDescendants = (
+  unit: AjsUnit,
+  expandableUnitIds: string[],
+) => {
+  for (const child of unit.children) {
+    if (child.unitType === "n" && child.children.length > 0) {
+      expandableUnitIds.push(child.id);
+    }
+    if (child.children.length > 0) {
+      appendExpandableDescendants(child, expandableUnitIds);
+    }
+  }
+};
+
+export const collectExpandableNestedUnitIds = (
+  currentUnit?: AjsUnit,
+): string[] => {
+  if (!currentUnit) {
+    return [];
+  }
+  const expandableUnitIds: string[] = [];
+  appendExpandableDescendants(currentUnit, expandableUnitIds);
+  return expandableUnitIds;
+};
+
+export const hasExpandedAllNestedUnitIds = (
+  expandableUnitIds: readonly string[],
+  expandedUnitIds: ReadonlySet<string>,
+): boolean =>
+  expandableUnitIds.length > 0 &&
+  expandableUnitIds.every((unitId) => expandedUnitIds.has(unitId));


### PR DESCRIPTION
## Summary
- add a one-click expand-all control to the flow viewer header using the existing nested-expansion state model
- extract nested-expansion scope helpers and add focused regression coverage for expand-all eligibility and fully-expanded detection
- update the enhance-flow-graph-experience SDD docs to mark this slice complete and move the next priority to deeper nested expansion and flow search

## Why
The previous slice added incremental nested expansion for direct child jobnets, but opening a larger scope still required repeated per-node interactions. This change adds the planned follow-up control so users can reveal or collapse the current nested scope in one step without changing the current-unit selection contract.

## Validation
- `pnpm run qlty`
- `pnpm test`
- `pnpm run build`
- `pnpm run test:web` *(fails in this environment because headless Chromium cannot start under the current macOS sandbox permissions: `bootstrap_check_in ... Permission denied (1100)`)*
