### PR TITLE
[codex] Add flow-view search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added inline nested expansion for nested jobnets in the flow viewer,
   including deeper nested scopes.
 - Improved flow-view expansion layout, re-layout stability, and highlighting.
+- Added current-scope flow search that reveals collapsed ancestors and
+  highlights the first matching unit.
 
 ## [1.12.0]
 

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -93,6 +93,27 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
   `buildExpandedFlowGraph.ts` so expansion, panel sizing, and sibling
   re-layout steps are separated into focused helpers before adding more
   interaction on top.
+- 2026-04-19 search slice decision:
+  start with search inside the current flow scope only, keep
+  `currentUnitId` as the stable base scope, reveal collapsed ancestor jobnets
+  through the existing nested-expansion state, and use a presentation-local
+  visual focus marker for the first match instead of changing the graph DTO
+  contract or adding cross-scope camera navigation in the same slice.
+- 2026-04-19 implementation result:
+  the flow header now exposes a search box for the current scope; submitting a
+  query finds the first matching unit by visible JP1/AJS labels and paths,
+  expands the collapsed ancestor jobnets needed to reveal it in the current
+  canvas, and visually highlights the matching node without re-scoping the
+  viewer away from the current unit.
+- 2026-04-19 validation result:
+  focused helper coverage now verifies current-scope search matching and
+  ancestor expansion decisions, flow-node mapping coverage verifies the new
+  search-match decoration path, and the standard desktop, web, and build
+  baseline should continue to validate host compatibility.
+- 2026-04-19 next slice:
+  decide whether flow-view search should grow beyond the current scope through
+  multi-match navigation, explicit camera centering, or cross-scope search
+  before moving on to list/flow navigation.
 
 ## Validation
 

--- a/docs/specs/features/enhance-flow-graph-experience/SPECS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/SPECS.md
@@ -17,6 +17,9 @@ navigation from and to the unit list.
 - flow-graph presentation goals are described as visual resemblance to
   JP1/AJS View, not full interaction parity in one slice
 - nested graphs can be revealed progressively in the same screen
+- the first flow-view search slice may stay within the current flow scope
+  if it reveals collapsed ancestors needed to show the first match before
+  visually focusing that match
 - a one-click expand-all path is considered in the design, even if it lands
   after the first incremental expansion slice
 - explicit navigation between unit-list and flow-graph units is defined when
@@ -28,6 +31,9 @@ navigation from and to the unit list.
 - keep graph DTO construction separate from viewer styling and interaction
   controls
 - prefer stable unit identity or path when coordinating list/flow navigation
+- for the first flow-view search slice, prefer reusing the existing
+  nested-expansion state and a presentation-local focus marker instead of
+  introducing a new graph DTO contract or a second scope-selection model
 - split the work into small viewer-facing slices:
   visual refresh, nested expansion, and cross-view navigation do not need to
   land in one commit

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -26,8 +26,14 @@
 - [x] Refactor `buildExpandedFlowGraph.ts` after the deeper nested-expansion
       fixes so expansion, panel sizing, and sibling collision handling are
       easier to extend without changing behavior
-- [ ] Add flow-view search that finds a target unit and opens the hierarchy
-      needed to reveal that unit in context before focusing it
+- [x] Add the first flow-view search slice inside the current scope:
+      search by unit name, comment, or path from the flow header, reveal the
+      collapsed ancestor hierarchy needed to show the first match, and
+      visually focus that match without changing the current scope
+- [ ] Decide whether flow-view search needs follow-up work beyond the first
+      current-scope slice:
+      examples include multi-match navigation, explicit camera centering, or
+      cross-scope search that can rebase the current flow scope predictably
 - [x] Define the visual cues that most matter for JP1/AJS View resemblance
 - [x] Decide whether expand-all ships in the same slice as incremental
       expansion or immediately after
@@ -91,6 +97,12 @@
   behavior is to search units from the flow surface, reveal any collapsed
   ancestors needed to show the match, and then focus the matching unit without
   requiring manual hierarchy expansion first.
+- 2026-04-19: the first implemented flow-view search slice intentionally stays
+  inside the current flow scope. It searches current-scope descendants by
+  unit name, comment, and absolute path, expands any collapsed ancestor
+  jobnets needed to reveal the first match, and uses a presentation-local
+  focus marker rather than rebasing `currentUnitId` or adding camera control
+  in the same change.
 - 2026-04-19: after the nested-expansion bug fixes, `buildExpandedFlowGraph.ts`
   should keep the same layout semantics but separate node reveal, panel-bounds
   calculation, and sibling re-layout so the next flow-view interactions do not

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -134,6 +134,11 @@ structure in `docs/specs/features/<feature>/`.
   rather than persisted extension or webview state, and the next eventual hash
   slice should preserve normalized `absolutePath`-based DTO contracts while
   refreshing focused selection and anchor regressions.
+- The first flow-view search slice is now in place:
+  the flow header can search within the current scope subtree, reveal the
+  collapsed nested-jobnet hierarchy required to show the first match, and
+  visually emphasize that match without changing the base `currentUnitId`
+  scope contract.
 
 ### How To Maintain This Section
 
@@ -149,10 +154,11 @@ structure in `docs/specs/features/<feature>/`.
 ### Next Priority Tasks
 
 1. Refresh flow-graph UX in focused slices:
-   visual parity with JP1/AJS View plus incremental, one-click, and deeper
-   nested expansion are now in place, so the next active follow-ups are
-   flow-view search that can reveal a target unit's hierarchy, and then
-   explicit view-to-view navigation on top of the same interaction model.
+   visual parity with JP1/AJS View plus incremental, one-click, deeper nested
+   expansion, and first-slice current-scope search are now in place, so the
+   next active follow-ups are deciding whether flow search needs broader
+   navigation behavior, and then explicit view-to-view navigation on top of
+   the same interaction model.
 2. Align parameter parsing and `ajs` command generation with
    JP1/Automatic Job Management System 3 version 13 reference manuals.
 3. Define a read-only JP1/AJS WebAPI import boundary with clear application

--- a/src/test/suite/flowGraphView.test.ts
+++ b/src/test/suite/flowGraphView.test.ts
@@ -145,6 +145,7 @@ suite("Flow Graph View", () => {
       },
       {
         nodeDecorations: new Map(),
+        searchedUnitId: "/root/jobnet/child-net/grand-net",
         unitById: new Map([
           [
             "/root/jobnet/child-net",
@@ -258,6 +259,13 @@ suite("Flow Graph View", () => {
     assert.strictEqual(nodes[0].data.isAncestor, true);
     assert.strictEqual(nodes[0].data.isRootJobnet, true);
     assert.strictEqual(nodes[0].data.canExpandNested, false);
+    assert.strictEqual(nodes[0].data.isSearchMatch, false);
+    const searchMatchNode = nodes.find(
+      (node) => node.id === "/root/jobnet/child-net/grand-net",
+    );
+    assert.ok(searchMatchNode);
+    assert.strictEqual(searchMatchNode.data.isSearchMatch, true);
+    assert.strictEqual(searchMatchNode.selected, true);
     assert.strictEqual(nodes[1].data.unitId, "/root/jobnet/job-a");
     assert.strictEqual(nodes[1].data.hasWaitedFor, true);
     assert.strictEqual(nodes[2].data.canExpandNested, true);

--- a/src/test/suite/flowSearch.test.ts
+++ b/src/test/suite/flowSearch.test.ts
@@ -1,0 +1,101 @@
+import * as assert from "assert";
+import { flattenAjsUnits } from "../../domain/models/ajs/AjsDocument";
+import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
+import { parseAjs } from "../../domain/services/parser/AjsParser";
+import { findFlowSearchResult } from "../../ui-component/editor/ajsFlow/flowSearch";
+
+const nestedDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    cm="scope root";
+    el=child-net,n,+240+144;
+    el=job-b,j,+400+144;
+    unit=child-net,,jp1admin,;
+    {
+      ty=n;
+      cm="nested comment";
+      el=grand-net,n,+240+144;
+      el=nested-job,j,+400+144;
+      unit=grand-net,,jp1admin,;
+      {
+        ty=n;
+        el=leaf-job,j,+240+144;
+        unit=leaf-job,,jp1admin,;
+        {
+          ty=j;
+          cm="leaf comment";
+        }
+      }
+      unit=nested-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=job-b,,jp1admin,;
+    {
+      ty=j;
+      cm="outside nested scope";
+    }
+  }
+}
+`;
+
+suite("Flow Search", () => {
+  test("finds the first current-scope match and expands ancestor jobnets", () => {
+    const result = parseAjs(nestedDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const allUnits = flattenAjsUnits(document.rootUnits);
+    const unitById = new Map(allUnits.map((unit) => [unit.id, unit]));
+    const currentUnit = document.rootUnits[0].children[0];
+    const childNetId = currentUnit.children[0].id;
+    const grandNetId = currentUnit.children[0].children[0].id;
+    const leafJobId = currentUnit.children[0].children[0].children[0].id;
+
+    const searchResult = findFlowSearchResult(
+      currentUnit,
+      "leaf comment",
+      unitById,
+    );
+
+    assert.deepStrictEqual(searchResult, {
+      matchedUnitId: leafJobId,
+      expandedAncestorUnitIds: [childNetId, grandNetId],
+    });
+  });
+
+  test("matches by absolute path and stays inside the current scope", () => {
+    const result = parseAjs(nestedDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const allUnits = flattenAjsUnits(document.rootUnits);
+    const unitById = new Map(allUnits.map((unit) => [unit.id, unit]));
+    const currentUnit = document.rootUnits[0].children[0].children[0];
+
+    const searchResult = findFlowSearchResult(
+      currentUnit,
+      "/jobnet/job-b",
+      unitById,
+    );
+
+    assert.strictEqual(searchResult, undefined);
+  });
+
+  test("returns undefined for blank queries", () => {
+    const result = parseAjs(nestedDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const allUnits = flattenAjsUnits(document.rootUnits);
+    const unitById = new Map(allUnits.map((unit) => [unit.id, unit]));
+    const currentUnit = document.rootUnits[0].children[0];
+
+    const searchResult = findFlowSearchResult(currentUnit, "   ", unitById);
+
+    assert.strictEqual(searchResult, undefined);
+  });
+});

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -50,6 +50,7 @@ import {
   collectExpandableNestedUnitIds,
   hasExpandedAllNestedUnitIds,
 } from "./nestedExpansion";
+import { findFlowSearchResult } from "./flowSearch";
 
 const defaultViewport = { x: 0, y: 0, zoom: 1.0 };
 
@@ -98,6 +99,7 @@ const FlowContents: FC = () => {
   const [ajsDocument, setAjsDocument] = useState<AjsDocument>();
   const [currentUnitId, setCurrentUnitId] = useState<string>();
   const [expandedUnitIds, setExpandedUnitIds] = useState<string[]>([]);
+  const [searchedUnitId, setSearchedUnitId] = useState<string>();
   const prevUnitEntityId = useRef<string | undefined>(undefined);
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
@@ -226,6 +228,7 @@ const FlowContents: FC = () => {
         currentUnitIdState,
         {
           nodeDecorations,
+          searchedUnitId,
           unitById,
           nestedExpansionState,
           positionOverrides,
@@ -242,8 +245,32 @@ const FlowContents: FC = () => {
       theme,
       unitDefinitionByPath,
       unitById,
+      searchedUnitId,
     ],
   );
+
+  const handleSearchSubmit = useCallback(
+    (query: string) => {
+      const result = findFlowSearchResult(currentUnit, query, unitById);
+      if (!result) {
+        setSearchedUnitId(undefined);
+        return;
+      }
+
+      setExpandedUnitIds((prev) => {
+        const next = new Set(prev);
+        for (const unitId of result.expandedAncestorUnitIds) {
+          next.add(unitId);
+        }
+        return [...next];
+      });
+      setSearchedUnitId(result.matchedUnitId);
+    },
+    [currentUnit, unitById],
+  );
+  const handleSearchClear = useCallback(() => {
+    setSearchedUnitId(undefined);
+  }, []);
 
   useEffect(() => {
     updateNodesAndEdges(currentUnitId);
@@ -252,6 +279,7 @@ const FlowContents: FC = () => {
 
   useEffect(() => {
     setExpandedUnitIds((prev) => (prev.length === 0 ? prev : []));
+    setSearchedUnitId(undefined);
   }, [ajsDocument, currentUnitId]);
 
   useEffect(() => {
@@ -344,6 +372,9 @@ const FlowContents: FC = () => {
               canToggleExpandAllNestedUnits={expandableNestedUnitIds.length > 0}
               hasExpandedAllNestedUnits={hasExpandedAllNestedUnits}
               toggleExpandAllNestedUnits={toggleExpandAllNestedUnits}
+              searchedUnitId={searchedUnitId}
+              onSearchSubmit={handleSearchSubmit}
+              onSearchClear={handleSearchClear}
             />
             <Box
               sx={{

--- a/src/ui-component/editor/ajsFlow/Header.tsx
+++ b/src/ui-component/editor/ajsFlow/Header.tsx
@@ -1,12 +1,27 @@
-import React, { FC, memo, ReactElement, useCallback, useMemo } from "react";
+import React, {
+  ChangeEvent,
+  FC,
+  KeyboardEvent,
+  memo,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import AppBar from "@mui/material/AppBar";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Chip from "@mui/material/Chip";
 import IconButton from "@mui/material/IconButton";
+import InputAdornment from "@mui/material/InputAdornment";
 import Link from "@mui/material/Link";
+import TextField from "@mui/material/TextField";
 import Toolbar from "@mui/material/Toolbar";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import ClearAllIcon from "@mui/icons-material/ClearAll";
+import SearchIcon from "@mui/icons-material/Search";
 import UnfoldLess from "@mui/icons-material/UnfoldLess";
 import UnfoldMore from "@mui/icons-material/UnfoldMore";
 import ViewColumn from "@mui/icons-material/ViewColumn";
@@ -29,6 +44,9 @@ type HeaderProps = {
   canToggleExpandAllNestedUnits: boolean;
   hasExpandedAllNestedUnits: boolean;
   toggleExpandAllNestedUnits: () => void;
+  searchedUnitId?: string;
+  onSearchSubmit: (query: string) => void;
+  onSearchClear: () => void;
 };
 
 const Header: FC<HeaderProps> = ({
@@ -40,13 +58,19 @@ const Header: FC<HeaderProps> = ({
   canToggleExpandAllNestedUnits,
   hasExpandedAllNestedUnits,
   toggleExpandAllNestedUnits,
+  searchedUnitId,
+  onSearchSubmit,
+  onSearchClear,
 }) => {
   console.log("render Header.");
 
   const { setMenuStatus } = flowMenuState;
   const { setDrawerWidth } = drawerWidthState;
   const { setCurrentUnitId } = currentUnitIdState;
-  const { lang } = useMyAppContext();
+  const { lang, os } = useMyAppContext();
+  const isMac = os === "darwin";
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [searchValue, setSearchValue] = useState<string>("");
 
   const breadcrumbs = useMemo(() => {
     const crumbs: ReactElement[] = [];
@@ -97,9 +121,46 @@ const Header: FC<HeaderProps> = ({
     setDrawerWidth(0);
     setMenuStatus((prev) => ({ ...prev, menuItem1: !prev.menuItem1 }));
   }, [setDrawerWidth, setMenuStatus]);
+  const handleShortcut = useCallback(
+    (event: globalThis.KeyboardEvent) => {
+      if ((isMac ? event.metaKey : event.ctrlKey) && event.key === "f") {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+      }
+    },
+    [isMac],
+  );
+  useEffect(() => {
+    document.addEventListener("keydown", handleShortcut);
+    return () => document.removeEventListener("keydown", handleShortcut);
+  }, [handleShortcut]);
+  const handleSearchChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) =>
+      setSearchValue(event.target.value),
+    [],
+  );
+  const handleSearchSubmit = useCallback(() => {
+    onSearchSubmit(searchValue);
+  }, [onSearchSubmit, searchValue]);
+  const handleSearchKeyUp = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter") {
+        handleSearchSubmit();
+      }
+    },
+    [handleSearchSubmit],
+  );
+  const handleSearchClear = useCallback(() => {
+    setSearchValue("");
+    onSearchClear();
+    searchInputRef.current?.focus();
+  }, [onSearchClear]);
   const expandAllLabel = hasExpandedAllNestedUnits
     ? "Collapse all nested jobnets."
     : "Expand all nested jobnets.";
+  const searchHelperText = searchedUnitId
+    ? "Matched unit is highlighted in the current scope."
+    : "Search current scope by unit name, comment, or path.";
 
   return (
     <>
@@ -143,6 +204,43 @@ const Header: FC<HeaderProps> = ({
               </IconButton>
             </span>
           </Tooltip>
+          <TextField
+            size="small"
+            variant="standard"
+            placeholder={`Search current scope...(${isMac ? "\u2318" : "CTRL+"}F)`}
+            helperText={searchHelperText}
+            value={searchValue}
+            onChange={handleSearchChange}
+            onKeyUp={handleSearchKeyUp}
+            onBlur={handleSearchSubmit}
+            inputRef={searchInputRef}
+            sx={{ width: "20rem", maxWidth: "32vw", flexShrink: 0 }}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <Tooltip title="Clear flow search.">
+                      <span>
+                        <IconButton
+                          size="small"
+                          aria-label="Clear flow search."
+                          onClick={handleSearchClear}
+                          disabled={searchValue.length === 0 && !searchedUnitId}
+                        >
+                          <ClearAllIcon fontSize="inherit" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
           <Breadcrumbs
             separator="›"
             aria-label="breadcrumb"

--- a/src/ui-component/editor/ajsFlow/flowGraphView.ts
+++ b/src/ui-component/editor/ajsFlow/flowGraphView.ts
@@ -21,6 +21,7 @@ type CreateReactFlowDataOptions = {
   nestedExpansionState?: NestedExpansionStateType;
   nodeDecorations?: ReadonlyMap<string, ExpandedNodeDecoration>;
   positionOverrides?: ReadonlyMap<string, { x: number; y: number }>;
+  searchedUnitId?: string;
 };
 
 const hasExpandableChildren = (unit?: AjsUnit): boolean =>
@@ -54,6 +55,7 @@ const toNodeData = (
     isRootJobnet: node.metadata.isRootJobnet,
     hasSchedule: node.metadata.hasSchedule,
     hasWaitedFor: node.metadata.hasWaitedFor,
+    isSearchMatch: options?.searchedUnitId === node.id,
     canExpandNested:
       !node.metadata.isCurrent &&
       !node.metadata.isAncestor &&
@@ -99,6 +101,7 @@ export const createReactFlowData = (
   const nodes: Node<AjsNode>[] = graph.nodes.map((node) => ({
     id: node.id,
     type: node.type,
+    selected: options?.searchedUnitId === node.id,
     data: toNodeData(
       node,
       unitDefinitionByPath,

--- a/src/ui-component/editor/ajsFlow/flowSearch.ts
+++ b/src/ui-component/editor/ajsFlow/flowSearch.ts
@@ -1,0 +1,73 @@
+import { AjsUnit } from "../../../domain/models/ajs/AjsDocument";
+
+export type FlowSearchResult = {
+  matchedUnitId: string;
+  expandedAncestorUnitIds: string[];
+};
+
+const normalizeQuery = (query: string): string => query.trim().toLowerCase();
+
+const unitSearchText = (unit: AjsUnit): string =>
+  [unit.name, unit.comment, unit.absolutePath]
+    .filter((value): value is string => typeof value === "string")
+    .join("\n")
+    .toLowerCase();
+
+const collectScopeUnits = (root: AjsUnit): AjsUnit[] => {
+  const units: AjsUnit[] = [root];
+  for (const child of root.children) {
+    units.push(...collectScopeUnits(child));
+  }
+  return units;
+};
+
+const collectExpandedAncestorUnitIds = (
+  scopeRoot: AjsUnit,
+  matchedUnit: AjsUnit,
+  unitById: ReadonlyMap<string, AjsUnit>,
+): string[] => {
+  const expandedAncestorUnitIds: string[] = [];
+  let current = matchedUnit.parentId
+    ? unitById.get(matchedUnit.parentId)
+    : undefined;
+
+  while (current && current.id !== scopeRoot.id) {
+    if (current.unitType === "n" && current.children.length > 0) {
+      expandedAncestorUnitIds.unshift(current.id);
+    }
+    current = current.parentId ? unitById.get(current.parentId) : undefined;
+  }
+
+  return expandedAncestorUnitIds;
+};
+
+export const findFlowSearchResult = (
+  scopeRoot: AjsUnit | undefined,
+  query: string,
+  unitById: ReadonlyMap<string, AjsUnit>,
+): FlowSearchResult | undefined => {
+  if (!scopeRoot) {
+    return undefined;
+  }
+
+  const normalizedQuery = normalizeQuery(query);
+  if (normalizedQuery.length === 0) {
+    return undefined;
+  }
+
+  const matchedUnit = collectScopeUnits(scopeRoot).find((unit) =>
+    unitSearchText(unit).includes(normalizedQuery),
+  );
+  if (!matchedUnit) {
+    return undefined;
+  }
+
+  return {
+    matchedUnitId: matchedUnit.id,
+    expandedAncestorUnitIds: collectExpandedAncestorUnitIds(
+      scopeRoot,
+      matchedUnit,
+      unitById,
+    ),
+  };
+};

--- a/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
@@ -28,6 +28,7 @@ export type AjsNode = {
   isRootJobnet: boolean;
   hasSchedule: boolean;
   hasWaitedFor: boolean;
+  isSearchMatch?: boolean;
   canExpandNested?: boolean;
   isExpandedNested?: boolean;
   toggleExpandedUnitId?: (unitId: string) => void;
@@ -39,10 +40,11 @@ export const buildNodeSxProps = ({
   isCurrent,
   isAncestor,
   isRootJobnet,
+  isSearchMatch,
   nestedPanel,
 }: Pick<
   AjsNode,
-  "isCurrent" | "isAncestor" | "isRootJobnet" | "nestedPanel"
+  "isCurrent" | "isAncestor" | "isRootJobnet" | "isSearchMatch" | "nestedPanel"
 >): SxProps<Theme> => ({
   position: "relative",
   zIndex: 1,
@@ -57,12 +59,17 @@ export const buildNodeSxProps = ({
   borderColor: (theme) =>
     isCurrent
       ? theme.palette.info.main
-      : isRootJobnet
-        ? theme.palette.primary.main
-        : theme.palette.divider,
+      : isSearchMatch
+        ? theme.palette.success.main
+        : isRootJobnet
+          ? theme.palette.primary.main
+          : theme.palette.divider,
   background: (theme) => {
     if (isCurrent) {
       return `linear-gradient(160deg, ${theme.palette.info.light}22 0%, ${theme.palette.background.paper} 58%, ${theme.palette.background.default} 100%)`;
+    }
+    if (isSearchMatch) {
+      return `linear-gradient(180deg, ${theme.palette.success.light}20 0%, ${theme.palette.background.paper} 100%)`;
     }
     if (isAncestor) {
       return `linear-gradient(180deg, ${theme.palette.warning.light}1f 0%, ${theme.palette.background.paper} 100%)`;
@@ -75,9 +82,11 @@ export const buildNodeSxProps = ({
   boxShadow: (theme) =>
     isCurrent
       ? `0 0 0 4px ${theme.palette.info.light}30, ${theme.shadows[6]}`
-      : isAncestor
-        ? theme.shadows[4]
-        : theme.shadows[2],
+      : isSearchMatch
+        ? `0 0 0 3px ${theme.palette.success.light}30, ${theme.shadows[4]}`
+        : isAncestor
+          ? theme.shadows[4]
+          : theme.shadows[2],
   justifyContent: "center",
   alignItems: "center",
   gap: "0.15em",
@@ -105,7 +114,11 @@ export const buildNodeSxProps = ({
     : undefined,
   "& button": {
     color: (theme) =>
-      isCurrent ? theme.palette.info.dark : theme.palette.text.secondary,
+      isCurrent
+        ? theme.palette.info.dark
+        : isSearchMatch
+          ? theme.palette.success.dark
+          : theme.palette.text.secondary,
   },
 });
 

--- a/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
@@ -41,6 +41,7 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
     hasSchedule,
     hasWaitedFor,
     isRootJobnet,
+    isSearchMatch,
     canExpandNested,
     isExpandedNested,
     label,
@@ -56,6 +57,7 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
           isCurrent,
           isAncestor,
           isRootJobnet,
+          isSearchMatch,
           nestedPanel: data.nestedPanel,
         })}
         className={classNames({

--- a/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
@@ -20,14 +20,27 @@ type JobNodeProps = NodeProps<JobNode>;
 const JobNode: FC<JobNodeProps> = ({ data }: JobNodeProps) => {
   console.log("render JobNode.");
 
-  const { unitId, hasWaitedFor, label, comment, ty, isAncestor, isCurrent } =
-    data;
+  const {
+    unitId,
+    hasWaitedFor,
+    label,
+    comment,
+    ty,
+    isAncestor,
+    isCurrent,
+    isSearchMatch,
+  } = data;
 
   return (
     <>
       <Stack
         id={unitId}
-        sx={buildNodeSxProps({ isCurrent, isAncestor, isRootJobnet: false })}
+        sx={buildNodeSxProps({
+          isCurrent,
+          isAncestor,
+          isRootJobnet: false,
+          isSearchMatch,
+        })}
       >
         <TyTitle ty={ty} />
         {/* action */}


### PR DESCRIPTION
## Summary
- add the first flow-view search slice inside the current scope
- reveal collapsed ancestor jobnets needed to show the first search match and highlight that node in the flow viewer
- update the flow-graph SDD documents and add a 1.13.0 changelog note for the feature candidate

## Validation
- `pnpm run qlty`
- `pnpm test`
- `pnpm run test:web`
- `pnpm run build`

## Notes
- this first slice intentionally keeps search inside the current flow scope and preserves the existing `currentUnitId` scope contract
- follow-up work can decide whether to add multi-match navigation, camera centering, or cross-scope search
