### PR TITLE
Add list/flow bridge navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Improved flow-view expansion layout, re-layout stability, and highlighting.
 - Added current-scope flow search that reveals collapsed ancestors and
   highlights the first matching unit.
+- Added explicit bridge actions between the unit list and flow viewer when the
+  counterpart viewer is already open.
 
 ## [1.12.0]
 

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -111,9 +111,26 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
   search-match decoration path, and the standard desktop, web, and build
   baseline should continue to validate host compatibility.
 - 2026-04-19 next slice:
-  decide whether flow-view search should grow beyond the current scope through
-  multi-match navigation, explicit camera centering, or cross-scope search
-  before moving on to list/flow navigation.
+  keep the first flow-view search slice as the stable baseline, defer broader
+  search behavior for now, and move next to explicit unit-list and flow-graph
+  navigation on top of the same identity and expansion-state model.
+- 2026-04-19 next slice decision:
+  do not add multi-match stepping, explicit camera centering, or cross-scope
+  search before cross-view navigation. Those search follow-ups stay deferred
+  until a later slice shows that the first current-scope search behavior is
+  insufficient for real navigation needs.
+- 2026-04-19 navigation implementation focus:
+  use stable normalized identity that already exists in both viewers
+  (`absolutePath` for unit-list rows and the flow viewer's current-unit scope
+  contract) to open or focus the counterpart viewer without importing the
+  other viewer's internal component state. Keep unavailable-counterpart paths
+  as hidden, disabled, or no-op behaviors rather than mutating the current
+  viewer opportunistically.
+- 2026-04-19 navigation validation focus:
+  add focused regression coverage for list-to-flow target resolution and
+  flow-to-list target resolution, then re-run the standard desktop, web, and
+  production-build baseline to confirm the navigation wiring behaves the same
+  in both hosts.
 
 ## Validation
 

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -30,10 +30,10 @@
       search by unit name, comment, or path from the flow header, reveal the
       collapsed ancestor hierarchy needed to show the first match, and
       visually focus that match without changing the current scope
-- [ ] Decide whether flow-view search needs follow-up work beyond the first
+- [x] Decide whether flow-view search needs follow-up work beyond the first
       current-scope slice:
-      examples include multi-match navigation, explicit camera centering, or
-      cross-scope search that can rebase the current flow scope predictably
+      broader search behavior is intentionally deferred for now so the next
+      viewer-facing slice can focus on explicit list/flow navigation first
 - [x] Define the visual cues that most matter for JP1/AJS View resemblance
 - [x] Decide whether expand-all ships in the same slice as incremental
       expansion or immediately after
@@ -107,3 +107,9 @@
   should keep the same layout semantics but separate node reveal, panel-bounds
   calculation, and sibling re-layout so the next flow-view interactions do not
   pile more stateful logic into one long function.
+- 2026-04-19: broader flow-search follow-up is intentionally deferred after the
+  first current-scope slice. Multi-match stepping, explicit camera centering,
+  and cross-scope search remain valid future ideas, but the next active
+  implementation slice should be explicit unit-list and flow-graph navigation
+  because that use case is already specified and benefits from the stable
+  `absolutePath` / `currentUnitId` identity seams now in place.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -155,10 +155,10 @@ structure in `docs/specs/features/<feature>/`.
 
 1. Refresh flow-graph UX in focused slices:
    visual parity with JP1/AJS View plus incremental, one-click, deeper nested
-   expansion, and first-slice current-scope search are now in place, so the
-   next active follow-ups are deciding whether flow search needs broader
-   navigation behavior, and then explicit view-to-view navigation on top of
-   the same interaction model.
+   expansion, and first-slice current-scope search are now in place. Broader
+   flow-search behavior is intentionally deferred for now, so the next active
+   viewer-facing slice is explicit unit-list and flow-graph navigation on top
+   of the same interaction model.
 2. Align parameter parsing and `ajs` command generation with
    JP1/Automatic Job Management System 3 version 13 reference manuals.
 3. Define a read-only JP1/AJS WebAPI import boundary with clear application

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -74,23 +74,21 @@
 
 1. Refresh the flow-graph presentation so its visual design is closer to
    JP1/AJS View while preserving current desktop and web compatibility.
-2. Add flow-view search that locates a unit and reveals the hierarchy needed
-   to show that unit in context before focusing it.
-3. Add explicit navigation between unit-list and flow-graph units when the
+2. Add explicit navigation between unit-list and flow-graph units when the
    counterpart view for the selected unit is available.
-4. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+3. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
-5. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
+4. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
    generated commands with JP1/Automatic Job Management System 3 version 13
    Command Reference.
-6. Add a read-only JP1/AJS WebAPI import path for loading server-side
+5. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
-7. Replace the custom `UnitEntity` hash implementation with a common
+6. Replace the custom `UnitEntity` hash implementation with a common
    algorithm once identity and compatibility checks are explicit.
-8. Add richer unit-list search on top of the current presentation-local
+7. Add richer unit-list search on top of the current presentation-local
    matcher so parameter-key and parameter-value queries complement the current
    partial-match behavior.
-9. Consolidate i18n translation files to reduce duplication between language
+8. Consolidate i18n translation files to reduce duplication between language
    variants.
 
 ## Deferred / Optional Slices
@@ -106,6 +104,10 @@
 5. Revisit viewer-specific bundle-size reductions only if a future
    compatibility, startup, or payload target creates stronger pressure than
    the current marginal gains justify.
+6. Revisit broader flow-view search behavior only if the current-scope
+   first-match slice proves insufficient after explicit list/flow navigation
+   lands; likely candidates are multi-match stepping, explicit camera
+   centering, or cross-scope rebasing.
 
 ## Done Criteria For A Slice
 

--- a/src/extension/bootstrap/viewerWiring.ts
+++ b/src/extension/bootstrap/viewerWiring.ts
@@ -1,6 +1,10 @@
 import * as vscode from "vscode";
 import type { TelemetryPort } from "../../application/telemetry/TelemetryPort";
 import {
+  createRevealUnitEvent,
+  type NavigationTargetView,
+} from "../../shared/webviewEvents";
+import {
   type OpenPreviewCommandDependencies,
   executeOpenPreviewCommand,
 } from "../commands/openPreviewCommand";
@@ -47,11 +51,42 @@ const createPreviewCommandDependencies = (
   },
 });
 
-const createViewerBundle = (
-  { context, telemetry }: ViewerWiringDeps,
-  previewDeps: OpenPreviewCommandDependencies,
-  { viewType, saveHandler }: ViewerConfig,
-): vscode.Disposable[] => {
+const resolveTargetViewType = (targetView: NavigationTargetView): string =>
+  targetView === "flow" ? AJS_FLOW_VIEWER_TYPE : AJS_TABLE_VIEWER_TYPE;
+
+const revealExistingCounterpartPanel = (
+  document: vscode.TextDocument,
+  targetViewType: string,
+  absolutePath: string,
+  factoryByViewType: ReadonlyMap<string, ViewerFactory>,
+): void => {
+  const targetFactory = factoryByViewType.get(targetViewType);
+  if (!targetFactory) {
+    return;
+  }
+
+  const panel = targetFactory.getExistingPanel(document);
+  if (!panel) {
+    return;
+  }
+
+  panel.reveal(panel.viewColumn);
+  panel.webview.postMessage(createRevealUnitEvent(absolutePath));
+};
+
+const createViewerBundle = ({
+  context,
+  telemetry,
+  previewDeps,
+  factoryByViewType,
+  viewType,
+  saveHandler,
+}: ViewerWiringDeps & {
+  previewDeps: OpenPreviewCommandDependencies;
+  factoryByViewType: Map<string, ViewerFactory>;
+  viewType: string;
+  saveHandler?: (content: string) => Promise<void>;
+}): vscode.Disposable[] => {
   const store = new WebviewStore(viewType);
   const mediator = new WebviewMediator(
     context,
@@ -64,8 +99,17 @@ const createViewerBundle = (
     telemetry,
     store,
     readyAjsDocument,
+    (document, event) => {
+      revealExistingCounterpartPanel(
+        document,
+        resolveTargetViewType(event.data.targetView),
+        event.data.absolutePath,
+        factoryByViewType,
+      );
+    },
     saveHandler,
   );
+  factoryByViewType.set(viewType, factory);
 
   return [
     mediator,
@@ -87,8 +131,14 @@ export const createViewerSubscriptions = (
     deps.context,
     deps.telemetry,
   );
+  const factoryByViewType = new Map<string, ViewerFactory>();
 
   return viewerConfigs.flatMap((config) =>
-    createViewerBundle(deps, previewDeps, config),
+    createViewerBundle({
+      ...deps,
+      previewDeps,
+      factoryByViewType,
+      ...config,
+    }),
   );
 };

--- a/src/extension/webview/ViewerFactory.ts
+++ b/src/extension/webview/ViewerFactory.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import type { TelemetryPort } from "../../application/telemetry/TelemetryPort";
+import type { NavigationEventType } from "../../shared/webviewEvents";
 import { postResourceMessage, reportWebviewOperation } from "./messageHandlers";
 import {
   createViewerMessageHandler,
@@ -25,6 +26,10 @@ type ViewerReadyHandler = (
   document: vscode.TextDocument,
   panel: vscode.WebviewPanel,
 ) => void;
+type ViewerNavigateHandler = (
+  document: vscode.TextDocument,
+  event: NavigationEventType,
+) => void;
 
 /**
  * PanelFactory is responsible for creating and managing webview panels.
@@ -35,6 +40,7 @@ export class ViewerFactory {
   #viewType: string;
   #telemetry: TelemetryPort;
   #onReady: ViewerReadyHandler;
+  #onNavigate: ViewerNavigateHandler;
   #onSave?: (content: string) => Promise<void>;
   #deps: ViewerFactoryDeps;
 
@@ -43,6 +49,7 @@ export class ViewerFactory {
     telemetry: TelemetryPort,
     store: ViewerFactoryStore,
     onReady: ViewerReadyHandler,
+    onNavigate: ViewerNavigateHandler,
     onSave?: (content: string) => Promise<void>,
     deps: ViewerFactoryDeps = defaultDeps,
   ) {
@@ -50,6 +57,7 @@ export class ViewerFactory {
     this.#telemetry = telemetry;
     this.#store = store;
     this.#onReady = onReady;
+    this.#onNavigate = onNavigate;
     this.#onSave = onSave;
     this.#deps = deps;
   }
@@ -62,12 +70,18 @@ export class ViewerFactory {
       `invoke PanelFactory.getPanel. (${this.#viewType}, ${document.uri.toString()})`,
     );
 
-    const existingPanel = this.#store.panelByUri(document.uri);
+    const existingPanel = this.getExistingPanel(document);
     if (existingPanel) {
       return existingPanel;
     }
 
     return this.createAndStorePanel(document);
+  }
+
+  public getExistingPanel(
+    document: vscode.TextDocument,
+  ): vscode.WebviewPanel | undefined {
+    return this.#store.panelByUri(document.uri);
   }
 
   private registerStandardViewerCustomize(
@@ -89,6 +103,7 @@ export class ViewerFactory {
         postResourceMessage(event.data, receivedPanel);
       },
       onOperation: reportWebviewOperation,
+      onNavigate: this.#onNavigate,
       onSave,
       showErrorMessage: (message) => vscode.window.showErrorMessage(message),
     });

--- a/src/extension/webview/viewerMessageRouting.ts
+++ b/src/extension/webview/viewerMessageRouting.ts
@@ -1,10 +1,12 @@
 import * as vscode from "vscode";
 import type { TelemetryPort } from "../../application/telemetry/TelemetryPort";
 import {
+  NAVIGATE,
   OPERATION,
   READY,
   RESOURCE,
   SAVE,
+  type NavigationEventType,
   type ResourceEventType,
   type WebviewEventType,
 } from "../../shared/webviewEvents";
@@ -21,6 +23,10 @@ type ViewerMessageRoutingDeps = {
     telemetry: TelemetryPort,
     operation: string,
   ) => void;
+  onNavigate: (
+    document: vscode.TextDocument,
+    event: NavigationEventType,
+  ) => void;
   onSave?: (content: string) => Promise<void>;
   showErrorMessage: (message: string) => Thenable<string | undefined>;
 };
@@ -33,6 +39,7 @@ export const createViewerMessageHandler =
     onReady,
     onResource,
     onOperation,
+    onNavigate,
     onSave,
     showErrorMessage,
   }: ViewerMessageRoutingDeps) =>
@@ -56,6 +63,10 @@ export const createViewerMessageHandler =
       }
       case OPERATION: {
         onOperation(document, panel, telemetry, event.data);
+        break;
+      }
+      case NAVIGATE: {
+        onNavigate(document, event);
         break;
       }
     }

--- a/src/shared/webviewEvents.ts
+++ b/src/shared/webviewEvents.ts
@@ -5,14 +5,49 @@ export const READY = "ready";
 export const SAVE = "save";
 export const CHANGE_DOCUMENT = "changeDocument";
 export const OPERATION = "operation";
+export const NAVIGATE = "navigate";
+export const REVEAL_UNIT = "revealUnit";
+
+export type NavigationTargetView = "flow" | "table";
+export type NavigationEventData = {
+  targetView: NavigationTargetView;
+  absolutePath: string;
+};
+export type RevealUnitEventData = {
+  absolutePath: string;
+};
 
 export type ResourceEventType = { type: typeof RESOURCE; data: MyAppResource };
 export type ReadyEventType = { type: typeof READY };
 export type SaveEventType = { type: typeof SAVE; data: string };
 export type OperationEventType = { type: typeof OPERATION; data: string };
+export type NavigationEventType = {
+  type: typeof NAVIGATE;
+  data: NavigationEventData;
+};
+export type RevealUnitEventType = {
+  type: typeof REVEAL_UNIT;
+  data: RevealUnitEventData;
+};
+
+export const createNavigationEvent = (
+  targetView: NavigationTargetView,
+  absolutePath: string,
+): NavigationEventType => ({
+  type: NAVIGATE,
+  data: { targetView, absolutePath },
+});
+
+export const createRevealUnitEvent = (
+  absolutePath: string,
+): RevealUnitEventType => ({
+  type: REVEAL_UNIT,
+  data: { absolutePath },
+});
 
 export type WebviewEventType =
   | ResourceEventType
   | ReadyEventType
   | SaveEventType
-  | OperationEventType;
+  | OperationEventType
+  | NavigationEventType;

--- a/src/test/suite/revealUnit.test.ts
+++ b/src/test/suite/revealUnit.test.ts
@@ -1,0 +1,156 @@
+import * as assert from "assert";
+import {
+  findRowIndexByAbsolutePath,
+  getRevealUnitAbsolutePath,
+  resolveFlowRevealTarget,
+} from "../../ui-component/editor/revealUnit";
+
+suite("Reveal unit helpers", () => {
+  test("reads a reveal-unit absolute path from event data", () => {
+    assert.strictEqual(
+      getRevealUnitAbsolutePath({ absolutePath: "/root/jobnet/job" }),
+      "/root/jobnet/job",
+    );
+    assert.strictEqual(
+      getRevealUnitAbsolutePath({ absolutePath: 1 }),
+      undefined,
+    );
+    assert.strictEqual(getRevealUnitAbsolutePath(undefined), undefined);
+  });
+
+  test("opens the containing jobnet and highlights the revealed unit", () => {
+    const unitById = new Map([
+      [
+        "root",
+        {
+          id: "root",
+          absolutePath: "/root",
+          unitType: "n",
+          children: [{}],
+        },
+      ],
+      [
+        "job",
+        {
+          id: "job",
+          absolutePath: "/root/job",
+          unitType: "j",
+          parentId: "root",
+          children: [],
+        },
+      ],
+    ]);
+
+    assert.deepStrictEqual(resolveFlowRevealTarget(unitById, "/root/job"), {
+      scopeUnitId: "root",
+      revealedUnitId: "job",
+      expandedAncestorUnitIds: [],
+    });
+    assert.strictEqual(
+      resolveFlowRevealTarget(unitById, "/missing"),
+      undefined,
+    );
+  });
+
+  test("opens the direct condition scope for units under .condition", () => {
+    const unitById = new Map([
+      [
+        "root",
+        {
+          id: "root",
+          absolutePath: "/root",
+          unitType: "n",
+          children: [{}],
+        },
+      ],
+      [
+        "condition",
+        {
+          id: "condition",
+          absolutePath: "/root/.condition",
+          unitType: "rc",
+          parentId: "root",
+          children: [{}],
+        },
+      ],
+      [
+        "job",
+        {
+          id: "job",
+          absolutePath: "/root/.condition/job",
+          unitType: "j",
+          parentId: "condition",
+          children: [],
+        },
+      ],
+    ]);
+
+    assert.deepStrictEqual(
+      resolveFlowRevealTarget(unitById, "/root/.condition/job"),
+      {
+        scopeUnitId: "condition",
+        revealedUnitId: "job",
+        expandedAncestorUnitIds: [],
+      },
+    );
+  });
+
+  test("expands nested jobnets needed to reveal the target unit", () => {
+    const unitById = new Map([
+      [
+        "root",
+        {
+          id: "root",
+          absolutePath: "/root",
+          unitType: "n",
+          children: [{}],
+        },
+      ],
+      [
+        "child-net",
+        {
+          id: "child-net",
+          absolutePath: "/root/child-net",
+          unitType: "n",
+          parentId: "root",
+          children: [{}],
+        },
+      ],
+      [
+        "job",
+        {
+          id: "job",
+          absolutePath: "/root/child-net/job",
+          unitType: "j",
+          parentId: "child-net",
+          children: [],
+        },
+      ],
+    ]);
+
+    assert.deepStrictEqual(
+      resolveFlowRevealTarget(unitById, "/root/child-net/job"),
+      {
+        scopeUnitId: "child-net",
+        revealedUnitId: "job",
+        expandedAncestorUnitIds: [],
+      },
+    );
+  });
+
+  test("finds a table row index from a stable absolute path", () => {
+    const rowIndexByAbsolutePath = new Map<string, number>([
+      ["/root", 0],
+      ["/root/job", 3],
+    ]);
+
+    assert.strictEqual(
+      findRowIndexByAbsolutePath(rowIndexByAbsolutePath, "/root/job"),
+      3,
+    );
+    assert.strictEqual(
+      findRowIndexByAbsolutePath(rowIndexByAbsolutePath, "/missing"),
+      undefined,
+    );
+  });
+});

--- a/src/test/suite/viewerFactory.test.ts
+++ b/src/test/suite/viewerFactory.test.ts
@@ -2,7 +2,13 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import type { TelemetryPort } from "../../application/telemetry/TelemetryPort";
 import { ViewerFactory } from "../../extension/webview/ViewerFactory";
-import { OPERATION, READY, RESOURCE, SAVE } from "../../shared/webviewEvents";
+import {
+  NAVIGATE,
+  OPERATION,
+  READY,
+  RESOURCE,
+  SAVE,
+} from "../../shared/webviewEvents";
 
 type ViewerFactoryDeps = {
   createWebviewPanel: typeof vscode.window.createWebviewPanel;
@@ -38,6 +44,7 @@ suite("ViewerFactory", () => {
       () => {
         readyCalled = true;
       },
+      () => {},
       undefined,
       {
         createWebviewPanel() {
@@ -88,6 +95,7 @@ suite("ViewerFactory", () => {
       (receivedDocument, receivedPanel) => {
         readyArgs = { document: receivedDocument, panel: receivedPanel };
       },
+      () => {},
       undefined,
       {
         createWebviewPanel() {
@@ -106,10 +114,39 @@ suite("ViewerFactory", () => {
     assert.deepStrictEqual(added, [{ uri: document.uri, panel: createdPanel }]);
   });
 
+  test("returns an existing panel without creating a new one", () => {
+    const telemetry: TelemetryPort = {
+      trackEvent() {},
+      dispose() {},
+    };
+    const existingPanel = { id: "existing" } as unknown as vscode.WebviewPanel;
+    const document = {
+      fileName: "/tmp/sample.ajs",
+      uri: { toString: () => "file:///sample.ajs" },
+    } as unknown as vscode.TextDocument;
+
+    const factory = new ViewerFactory(
+      "ajsbutler.testViewer",
+      telemetry,
+      {
+        panelByUri() {
+          return existingPanel;
+        },
+        add() {},
+        removeByUri() {},
+      },
+      () => {},
+      () => {},
+    );
+
+    assert.strictEqual(factory.getExistingPanel(document), existingPanel);
+  });
+
   test("registers the shared viewer customize flow", async () => {
     const calls: string[] = [];
     const telemetryEvents: string[] = [];
     const removed: string[] = [];
+    const navigated: string[] = [];
     let receiverDisposed = false;
     let receiveMessageHandler:
       | ((event: { type: string; data?: unknown }) => void)
@@ -171,6 +208,9 @@ suite("ViewerFactory", () => {
           `ready:${receivedDocument.uri.toString()}:${receivedPanel.viewType}`,
         );
       },
+      (_receivedDocument, event) => {
+        navigated.push(`${event.data.targetView}:${event.data.absolutePath}`);
+      },
       async (content) => {
         calls.push(`save:${content}`);
       },
@@ -190,6 +230,10 @@ suite("ViewerFactory", () => {
     });
     receiveMessageHandler?.({ type: SAVE, data: "body" });
     receiveMessageHandler?.({ type: OPERATION, data: "copy.csv" });
+    receiveMessageHandler?.({
+      type: NAVIGATE,
+      data: { targetView: "table", absolutePath: "/root/unit" },
+    });
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     onDidDispose?.();
@@ -201,6 +245,7 @@ suite("ViewerFactory", () => {
     ]);
     assert.strictEqual(createdPanel, panel);
     assert.deepStrictEqual(added, [{ uri: document.uri, panel }]);
+    assert.deepStrictEqual(navigated, ["table:/root/unit"]);
     assert.deepStrictEqual(telemetryEvents, [OPERATION]);
     assert.deepStrictEqual(removed, ["file:///sample.ajs"]);
     assert.strictEqual(receiverDisposed, true);

--- a/src/test/suite/viewerMessageRouting.test.ts
+++ b/src/test/suite/viewerMessageRouting.test.ts
@@ -1,5 +1,11 @@
 import * as assert from "assert";
-import { OPERATION, READY, RESOURCE, SAVE } from "../../shared/webviewEvents";
+import {
+  NAVIGATE,
+  OPERATION,
+  READY,
+  RESOURCE,
+  SAVE,
+} from "../../shared/webviewEvents";
 import {
   createViewerMessageHandler,
   registerViewerPanelDispose,
@@ -28,6 +34,11 @@ suite("Viewer message routing", () => {
       onOperation: (_document, _panel, _telemetry, operation) => {
         calls.push(`operation:${operation}`);
       },
+      onNavigate: (_document, event) => {
+        calls.push(
+          `navigate:${event.data.targetView}:${event.data.absolutePath}`,
+        );
+      },
       onSave: async (content) => {
         calls.push(`save:${content}`);
       },
@@ -38,6 +49,10 @@ suite("Viewer message routing", () => {
     handler({ type: READY });
     handler({ type: SAVE, data: "body" });
     handler({ type: OPERATION, data: "copy.csv" });
+    handler({
+      type: NAVIGATE,
+      data: { targetView: "flow", absolutePath: "/root/unit" },
+    });
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     assert.deepStrictEqual(calls, [
@@ -45,6 +60,7 @@ suite("Viewer message routing", () => {
       "ready",
       "save:body",
       "operation:copy.csv",
+      "navigate:flow:/root/unit",
     ]);
   });
 
@@ -57,6 +73,7 @@ suite("Viewer message routing", () => {
       onReady: () => {},
       onResource: () => {},
       onOperation: () => {},
+      onNavigate: () => {},
       onSave: async () => undefined,
       showErrorMessage: async (message) => {
         errors.push(message);

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -51,6 +51,11 @@ import {
   hasExpandedAllNestedUnitIds,
 } from "./nestedExpansion";
 import { findFlowSearchResult } from "./flowSearch";
+import { REVEAL_UNIT } from "../../../shared/webviewEvents";
+import {
+  getRevealUnitAbsolutePath,
+  resolveFlowRevealTarget,
+} from "../revealUnit";
 
 const defaultViewport = { x: 0, y: 0, zoom: 1.0 };
 
@@ -100,6 +105,7 @@ const FlowContents: FC = () => {
   const [currentUnitId, setCurrentUnitId] = useState<string>();
   const [expandedUnitIds, setExpandedUnitIds] = useState<string[]>([]);
   const [searchedUnitId, setSearchedUnitId] = useState<string>();
+  const preserveSearchOnNextScopeChange = useRef<boolean>(false);
   const prevUnitEntityId = useRef<string | undefined>(undefined);
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
@@ -272,6 +278,20 @@ const FlowContents: FC = () => {
     setSearchedUnitId(undefined);
   }, []);
 
+  const handleRevealUnit = useCallback(
+    (absolutePath: string) => {
+      const revealTarget = resolveFlowRevealTarget(unitById, absolutePath);
+      if (!revealTarget) {
+        return;
+      }
+      preserveSearchOnNextScopeChange.current = true;
+      setExpandedUnitIds(revealTarget.expandedAncestorUnitIds);
+      setCurrentUnitId(revealTarget.scopeUnitId);
+      setSearchedUnitId(revealTarget.revealedUnitId);
+    },
+    [unitById],
+  );
+
   useEffect(() => {
     updateNodesAndEdges(currentUnitId);
     prevUnitEntityId.current = currentUnitId;
@@ -279,6 +299,10 @@ const FlowContents: FC = () => {
 
   useEffect(() => {
     setExpandedUnitIds((prev) => (prev.length === 0 ? prev : []));
+    if (preserveSearchOnNextScopeChange.current) {
+      preserveSearchOnNextScopeChange.current = false;
+      return;
+    }
     setSearchedUnitId(undefined);
   }, [ajsDocument, currentUnitId]);
 
@@ -303,6 +327,20 @@ const FlowContents: FC = () => {
       window.EventBridge.removeCallback("changeDocument", changeDocumentFn);
     };
   }, []); // fire this when mount.
+
+  useEffect(() => {
+    const revealUnitFn = (_type: string, data: unknown) => {
+      const absolutePath = getRevealUnitAbsolutePath(data);
+      if (!absolutePath) {
+        return;
+      }
+      handleRevealUnit(absolutePath);
+    };
+    window.EventBridge.addCallback(REVEAL_UNIT, revealUnitFn);
+    return () => {
+      window.EventBridge.removeCallback(REVEAL_UNIT, revealUnitFn);
+    };
+  }, [handleRevealUnit]);
 
   useEffect(() => {
     const root = document.getElementById("root");

--- a/src/ui-component/editor/ajsFlow/flowGraphView.ts
+++ b/src/ui-component/editor/ajsFlow/flowGraphView.ts
@@ -45,6 +45,7 @@ const toNodeData = (
   return {
     nestedPanel: options?.nodeDecorations?.get(node.id),
     unitId: node.id,
+    absolutePath: node.metadata.absolutePath,
     unitDefinition,
     label: node.label,
     comment: node.metadata.comment,

--- a/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
@@ -18,6 +18,7 @@ export type AjsNode = {
     panelHeightPx: number;
   };
   unitId: string;
+  absolutePath: string;
   unitDefinition: UnitDefinitionDialogDto;
   label: string;
   comment?: string;

--- a/src/ui-component/editor/ajsFlow/nodes/ConditionNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/ConditionNode.tsx
@@ -4,6 +4,7 @@ import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import DescriptionIcon from "@mui/icons-material/Description";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
+import TableChartIcon from "@mui/icons-material/TableChart";
 import {
   ActionIcon,
   AjsNode,
@@ -15,8 +16,10 @@ import {
 import {
   handleClickChildOpen,
   handleClickDialogOpen,
+  handleClickNavigateToTable,
   handleKeyDownChildOpen,
   handleKeyDownDialogOpen,
+  handleKeyDownNavigateToTable,
 } from "./Utils";
 
 export type ConditionNode = Node<AjsNode, "condition">;
@@ -44,6 +47,13 @@ const ConditionNode: FC<ConditionNodeProps> = ({
             onClick={handleClickDialogOpen(data)}
             onKeyDown={handleKeyDownDialogOpen(data)}
             icon={<DescriptionIcon fontSize="inherit" />}
+          />
+          <ActionIcon
+            title="Open the matching unit in the unit list."
+            ariaLabel="Open the matching unit in the unit list."
+            onClick={handleClickNavigateToTable(data)}
+            onKeyDown={handleKeyDownNavigateToTable(data)}
+            icon={<TableChartIcon fontSize="inherit" />}
           />
           {!isCurrent && (
             <ActionIcon

--- a/src/ui-component/editor/ajsFlow/nodes/JobGroupNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobGroupNode.tsx
@@ -3,6 +3,7 @@ import { Node, NodeProps } from "@xyflow/react";
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import DescriptionIcon from "@mui/icons-material/Description";
+import TableChartIcon from "@mui/icons-material/TableChart";
 import {
   ActionIcon,
   AjsNode,
@@ -11,7 +12,12 @@ import {
   NameOrComment,
   TyTitle,
 } from "./AjsNode";
-import { handleClickDialogOpen, handleKeyDownDialogOpen } from "./Utils";
+import {
+  handleClickDialogOpen,
+  handleClickNavigateToTable,
+  handleKeyDownDialogOpen,
+  handleKeyDownNavigateToTable,
+} from "./Utils";
 import classNames from "classnames";
 
 export type JobGroupNode = Node<AjsNode, "jobgroup">;
@@ -42,6 +48,13 @@ const JobGroupNode: FC<JobGroupNodeProp> = ({ data }: JobGroupNodeProp) => {
             onClick={handleClickDialogOpen(data)}
             onKeyDown={handleKeyDownDialogOpen(data)}
             icon={<DescriptionIcon fontSize="inherit" />}
+          />
+          <ActionIcon
+            title="Open the matching unit in the unit list."
+            ariaLabel="Open the matching unit in the unit list."
+            onClick={handleClickNavigateToTable(data)}
+            onKeyDown={handleKeyDownNavigateToTable(data)}
+            icon={<TableChartIcon fontSize="inherit" />}
           />
         </Box>
       </Stack>

--- a/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
@@ -5,6 +5,7 @@ import Stack from "@mui/material/Stack";
 import DescriptionIcon from "@mui/icons-material/Description";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import ScheduleIcon from "@mui/icons-material/Schedule";
+import TableChartIcon from "@mui/icons-material/TableChart";
 import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
 import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
@@ -22,9 +23,11 @@ import {
 import {
   handleClickChildOpen,
   handleClickDialogOpen,
+  handleClickNavigateToTable,
   handleClickNestedToggle,
   handleKeyDownChildOpen,
   handleKeyDownDialogOpen,
+  handleKeyDownNavigateToTable,
   handleKeyDownNestedToggle,
 } from "./Utils";
 
@@ -75,6 +78,13 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
             onClick={handleClickDialogOpen(data)}
             onKeyDown={handleKeyDownDialogOpen(data)}
             icon={<DescriptionIcon fontSize="inherit" />}
+          />
+          <ActionIcon
+            title="Open the matching unit in the unit list."
+            ariaLabel="Open the matching unit in the unit list."
+            onClick={handleClickNavigateToTable(data)}
+            onKeyDown={handleKeyDownNavigateToTable(data)}
+            icon={<TableChartIcon fontSize="inherit" />}
           />
           {!isCurrent && (
             <ActionIcon

--- a/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
@@ -4,6 +4,7 @@ import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import DescriptionIcon from "@mui/icons-material/Description";
 import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
+import TableChartIcon from "@mui/icons-material/TableChart";
 import {
   ActionIcon,
   AjsNode,
@@ -13,7 +14,12 @@ import {
   TyTitle,
   handleStyle,
 } from "./AjsNode";
-import { handleClickDialogOpen, handleKeyDownDialogOpen } from "./Utils";
+import {
+  handleClickDialogOpen,
+  handleClickNavigateToTable,
+  handleKeyDownDialogOpen,
+  handleKeyDownNavigateToTable,
+} from "./Utils";
 
 export type JobNode = Node<AjsNode, "job">;
 type JobNodeProps = NodeProps<JobNode>;
@@ -51,6 +57,13 @@ const JobNode: FC<JobNodeProps> = ({ data }: JobNodeProps) => {
             onClick={handleClickDialogOpen(data)}
             onKeyDown={handleKeyDownDialogOpen(data)}
             icon={<DescriptionIcon fontSize="inherit" />}
+          />
+          <ActionIcon
+            title="Open the matching unit in the unit list."
+            ariaLabel="Open the matching unit in the unit list."
+            onClick={handleClickNavigateToTable(data)}
+            onKeyDown={handleKeyDownNavigateToTable(data)}
+            icon={<TableChartIcon fontSize="inherit" />}
           />
           {hasWaitedFor && (
             <ActionIcon

--- a/src/ui-component/editor/ajsFlow/nodes/Utils.ts
+++ b/src/ui-component/editor/ajsFlow/nodes/Utils.ts
@@ -1,4 +1,5 @@
 import { AjsNode } from "./AjsNode";
+import { createNavigationEvent } from "../../../../shared/webviewEvents";
 
 export const handleClickDialogOpen = (data: AjsNode) => () => {
   const { unitDefinition, setDialogData } = data;
@@ -32,5 +33,18 @@ export const handleKeyDownNestedToggle =
     const { unitId, toggleExpandedUnitId } = data;
     if (event.key === "Enter") {
       toggleExpandedUnitId?.(unitId);
+    }
+  };
+
+export const handleClickNavigateToTable = (data: AjsNode) => () => {
+  window.vscode.postMessage(createNavigationEvent("table", data.absolutePath));
+};
+
+export const handleKeyDownNavigateToTable =
+  (data: AjsNode) => (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter") {
+      window.vscode.postMessage(
+        createNavigationEvent("table", data.absolutePath),
+      );
     }
   };

--- a/src/ui-component/editor/ajsTable/TableContents.tsx
+++ b/src/ui-component/editor/ajsTable/TableContents.tsx
@@ -44,6 +44,11 @@ import DisplayColumnSelector from "./DisplayColumnSelector";
 import { AccessorType } from "./columnDefs/common";
 import UnitEntityDialog from "../UnitEntityDialog";
 import Parameter from "../../../domain/models/parameters/Parameter";
+import { REVEAL_UNIT } from "../../../shared/webviewEvents";
+import {
+  findRowIndexByAbsolutePath,
+  getRevealUnitAbsolutePath,
+} from "../revealUnit";
 
 const normalizeValue = (v: unknown) =>
   v instanceof Parameter ? v.value() : String(v);
@@ -123,6 +128,9 @@ const TableContents = () => {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [drawerWidth, setDrawerWidth] = useState<number>(0);
   const [rowIndex, setRowIndex] = useState<number | undefined>(undefined);
+  const [revealedAbsolutePath, setRevealedAbsolutePath] = useState<
+    string | undefined
+  >(undefined);
   const [rowViews, ajsDocument, changeDocumentFn] = useChangeDocument();
 
   const unitDefinitionByPath = useMemo(
@@ -149,9 +157,19 @@ const TableContents = () => {
 
   useEffect(() => {
     window.EventBridge.addCallback("changeDocument", changeDocumentFn);
+    const revealUnitFn = (_type: string, data: unknown) => {
+      const absolutePath = getRevealUnitAbsolutePath(data);
+      if (!absolutePath) {
+        return;
+      }
+      setGlobalFilter("");
+      setRevealedAbsolutePath(absolutePath);
+    };
+    window.EventBridge.addCallback(REVEAL_UNIT, revealUnitFn);
     window.vscode.postMessage({ type: "ready" });
     return () => {
       window.EventBridge.removeCallback("changeDocument", changeDocumentFn);
+      window.EventBridge.removeCallback(REVEAL_UNIT, revealUnitFn);
     };
   }, []); // fire this when mount.
 
@@ -193,6 +211,18 @@ const TableContents = () => {
     });
     return map;
   }, [rows]);
+
+  useEffect(() => {
+    if (!revealedAbsolutePath) {
+      return;
+    }
+    const index = findRowIndexByAbsolutePath(rowIndexMap, revealedAbsolutePath);
+    if (index === undefined) {
+      return;
+    }
+    setRowIndex(index);
+    setRevealedAbsolutePath(undefined);
+  }, [revealedAbsolutePath, rowIndexMap]);
 
   useEffect(() => {
     handleJumpRef.current = (id: string) => {

--- a/src/ui-component/editor/ajsTable/tableColumnDef.tsx
+++ b/src/ui-component/editor/ajsTable/tableColumnDef.tsx
@@ -1,6 +1,7 @@
 // import * as vscode from 'vscode';
 import React from "react";
 import { CellContext, createColumnHelper } from "@tanstack/table-core";
+import AccountTreeIcon from "@mui/icons-material/AccountTree";
 import DescriptionIcon from "@mui/icons-material/Description";
 import {
   ajsTableColumnHeaderLang,
@@ -32,6 +33,7 @@ import group20 from "./columnDefs/group20";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
+import { createNavigationEvent } from "../../../shared/webviewEvents";
 
 // default setting of
 export const tableDefaultColumnDef = {
@@ -55,6 +57,10 @@ export const handleOpenUnitDefinition =
   () => {
     openUnitDefinition(absolutePath);
   };
+
+export const handleNavigateToFlow = (absolutePath: string) => () => {
+  window.vscode.postMessage(createNavigationEvent("flow", absolutePath));
+};
 
 export const tableColumnDef = (
   language: string | undefined = "en",
@@ -91,6 +97,15 @@ export const tableColumnDef = (
                 )}
               >
                 <DescriptionIcon fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Open the matching unit in the flow graph">
+              <IconButton
+                size="small"
+                aria-label="Open the matching unit in the flow graph"
+                onClick={handleNavigateToFlow(props.row.original.absolutePath)}
+              >
+                <AccountTreeIcon fontSize="inherit" />
               </IconButton>
             </Tooltip>
           </Box>

--- a/src/ui-component/editor/bootstrapViewer.tsx
+++ b/src/ui-component/editor/bootstrapViewer.tsx
@@ -8,7 +8,13 @@ const installViewerBridge = () => {
   window.EventBridge = {
     callbacks: {}, // {[type: string]: (type: string, data: unknown) => void}
     dispatch: (event) => {
+      if (!event.data || typeof event.data !== "object") {
+        return;
+      }
       const type = event.data.type;
+      if (typeof type !== "string") {
+        return;
+      }
       const functions = window.EventBridge.callbacks[type];
       if (functions) {
         functions.forEach((fn) => {
@@ -26,6 +32,9 @@ const installViewerBridge = () => {
     },
     removeCallback: (type, fn) => {
       let functions = window.EventBridge.callbacks[type];
+      if (!functions) {
+        return;
+      }
       functions = functions.filter((item) => item !== fn);
       window.EventBridge.callbacks[type] = functions;
     },

--- a/src/ui-component/editor/revealUnit.ts
+++ b/src/ui-component/editor/revealUnit.ts
@@ -1,0 +1,100 @@
+export const getRevealUnitAbsolutePath = (
+  data: unknown,
+): string | undefined => {
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  const absolutePath = (data as { absolutePath?: unknown }).absolutePath;
+  return typeof absolutePath === "string" ? absolutePath : undefined;
+};
+
+type FlowRevealUnit = {
+  id: string;
+  absolutePath: string;
+  unitType: string;
+  parentId?: string;
+  children: Array<unknown>;
+};
+
+export type FlowRevealTarget = {
+  scopeUnitId: string;
+  revealedUnitId: string;
+  expandedAncestorUnitIds: string[];
+};
+
+const findFlowRevealUnitByAbsolutePath = (
+  unitById: ReadonlyMap<string, FlowRevealUnit>,
+  absolutePath: string,
+): FlowRevealUnit | undefined =>
+  Array.from(unitById.values()).find(
+    (unit) => unit.absolutePath === absolutePath,
+  );
+
+const findFlowRevealParentUnit = (
+  unitById: ReadonlyMap<string, FlowRevealUnit>,
+  unit: FlowRevealUnit,
+): FlowRevealUnit | undefined =>
+  unit.parentId ? unitById.get(unit.parentId) : undefined;
+
+const resolveFlowRevealScopeUnit = (
+  unitById: ReadonlyMap<string, FlowRevealUnit>,
+  revealedUnit: FlowRevealUnit,
+): FlowRevealUnit => {
+  const directParent = findFlowRevealParentUnit(unitById, revealedUnit);
+  if (directParent?.unitType === "rc") {
+    return directParent;
+  }
+
+  let current = directParent;
+  while (current) {
+    if (current.unitType === "n") {
+      return current;
+    }
+    current = findFlowRevealParentUnit(unitById, current);
+  }
+
+  return revealedUnit;
+};
+
+const collectExpandedAncestorUnitIds = (
+  unitById: ReadonlyMap<string, FlowRevealUnit>,
+  revealedUnit: FlowRevealUnit,
+  scopeUnit: FlowRevealUnit,
+): string[] => {
+  const expandedAncestorUnitIds: string[] = [];
+  let current = findFlowRevealParentUnit(unitById, revealedUnit);
+  while (current && current.id !== scopeUnit.id) {
+    if (current.unitType === "n" && current.children.length > 0) {
+      expandedAncestorUnitIds.unshift(current.id);
+    }
+    current = findFlowRevealParentUnit(unitById, current);
+  }
+  return expandedAncestorUnitIds;
+};
+
+export const resolveFlowRevealTarget = (
+  unitById: ReadonlyMap<string, FlowRevealUnit>,
+  absolutePath: string,
+): FlowRevealTarget | undefined => {
+  const revealedUnit = findFlowRevealUnitByAbsolutePath(unitById, absolutePath);
+  if (!revealedUnit) {
+    return undefined;
+  }
+
+  const scopeUnit = resolveFlowRevealScopeUnit(unitById, revealedUnit);
+
+  return {
+    scopeUnitId: scopeUnit.id,
+    revealedUnitId: revealedUnit.id,
+    expandedAncestorUnitIds: collectExpandedAncestorUnitIds(
+      unitById,
+      revealedUnit,
+      scopeUnit,
+    ),
+  };
+};
+
+export const findRowIndexByAbsolutePath = (
+  rowIndexByAbsolutePath: ReadonlyMap<string, number>,
+  absolutePath: string,
+): number | undefined => rowIndexByAbsolutePath.get(absolutePath);


### PR DESCRIPTION
## Summary
- add explicit bridge actions between the unit list and flow viewer when the counterpart viewer is already open
- reveal the containing jobnet or .condition scope in flow and highlight the bridged unit instead of making non-root units the flow root
- update the 1.13.0 changelog and SDD notes for the finalized bridge behavior

## Validation
- pnpm run build
- pnpm test
- pnpm run qlty