### PR TITLE
[codex] Sync SDD after flow navigation and set next JP1 v13 slice

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -19,6 +19,16 @@ version 13 reference-driven contracts.
 4. Add manual-aligned coverage in small command and parameter slices
 5. Update consumers such as show-unit-definition
 
+## Current Slice
+
+- 2026-04-19 next slice decision:
+  start with an audit pass before behavior changes. Inventory the current
+  parameter semantics that already match the JP1/AJS3 version 13 Definition
+  File Reference, inventory the current command-generation behavior and its
+  coupling to `buildUnitDefinition.ts`, and use that evidence to choose the
+  first reusable extraction or supported-command slice without hiding known
+  mismatches.
+
 ## Validation
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -131,6 +131,19 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
   flow-to-list target resolution, then re-run the standard desktop, web, and
   production-build baseline to confirm the navigation wiring behaves the same
   in both hosts.
+- 2026-04-19 navigation implementation result:
+  explicit bridge actions now connect the table and flow viewers through shared
+  navigation events keyed by normalized `absolutePath`. The table can request
+  the matching flow scope, and flow nodes can request the matching table row,
+  while each viewer keeps ownership of its own local selection state.
+- 2026-04-19 navigation validation result:
+  shared viewer-message routing coverage now exercises navigation events,
+  reveal-helper coverage verifies flow target and table row resolution by
+  stable path, and viewer-factory coverage confirms the injected navigation
+  handler receives the expected target view plus absolute path.
+- 2026-04-19 follow-up decision:
+  keep broader flow-search behavior deferred for now and move the next active
+  SDD slice to JP1/AJS3 version 13 parameter and command-reference alignment.
 
 ## Validation
 

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -15,6 +15,11 @@
       the current viewer selection contract:
       child jobnets can now expand or collapse nested content inline while the
       existing scope-changing open action remains available
+- [x] Add explicit bridge actions between the unit list and flow graph using
+      stable `absolutePath`-based navigation events and reveal helpers:
+      the table can request the matching flow scope, and the flow view can
+      request the matching table row without importing the other viewer's
+      internal state
 
 ## Remaining Follow-up
 
@@ -113,3 +118,7 @@
   implementation slice should be explicit unit-list and flow-graph navigation
   because that use case is already specified and benefits from the stable
   `absolutePath` / `currentUnitId` identity seams now in place.
+- 2026-04-19: explicit list/flow bridge navigation is now implemented in both
+  directions. Table rows post shared navigation events toward the flow viewer,
+  flow nodes post the symmetric table-navigation event, and focused helper plus
+  routing tests cover the identity-preserving reveal behavior.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -139,6 +139,11 @@ structure in `docs/specs/features/<feature>/`.
   collapsed nested-jobnet hierarchy required to show the first match, and
   visually emphasize that match without changing the base `currentUnitId`
   scope contract.
+- Explicit list/flow bridge navigation is now in place:
+  table rows can request the matching flow scope and flow nodes can request the
+  matching table row through shared `absolutePath`-based navigation events and
+  local reveal helpers, without either viewer importing the other's internal
+  component state.
 
 ### How To Maintain This Section
 
@@ -153,25 +158,21 @@ structure in `docs/specs/features/<feature>/`.
 
 ### Next Priority Tasks
 
-1. Refresh flow-graph UX in focused slices:
-   visual parity with JP1/AJS View plus incremental, one-click, deeper nested
-   expansion, and first-slice current-scope search are now in place. Broader
-   flow-search behavior is intentionally deferred for now, so the next active
-   viewer-facing slice is explicit unit-list and flow-graph navigation on top
-   of the same interaction model.
-2. Align parameter parsing and `ajs` command generation with
-   JP1/Automatic Job Management System 3 version 13 reference manuals.
-3. Define a read-only JP1/AJS WebAPI import boundary with clear application
+1. Align parameter parsing and `ajs` command generation with
+   JP1/Automatic Job Management System 3 version 13 reference manuals,
+   starting with an explicit inventory of the current parameter semantics and
+   command-generation seams that already match the named references.
+2. Define a read-only JP1/AJS WebAPI import boundary with clear application
    and infrastructure responsibilities.
-4. Continue treating desktop and web compatibility as an explicit acceptance
+3. Continue treating desktop and web compatibility as an explicit acceptance
    criterion whenever bootstrap, preview, parsing, shared adapters, or package
    runtime behavior change.
-5. Keep feature follow-up verification evidence concrete:
+4. Keep feature follow-up verification evidence concrete:
    prefer automated smoke or regression coverage where practical, and reserve
    manual smoke debt for behavior that still lacks a reliable test seam.
-6. Revisit viewer bundle-size work only when a clearer reduction seam or
+5. Revisit viewer bundle-size work only when a clearer reduction seam or
    stronger product need appears.
-7. Extend list-view search on the current presentation path so parameter key
+6. Extend list-view search on the current presentation path so parameter key
    and value queries can complement the existing partial-match behavior, while
    still revisiting a dedicated application use case only if another
    non-table consumer needs the same matching semantics.

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -69,26 +69,26 @@
 27. Add a one-click expand-all path on top of the flow viewer's new
     nested-expansion state so users can reveal the current scope in one step
     without changing the existing selection contract.
+28. Refresh the flow-graph presentation so its visual design is closer to
+    JP1/AJS View while preserving current desktop and web compatibility.
+29. Add explicit navigation between unit-list and flow-graph units when the
+    counterpart view for the selected unit is available.
 
 ## Current Roadmap
 
-1. Refresh the flow-graph presentation so its visual design is closer to
-   JP1/AJS View while preserving current desktop and web compatibility.
-2. Add explicit navigation between unit-list and flow-graph units when the
-   counterpart view for the selected unit is available.
-3. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+1. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
-4. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
+2. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
    generated commands with JP1/Automatic Job Management System 3 version 13
    Command Reference.
-5. Add a read-only JP1/AJS WebAPI import path for loading server-side
+3. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
-6. Replace the custom `UnitEntity` hash implementation with a common
+4. Replace the custom `UnitEntity` hash implementation with a common
    algorithm once identity and compatibility checks are explicit.
-7. Add richer unit-list search on top of the current presentation-local
+5. Add richer unit-list search on top of the current presentation-local
    matcher so parameter-key and parameter-value queries complement the current
    partial-match behavior.
-8. Consolidate i18n translation files to reduce duplication between language
+6. Consolidate i18n translation files to reduce duplication between language
    variants.
 
 ## Deferred / Optional Slices


### PR DESCRIPTION
## What changed
- sync SDD docs to reflect that explicit unit-list and flow-graph navigation is already implemented
- move the completed flow-navigation slice into the recorded completed state in feature and branch-level planning docs
- set the next active SDD slice to a JP1/AJS3 version 13 parameter and command-reference audit

## Why
The code and changelog already showed list/flow bridge navigation as complete, but the SDD docs still treated it as upcoming work. This PR brings the specs and roadmap back in sync so the next slice starts from the current implementation reality.

## Impact
- no runtime behavior changes
- docs-only SDD synchronization
- next priority work is now explicitly the JP1/AJS3 version 13 reference audit

## Validation
- `pnpm run lint:md`
