### PR TITLE
[codex] audit JP1 v13 alignment baseline

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/AUDIT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/AUDIT.md
@@ -1,0 +1,118 @@
+# AUDIT: align-jp1-v13-parameter-and-command-reference
+
+## Purpose
+
+Record the current implementation seams that already encode JP1/AJS3 version 13
+parameter or command behavior before any alignment refactor changes that
+behavior.
+
+## Current Parameter Semantics Inventory
+
+### Stable entry seam
+
+- `src/domain/models/parameters/ParameterFactory.ts` is already the stable
+  parameter-construction facade for wrapper callers.
+- The facade is organized by builder family rather than by manual chapter:
+  optional scalar, optional array, required scalar, schedule-rule, and
+  transfer-operation builders.
+
+### Shared semantics already centralized
+
+- `src/domain/models/parameters/parameterHelpers.ts` is the main shared
+  interpretation seam today.
+- The helpers already centralize these JP1-facing behaviors:
+  inherited lookup from ancestor units
+  root-jobnet-only defaults for `rg`, `sd`, `ncl`, `ncs`, and `ncex`
+  connector-control default application modes
+  transfer-operation fallback resolution for `top1` to `top4`
+  schedule-rule sorting and `sd`-aligned schedule parameter expansion
+  required vs optional parameter resolution
+- `src/domain/models/parameters/Defaults.ts` is the single table for raw
+  default values that those helpers apply.
+
+### Builder families that already encode semantics
+
+- `optionalScalarParameterBuilders.ts` already separates three existing
+  behaviors without viewer coupling:
+  plain optional lookup
+  inherited optional lookup
+  default-aware optional lookup, including root-jobnet-aware defaults
+- `optionalArrayParameterBuilders.ts` already centralizes array lookup and the
+  inherited array cases that exist today, notably `cl` and `op`.
+- `ruleParameterBuilders.ts` already centralizes schedule-rule-bearing
+  parameters:
+  sorted rule arrays such as `ln`
+  root-default-aware `sd`
+  `sd`-aligned empty-value families such as `cy`, `ey`, `sh`, and `sy`
+  `sd`-aligned default-value families such as `cftd`, `shd`, `st`, `wc`, and
+  `wt`
+
+### Current gaps in the parameter audit
+
+- The current code organizes semantics by construction pattern, not by an
+  explicit JP1/AJS3 version 13 parameter coverage matrix.
+- Unit-type restrictions are still mostly implicit in wrapper ownership and
+  builder usage rather than recorded as manual-aligned support statements.
+- There is not yet one doc that states which parameter keys are:
+  already aligned
+  partially aligned
+  intentionally deferred
+  known mismatches
+
+## Current Command-Generation Inventory
+
+### Current owning seam
+
+- `src/application/unit-definition/buildUnitDefinition.ts` currently owns both
+  dialog assembly and command generation.
+- The same function builds:
+  `rawData` by joining normalized unit parameters as `key=value` lines
+  `commands` as presentation-ready DTOs for the unit-definition dialog
+
+### Currently supported auto-generated commands
+
+- The current implementation auto-generates exactly two commands:
+  `ajsshow -R <absolutePath>`
+  `ajsprint -a -R <absolutePath>`
+- The command input is the normalized `AjsUnit.absolutePath`, so the current
+  behavior already depends on stable application-facing data rather than
+  webview component state.
+- `buildUnitDefinitionByPath(...)` precomputes the same dialog DTO per
+  `absolutePath`, which means command generation is already reusable in shape
+  but not yet extracted as its own contract.
+
+### Current coupling to show-unit-definition
+
+- `UnitDefinitionDialogDto` embeds command DTOs directly, so command support is
+  still modeled as a property of the dialog payload instead of a dedicated
+  command-generation result.
+- `src/test/suite/buildUnitDefinition.test.ts` verifies command strings only
+  through the dialog builder, so command behavior cannot yet be tested or
+  evolved independently from dialog assembly.
+- No separate application service or use case names the supported command set,
+  which keeps the current scope implicit.
+
+## Decision For The First Extracted Command Set
+
+- Preserve the current user-visible command set as the first supported
+  auto-generated contract:
+  `ajsshow`
+  `ajsprint`
+- This is the safest first extraction because:
+  both commands already exist in shipped behavior
+  both are read-only and fit the current docs-only audit scope
+  the existing normalized `absolutePath` input is already sufficient
+
+## Mismatch Tracking Rule
+
+- Track future manual alignment one small slice at a time inside this feature
+  folder instead of hiding gaps in code comments.
+- For every parameter or command slice, record:
+  the JP1 key or command name
+  the source reference section
+  current status as `aligned`, `partial`, `mismatch`, or `deferred`
+  the owning code seam
+  the regression evidence or missing test
+- Until a dedicated matrix file is needed, keep that status in
+  `TASKS.md` notes and update it in the same commit as the behavior or doc
+  change.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -21,13 +21,17 @@ version 13 reference-driven contracts.
 
 ## Current Slice
 
-- 2026-04-19 next slice decision:
-  start with an audit pass before behavior changes. Inventory the current
-  parameter semantics that already match the JP1/AJS3 version 13 Definition
-  File Reference, inventory the current command-generation behavior and its
-  coupling to `buildUnitDefinition.ts`, and use that evidence to choose the
-  first reusable extraction or supported-command slice without hiding known
-  mismatches.
+- 2026-04-20 audit outcome:
+  the inventory pass is now recorded in `AUDIT.md`. Shared parameter
+  interpretation already lives mainly behind `ParamFactory`,
+  `parameterHelpers.ts`, the builder-family modules, and `Defaults.ts`,
+  while command generation is still directly embedded in
+  `buildUnitDefinition.ts`.
+- 2026-04-20 next implementation slice:
+  extract the existing `ajsshow` and `ajsprint` command generation into a
+  dedicated application-facing seam without changing the dialog DTO contract,
+  then use that seam as the first reusable command-generation contract for
+  `show-unit-definition`.
 
 ## Validation
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -16,14 +16,30 @@
 
 ## Remaining Follow-up
 
-- [ ] Inventory current parameter semantics that already match the version 13
+- [x] Inventory current parameter semantics that already match the version 13
       definition reference
-- [ ] Inventory current command-generation behavior and its coupling to
+- [x] Inventory current command-generation behavior and its coupling to
       show-unit-definition
-- [ ] Decide the first supported set of auto-generated `ajs` commands
-- [ ] Define how manual mismatches are tracked and closed incrementally
+- [x] Decide the first supported set of auto-generated `ajs` commands
+- [x] Define how manual mismatches are tracked and closed incrementally
+
+## Next Slice
+
+- [ ] Extract the current `ajsshow` and `ajsprint` generation logic from
+      `buildUnitDefinition.ts` into a dedicated application-facing seam while
+      preserving the existing dialog DTO behavior
+- [ ] Turn the audit notes into an explicit parameter-coverage matrix only when
+      a behavior-changing alignment slice needs per-key status beyond the
+      current audit summary
 
 ## Notes
 
 - 2026-04-18: normative parameter and command sources were fixed to the user
   supplied JP1/AJS3 version 13 reference documents.
+- 2026-04-20: the initial audit is recorded in `AUDIT.md`. Current parameter
+  semantics are already centralized mainly in `parameterHelpers.ts`,
+  `Defaults.ts`, and the builder families behind `ParamFactory`, while command
+  generation is still embedded in
+  `src/application/unit-definition/buildUnitDefinition.ts`.
+- 2026-04-20: the first extracted supported command set will preserve the
+  current user-visible behavior only: `ajsshow` and `ajsprint`.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -12,6 +12,12 @@ structure in `docs/specs/features/<feature>/`.
 
 ### Completed In This Branch
 
+- JP1/AJS3 version 13 alignment now has an explicit audit baseline:
+  `docs/specs/features/align-jp1-v13-parameter-and-command-reference/AUDIT.md`
+  records the current shared parameter-semantics seams, the current
+  command-generation coupling inside `buildUnitDefinition.ts`, the first
+  preserved supported command set (`ajsshow`, `ajsprint`), and the rule for
+  tracking manual mismatches incrementally.
 - Decompose `buildUnitListView.ts` into focused projection helpers:
   `group6` calendar, `group7`/`group11` priority, `group10` schedule, and
   linked-unit projections now live in dedicated helper modules with focused
@@ -159,9 +165,10 @@ structure in `docs/specs/features/<feature>/`.
 ### Next Priority Tasks
 
 1. Align parameter parsing and `ajs` command generation with
-   JP1/Automatic Job Management System 3 version 13 reference manuals,
-   starting with an explicit inventory of the current parameter semantics and
-   command-generation seams that already match the named references.
+   JP1/Automatic Job Management System 3 version 13 reference manuals by
+   using the new audit baseline to extract the current `ajsshow` and
+   `ajsprint` generation logic from `buildUnitDefinition.ts` into a dedicated
+   application-facing seam.
 2. Define a read-only JP1/AJS WebAPI import boundary with clear application
    and infrastructure responsibilities.
 3. Continue treating desktop and web compatibility as an explicit acceptance

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -77,10 +77,12 @@
 ## Current Roadmap
 
 1. Re-base parameter interpretation on JP1/Automatic Job Management System 3
-   version 13 Definition File Reference.
+   version 13 Definition File Reference, starting from the documented audit
+   of today's shared parameter-semantics seams.
 2. Separate `ajs` command generation from `buildUnitDefinition.ts` and align
    generated commands with JP1/Automatic Job Management System 3 version 13
-   Command Reference.
+   Command Reference, beginning with the existing `ajsshow` and `ajsprint`
+   behavior as the first extracted supported command set.
 3. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
 4. Replace the custom `UnitEntity` hash implementation with a common


### PR DESCRIPTION
## Summary

- add an SDD audit baseline for JP1/AJS3 version 13 parameter and command alignment
- document the current shared parameter-semantics seams and the remaining command-generation coupling in `buildUnitDefinition.ts`
- update feature and branch planning docs so the next slice is the extraction of the current `ajsshow` and `ajsprint` command generation path

## Why

The alignment feature already pointed to an audit-first slice, but the repository did not yet record where the current JP1-facing semantics live or how command generation is still coupled to the unit-definition dialog builder. This PR makes that baseline explicit before behavior-changing refactors.

## Impact

- no runtime behavior changes
- no VS Code compatibility change
- no web extension behavior change
- gives the next implementation slice a clear extracted-command target and mismatch-tracking rule

## Validation

- `pnpm run lint:md`
