### PR TITLE
[codex] Finish flow search for 1.13.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [1.13.0]
 
-- Added inline nested expansion for nested jobnets in the flow viewer,
-  including deeper nested scopes.
-- Improved flow-view expansion layout, re-layout stability, and highlighting.
-- Added current-scope flow search that reveals collapsed ancestors and
-  highlights the first matching unit.
+- Expanded the flow viewer with inline nested jobnet expansion, including
+  deeper nested scopes and more stable re-layout behavior.
+- Added current-scope flow search that preserves space-containing queries,
+  highlights all visible matches, and expands the ancestor hierarchy needed to
+  reveal them while keeping focus on the first chosen result.
 - Added explicit bridge actions between the unit list and flow viewer when the
   counterpart viewer is already open.
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,10 @@ information for JP1/AJS3 from Hitachi in a human-readable format.
 
 ## Recent Updates
 
-- Flow viewer visuals are more legible, with clearer emphasis on the current
-  node, ancestor chain, and root jobnet.
-- Flow webview sizing now stays within the available panel area instead of
-  showing stray browser-level scrollbars.
-- Table view scrolling behavior is preserved for both window-scroll and
-  table-scroll modes after the webview layout updates.
+- Flow viewer now supports inline nested jobnet expansion, current-scope flow
+  search, and list/flow bridge navigation.
+- Flow viewer visuals and layout behavior are more stable in both desktop and
+  web hosts.
 
 ## Extension Settings
 

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -121,18 +121,29 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
   insufficient for real navigation needs.
 - 2026-04-21 refinement focus:
   keep the first-match, current-scope search interaction unchanged, but widen
-  the matcher from whole-query substring checks to space-separated
-  case-insensitive partial-match keywords so shorter user input and combined
-  name/comment/path fragments can reveal the same first visible target.
+  the matcher so it stays case-insensitive and contiguous, preserves internal
+  spaces for comment/path fragments, and still chooses a visibly focused
+  descendant when the current scope root also matches the same query.
 - 2026-04-21 refinement result:
-  flow search now treats each non-blank query token as a partial-match keyword
-  against the existing searchable unit text, preserving current-scope first
-  match ordering and collapsed-ancestor expansion while reducing the need for
-  exact contiguous input.
+  flow search now preserves internal spaces in the query, treats the whole
+  normalized input as one contiguous partial match against the existing
+  searchable unit text, and prefers the first descendant over the scope root
+  when multiple current-scope units match the same query.
+- 2026-04-21 refinement follow-up:
+  current-scope search should not stop visual feedback at the first chosen
+  match. Keep first-match focus and ancestor expansion for stability, but pass
+  the full visible match set through the presentation layer so every matching
+  node is highlighted.
+- 2026-04-21 refinement correction:
+  first-match focus stays useful, but ancestor expansion should not stay
+  first-match-only. Expand the combined ancestor jobnet set for every current-
+  scope match so all matching nodes that can be revealed in the current canvas
+  become visible after one search submit.
 - 2026-04-21 refinement validation result:
-  focused flow-search regression coverage now verifies multi-keyword partial
-  matching alongside the existing blank-query and current-scope boundary
-  checks; desktop, web, and production-build validation remain the expected
+  focused flow-search regression coverage now verifies preserved-space comment
+  matching, descendant-priority focus, and all-match ancestor expansion
+  alongside the existing blank-query and current-scope boundary checks;
+  desktop, web, and production-build validation remain the expected
   compatibility baseline for this viewer-facing refinement.
 - 2026-04-19 navigation implementation focus:
   use stable normalized identity that already exists in both viewers

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -119,6 +119,21 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
   search before cross-view navigation. Those search follow-ups stay deferred
   until a later slice shows that the first current-scope search behavior is
   insufficient for real navigation needs.
+- 2026-04-21 refinement focus:
+  keep the first-match, current-scope search interaction unchanged, but widen
+  the matcher from whole-query substring checks to space-separated
+  case-insensitive partial-match keywords so shorter user input and combined
+  name/comment/path fragments can reveal the same first visible target.
+- 2026-04-21 refinement result:
+  flow search now treats each non-blank query token as a partial-match keyword
+  against the existing searchable unit text, preserving current-scope first
+  match ordering and collapsed-ancestor expansion while reducing the need for
+  exact contiguous input.
+- 2026-04-21 refinement validation result:
+  focused flow-search regression coverage now verifies multi-keyword partial
+  matching alongside the existing blank-query and current-scope boundary
+  checks; desktop, web, and production-build validation remain the expected
+  compatibility baseline for this viewer-facing refinement.
 - 2026-04-19 navigation implementation focus:
   use stable normalized identity that already exists in both viewers
   (`absolutePath` for unit-list rows and the flow viewer's current-unit scope

--- a/docs/specs/features/enhance-flow-graph-experience/SPECS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/SPECS.md
@@ -20,9 +20,9 @@ navigation from and to the unit list.
 - the first flow-view search slice may stay within the current flow scope
   if it reveals collapsed ancestors needed to show the first match before
   visually focusing that match
-- current-scope flow search supports partial-match keywords across unit name,
-  comment, and path so users do not need exact full-label input to find the
-  first match
+- current-scope flow search supports case-insensitive contiguous partial
+  matches across unit name, comment, and path so users do not need exact
+  full-label input to find the first match
 - a one-click expand-all path is considered in the design, even if it lands
   after the first incremental expansion slice
 - explicit navigation between unit-list and flow-graph units is defined when
@@ -38,8 +38,18 @@ navigation from and to the unit list.
   nested-expansion state and a presentation-local focus marker instead of
   introducing a new graph DTO contract or a second scope-selection model
 - keep current-scope search matching presentation-local:
-  normalize the query, split space-separated keywords, and treat each keyword
-  as a case-insensitive partial match against the existing unit search text
+  normalize the query, preserve internal spaces, and treat the full query as a
+  case-insensitive contiguous partial match against the existing unit search
+  text
+- when more than one unit matches inside the current scope, prefer the first
+  descendant match over the scope root itself so search still produces a
+  visible focus change
+- when more than one unit matches inside the current scope, visually
+  highlight every visible match while keeping keyboard focus and ancestor
+  expansion decisions anchored to the first chosen match
+- when more than one unit matches inside the current scope, expand the union
+  of collapsed ancestor jobnets needed to reveal every visible match rather
+  than only the first chosen one
 - split the work into small viewer-facing slices:
   visual refresh, nested expansion, and cross-view navigation do not need to
   land in one commit

--- a/docs/specs/features/enhance-flow-graph-experience/SPECS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/SPECS.md
@@ -20,6 +20,9 @@ navigation from and to the unit list.
 - the first flow-view search slice may stay within the current flow scope
   if it reveals collapsed ancestors needed to show the first match before
   visually focusing that match
+- current-scope flow search supports partial-match keywords across unit name,
+  comment, and path so users do not need exact full-label input to find the
+  first match
 - a one-click expand-all path is considered in the design, even if it lands
   after the first incremental expansion slice
 - explicit navigation between unit-list and flow-graph units is defined when
@@ -34,6 +37,9 @@ navigation from and to the unit list.
 - for the first flow-view search slice, prefer reusing the existing
   nested-expansion state and a presentation-local focus marker instead of
   introducing a new graph DTO contract or a second scope-selection model
+- keep current-scope search matching presentation-local:
+  normalize the query, split space-separated keywords, and treat each keyword
+  as a case-insensitive partial match against the existing unit search text
 - split the work into small viewer-facing slices:
   visual refresh, nested expansion, and cross-view navigation do not need to
   land in one commit

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -39,10 +39,17 @@
       current-scope slice:
       broader search behavior is intentionally deferred for now so the next
       viewer-facing slice can focus on explicit list/flow navigation first
-- [x] Refine current-scope flow search to support space-separated partial-match
-      keywords:
-      keep first-match behavior and ancestor reveal semantics, but reduce the
-      need for exact contiguous query text
+- [x] Refine current-scope flow search matching:
+      preserve space-containing query text, keep ancestor reveal semantics,
+      and prefer a descendant focus target when the current scope root also
+      matches
+- [x] Highlight all visible flow-search matches while preserving first-match
+      focus:
+      keep selected/focused state on the first chosen match, but decorate every
+      visible node that matches the current-scope query
+- [x] Expand all matched flow-search results in the current scope:
+      keep first-match focus, but reveal every matching node by expanding the
+      combined ancestor jobnet set for all matches
 - [x] Define the visual cues that most matter for JP1/AJS View resemblance
 - [x] Decide whether expand-all ships in the same slice as incremental
       expansion or immediately after
@@ -54,6 +61,14 @@
       seam, verify both desktop and web preview opening still succeed, and
       reserve nested-expansion plus cross-view navigation behavior for the
       follow-up slices that introduce those interactions
+
+## Release Note
+
+- 2026-04-21: this flow-view usability slice is complete for the `1.13.0`
+  release line:
+  visual refresh, nested expansion, current-scope search refinement, and
+  list/flow bridge navigation are now recorded in SDD, covered by focused
+  regression tests, and ready for release packaging.
 
 ## Notes
 
@@ -126,7 +141,16 @@
   directions. Table rows post shared navigation events toward the flow viewer,
   flow nodes post the symmetric table-navigation event, and focused helper plus
   routing tests cover the identity-preserving reveal behavior.
-- 2026-04-21: current-scope flow search now accepts space-separated keywords as
-  case-insensitive partial matches over the existing unit search text. The
-  first-match and collapsed-ancestor reveal behavior stay unchanged; only the
-  matcher becomes less strict than one contiguous whole-query substring.
+- 2026-04-21: current-scope flow search now keeps internal spaces in the query
+  and performs case-insensitive contiguous partial matching over the existing
+  unit search text. When the current scope root and its descendants both
+  match, the viewer prefers the first descendant so the highlighted result is
+  visibly useful without changing the collapsed-ancestor reveal behavior.
+- 2026-04-21: when one flow query matches multiple units in the current scope,
+  the viewer now keeps first-match selection semantics for focus and ancestor
+  reveal, but highlights every visible matching node instead of decorating only
+  the selected one.
+- 2026-04-21: when one flow query matches multiple units in the current scope,
+  ancestor expansion now uses the combined reveal path for every match instead
+  of only the first focused result, so one search submit can expose all
+  matching nodes that belong in the current canvas.

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -39,6 +39,10 @@
       current-scope slice:
       broader search behavior is intentionally deferred for now so the next
       viewer-facing slice can focus on explicit list/flow navigation first
+- [x] Refine current-scope flow search to support space-separated partial-match
+      keywords:
+      keep first-match behavior and ancestor reveal semantics, but reduce the
+      need for exact contiguous query text
 - [x] Define the visual cues that most matter for JP1/AJS View resemblance
 - [x] Decide whether expand-all ships in the same slice as incremental
       expansion or immediately after
@@ -122,3 +126,7 @@
   directions. Table rows post shared navigation events toward the flow viewer,
   flow nodes post the symmetric table-navigation event, and focused helper plus
   routing tests cover the identity-preserving reveal behavior.
+- 2026-04-21: current-scope flow search now accepts space-separated keywords as
+  case-insensitive partial matches over the existing unit search text. The
+  first-match and collapsed-ancestor reveal behavior stay unchanged; only the
+  matcher becomes less strict than one contiguous whole-query substring.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -145,14 +145,23 @@ structure in `docs/specs/features/<feature>/`.
   collapsed nested-jobnet hierarchy required to show the first match, and
   visually emphasize that match without changing the base `currentUnitId`
   scope contract.
-- Flow-view search now also accepts space-separated partial-match keywords
-  against unit name, comment, and path while keeping the same current-scope
-  first-match and ancestor-reveal behavior.
+- Flow-view search now keeps internal spaces in the query, matches contiguous
+  case-insensitive substrings against unit name, comment, and path, and
+  prefers a descendant over the current scope root when both match.
+- Flow-view search now also highlights every visible match in the current
+  scope while keeping focus and ancestor reveal anchored to the first chosen
+  match.
+- Flow-view search now also expands the combined ancestor jobnet set for all
+  current-scope matches so every matched node can be revealed by one submit.
 - Explicit list/flow bridge navigation is now in place:
   table rows can request the matching flow scope and flow nodes can request the
   matching table row through shared `absolutePath`-based navigation events and
   local reveal helpers, without either viewer importing the other's internal
   component state.
+- The `1.13.0` flow-view usability slice is now release-ready:
+  the visual refresh, nested expansion, current-scope search refinement, and
+  list/flow bridge navigation changes are recorded in SDD and backed by the
+  standard local validation baseline.
 
 ### How To Maintain This Section
 

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -145,6 +145,9 @@ structure in `docs/specs/features/<feature>/`.
   collapsed nested-jobnet hierarchy required to show the first match, and
   visually emphasize that match without changing the base `currentUnitId`
   scope contract.
+- Flow-view search now also accepts space-separated partial-match keywords
+  against unit name, comment, and path while keeping the same current-scope
+  first-match and ancestor-reveal behavior.
 - Explicit list/flow bridge navigation is now in place:
   table rows can request the matching flow scope and flow nodes can request the
   matching table row through shared `absolutePath`-based navigation events and

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-ajsbutler",
   "displayName": "vscode-ajsbutler",
   "description": "Support tool for JP1/AJS3",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",

--- a/src/test/suite/flowGraphView.test.ts
+++ b/src/test/suite/flowGraphView.test.ts
@@ -145,6 +145,10 @@ suite("Flow Graph View", () => {
       },
       {
         nodeDecorations: new Map(),
+        searchMatchedUnitIds: new Set([
+          "/root/jobnet/child-net",
+          "/root/jobnet/child-net/grand-net",
+        ]),
         searchedUnitId: "/root/jobnet/child-net/grand-net",
         unitById: new Map([
           [
@@ -266,6 +270,12 @@ suite("Flow Graph View", () => {
     assert.ok(searchMatchNode);
     assert.strictEqual(searchMatchNode.data.isSearchMatch, true);
     assert.strictEqual(searchMatchNode.selected, true);
+    const anotherSearchMatchNode = nodes.find(
+      (node) => node.id === "/root/jobnet/child-net",
+    );
+    assert.ok(anotherSearchMatchNode);
+    assert.strictEqual(anotherSearchMatchNode.data.isSearchMatch, true);
+    assert.strictEqual(anotherSearchMatchNode.selected, false);
     assert.strictEqual(nodes[1].data.unitId, "/root/jobnet/job-a");
     assert.strictEqual(nodes[1].data.hasWaitedFor, true);
     assert.strictEqual(nodes[2].data.canExpandNested, true);

--- a/src/test/suite/flowSearch.test.ts
+++ b/src/test/suite/flowSearch.test.ts
@@ -65,11 +65,12 @@ suite("Flow Search", () => {
 
     assert.deepStrictEqual(searchResult, {
       matchedUnitId: leafJobId,
+      matchedUnitIds: [leafJobId],
       expandedAncestorUnitIds: [childNetId, grandNetId],
     });
   });
 
-  test("matches space-separated partial keywords across searchable unit text", () => {
+  test("matches a contiguous query that includes spaces from searchable unit text", () => {
     const result = parseAjs(nestedDefinition);
     assert.deepStrictEqual(result.errors, []);
     const document = normalizeAjsDocument(result.rootUnits);
@@ -82,13 +83,40 @@ suite("Flow Search", () => {
 
     const searchResult = findFlowSearchResult(
       currentUnit,
-      "leaf /jobnet/child",
+      "leaf comment",
       unitById,
     );
 
     assert.deepStrictEqual(searchResult, {
       matchedUnitId: leafJobId,
+      matchedUnitIds: [leafJobId],
       expandedAncestorUnitIds: [childNetId, grandNetId],
+    });
+  });
+
+  test("prefers the first descendant match when the current scope also matches", () => {
+    const result = parseAjs(nestedDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const allUnits = flattenAjsUnits(document.rootUnits);
+    const unitById = new Map(allUnits.map((unit) => [unit.id, unit]));
+    const currentUnit = document.rootUnits[0].children[0];
+    const childNetId = currentUnit.children[0].id;
+
+    const searchResult = findFlowSearchResult(currentUnit, "/jobnet", unitById);
+
+    assert.deepStrictEqual(searchResult, {
+      matchedUnitId: childNetId,
+      matchedUnitIds: [
+        currentUnit.id,
+        childNetId,
+        currentUnit.children[0].children[0].id,
+        currentUnit.children[0].children[0].children[0].id,
+      ],
+      expandedAncestorUnitIds: [
+        childNetId,
+        currentUnit.children[0].children[0].id,
+      ],
     });
   });
 

--- a/src/test/suite/flowSearch.test.ts
+++ b/src/test/suite/flowSearch.test.ts
@@ -69,6 +69,29 @@ suite("Flow Search", () => {
     });
   });
 
+  test("matches space-separated partial keywords across searchable unit text", () => {
+    const result = parseAjs(nestedDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const allUnits = flattenAjsUnits(document.rootUnits);
+    const unitById = new Map(allUnits.map((unit) => [unit.id, unit]));
+    const currentUnit = document.rootUnits[0].children[0];
+    const childNetId = currentUnit.children[0].id;
+    const grandNetId = currentUnit.children[0].children[0].id;
+    const leafJobId = currentUnit.children[0].children[0].children[0].id;
+
+    const searchResult = findFlowSearchResult(
+      currentUnit,
+      "leaf /jobnet/child",
+      unitById,
+    );
+
+    assert.deepStrictEqual(searchResult, {
+      matchedUnitId: leafJobId,
+      expandedAncestorUnitIds: [childNetId, grandNetId],
+    });
+  });
+
   test("matches by absolute path and stays inside the current scope", () => {
     const result = parseAjs(nestedDefinition);
     assert.deepStrictEqual(result.errors, []);

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -105,6 +105,9 @@ const FlowContents: FC = () => {
   const [currentUnitId, setCurrentUnitId] = useState<string>();
   const [expandedUnitIds, setExpandedUnitIds] = useState<string[]>([]);
   const [searchedUnitId, setSearchedUnitId] = useState<string>();
+  const [searchMatchedUnitIds, setSearchMatchedUnitIds] = useState<string[]>(
+    [],
+  );
   const preserveSearchOnNextScopeChange = useRef<boolean>(false);
   const prevUnitEntityId = useRef<string | undefined>(undefined);
   const [nodes, setNodes] = useState<Node[]>([]);
@@ -234,6 +237,7 @@ const FlowContents: FC = () => {
         currentUnitIdState,
         {
           nodeDecorations,
+          searchMatchedUnitIds: new Set(searchMatchedUnitIds),
           searchedUnitId,
           unitById,
           nestedExpansionState,
@@ -251,6 +255,7 @@ const FlowContents: FC = () => {
       theme,
       unitDefinitionByPath,
       unitById,
+      searchMatchedUnitIds,
       searchedUnitId,
     ],
   );
@@ -260,6 +265,7 @@ const FlowContents: FC = () => {
       const result = findFlowSearchResult(currentUnit, query, unitById);
       if (!result) {
         setSearchedUnitId(undefined);
+        setSearchMatchedUnitIds([]);
         return;
       }
 
@@ -270,12 +276,14 @@ const FlowContents: FC = () => {
         }
         return [...next];
       });
+      setSearchMatchedUnitIds(result.matchedUnitIds);
       setSearchedUnitId(result.matchedUnitId);
     },
     [currentUnit, unitById],
   );
   const handleSearchClear = useCallback(() => {
     setSearchedUnitId(undefined);
+    setSearchMatchedUnitIds([]);
   }, []);
 
   const handleRevealUnit = useCallback(
@@ -287,6 +295,7 @@ const FlowContents: FC = () => {
       preserveSearchOnNextScopeChange.current = true;
       setExpandedUnitIds(revealTarget.expandedAncestorUnitIds);
       setCurrentUnitId(revealTarget.scopeUnitId);
+      setSearchMatchedUnitIds([revealTarget.revealedUnitId]);
       setSearchedUnitId(revealTarget.revealedUnitId);
     },
     [unitById],
@@ -304,6 +313,7 @@ const FlowContents: FC = () => {
       return;
     }
     setSearchedUnitId(undefined);
+    setSearchMatchedUnitIds([]);
   }, [ajsDocument, currentUnitId]);
 
   useEffect(() => {

--- a/src/ui-component/editor/ajsFlow/Header.tsx
+++ b/src/ui-component/editor/ajsFlow/Header.tsx
@@ -160,7 +160,7 @@ const Header: FC<HeaderProps> = ({
     : "Expand all nested jobnets.";
   const searchHelperText = searchedUnitId
     ? "Matched unit is highlighted in the current scope."
-    : "Search current scope by unit name, comment, or path.";
+    : "Search current scope by partial unit name, comment, or path.";
 
   return (
     <>

--- a/src/ui-component/editor/ajsFlow/Header.tsx
+++ b/src/ui-component/editor/ajsFlow/Header.tsx
@@ -160,7 +160,7 @@ const Header: FC<HeaderProps> = ({
     : "Expand all nested jobnets.";
   const searchHelperText = searchedUnitId
     ? "Matched unit is highlighted in the current scope."
-    : "Search current scope by partial unit name, comment, or path.";
+    : "Search current scope by unit name, comment, or path.";
 
   return (
     <>

--- a/src/ui-component/editor/ajsFlow/flowGraphView.ts
+++ b/src/ui-component/editor/ajsFlow/flowGraphView.ts
@@ -17,6 +17,7 @@ import { AjsNode } from "./nodes/AjsNode";
 import { calculateFlowGraphNodePosition } from "./flowGraphPosition";
 
 type CreateReactFlowDataOptions = {
+  searchMatchedUnitIds?: ReadonlySet<string>;
   unitById?: ReadonlyMap<string, AjsUnit>;
   nestedExpansionState?: NestedExpansionStateType;
   nodeDecorations?: ReadonlyMap<string, ExpandedNodeDecoration>;
@@ -56,7 +57,7 @@ const toNodeData = (
     isRootJobnet: node.metadata.isRootJobnet,
     hasSchedule: node.metadata.hasSchedule,
     hasWaitedFor: node.metadata.hasWaitedFor,
-    isSearchMatch: options?.searchedUnitId === node.id,
+    isSearchMatch: options?.searchMatchedUnitIds?.has(node.id) ?? false,
     canExpandNested:
       !node.metadata.isCurrent &&
       !node.metadata.isAncestor &&

--- a/src/ui-component/editor/ajsFlow/flowSearch.ts
+++ b/src/ui-component/editor/ajsFlow/flowSearch.ts
@@ -2,15 +2,11 @@ import { AjsUnit } from "../../../domain/models/ajs/AjsDocument";
 
 export type FlowSearchResult = {
   matchedUnitId: string;
+  matchedUnitIds: string[];
   expandedAncestorUnitIds: string[];
 };
 
-const normalizeQueryTokens = (query: string): string[] =>
-  query
-    .trim()
-    .toLowerCase()
-    .split(/\s+/)
-    .filter((token) => token.length > 0);
+const normalizeQuery = (query: string): string => query.trim().toLowerCase();
 
 const unitSearchText = (unit: AjsUnit): string =>
   [unit.name, unit.comment, unit.absolutePath]
@@ -46,6 +42,26 @@ const collectExpandedAncestorUnitIds = (
   return expandedAncestorUnitIds;
 };
 
+const collectExpandedAncestorUnitIdsForMatches = (
+  scopeRoot: AjsUnit,
+  matchedUnits: ReadonlyArray<AjsUnit>,
+  unitById: ReadonlyMap<string, AjsUnit>,
+): string[] => {
+  const expandedAncestorUnitIds = new Set<string>();
+
+  for (const matchedUnit of matchedUnits) {
+    for (const ancestorUnitId of collectExpandedAncestorUnitIds(
+      scopeRoot,
+      matchedUnit,
+      unitById,
+    )) {
+      expandedAncestorUnitIds.add(ancestorUnitId);
+    }
+  }
+
+  return [...expandedAncestorUnitIds];
+};
+
 export const findFlowSearchResult = (
   scopeRoot: AjsUnit | undefined,
   query: string,
@@ -55,25 +71,26 @@ export const findFlowSearchResult = (
     return undefined;
   }
 
-  const normalizedQueryTokens = normalizeQueryTokens(query);
-  if (normalizedQueryTokens.length === 0) {
+  const normalizedQuery = normalizeQuery(query);
+  if (normalizedQuery.length === 0) {
     return undefined;
   }
 
-  const matchedUnit = collectScopeUnits(scopeRoot).find((unit) =>
-    normalizedQueryTokens.every((token) =>
-      unitSearchText(unit).includes(token),
-    ),
+  const matchedUnits = collectScopeUnits(scopeRoot).filter((unit) =>
+    unitSearchText(unit).includes(normalizedQuery),
   );
+  const matchedUnit =
+    matchedUnits.find((unit) => unit.id !== scopeRoot.id) ?? matchedUnits[0];
   if (!matchedUnit) {
     return undefined;
   }
 
   return {
     matchedUnitId: matchedUnit.id,
-    expandedAncestorUnitIds: collectExpandedAncestorUnitIds(
+    matchedUnitIds: matchedUnits.map((unit) => unit.id),
+    expandedAncestorUnitIds: collectExpandedAncestorUnitIdsForMatches(
       scopeRoot,
-      matchedUnit,
+      matchedUnits,
       unitById,
     ),
   };

--- a/src/ui-component/editor/ajsFlow/flowSearch.ts
+++ b/src/ui-component/editor/ajsFlow/flowSearch.ts
@@ -5,7 +5,12 @@ export type FlowSearchResult = {
   expandedAncestorUnitIds: string[];
 };
 
-const normalizeQuery = (query: string): string => query.trim().toLowerCase();
+const normalizeQueryTokens = (query: string): string[] =>
+  query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
 
 const unitSearchText = (unit: AjsUnit): string =>
   [unit.name, unit.comment, unit.absolutePath]
@@ -50,13 +55,15 @@ export const findFlowSearchResult = (
     return undefined;
   }
 
-  const normalizedQuery = normalizeQuery(query);
-  if (normalizedQuery.length === 0) {
+  const normalizedQueryTokens = normalizeQueryTokens(query);
+  if (normalizedQueryTokens.length === 0) {
     return undefined;
   }
 
   const matchedUnit = collectScopeUnits(scopeRoot).find((unit) =>
-    unitSearchText(unit).includes(normalizedQuery),
+    normalizedQueryTokens.every((token) =>
+      unitSearchText(unit).includes(token),
+    ),
   );
   if (!matchedUnit) {
     return undefined;


### PR DESCRIPTION
## Summary

- finish the current-scope flow search behavior so it preserves space-containing queries, highlights every visible match, and expands the ancestor hierarchy needed to reveal all matches
- sync the flow-view SDD docs with the completed usability slice and mark the 1.13.0 flow-view work as release-ready
- trim the 1.13.0 changelog and README update notes down to the minimal release-facing summary

## Why

The original flow search slice only covered the first matched unit cleanly, while the release candidate needed the completed multi-match highlight and reveal behavior recorded in both code and SDD. This also prepares the release notes for the 1.13.0 line without carrying forward duplicate changelog wording.

## Impact

- flow search keeps focus on the first chosen result but highlights all visible matches
- one search submit now expands the combined ancestor jobnet set needed to reveal every current-scope match
- no VS Code engine compatibility change
- no intended desktop/web host behavior split

## Validation

- `pnpm run qlty`
- `pnpm test`
- `pnpm run test:web`
- `pnpm run build`

## Follow-up In This PR

- after PR checks pass, bump the extension version to `1.13.0` and push that update into this same PR before release publishing
