### PR TITLE
[codex] Fix flow expand/collapse layout

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 # npm
 node_modules/
+.pnpm-store/
 
 # antlr
 antlr/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.13.1]
+
+- Fixed flow-view nested expand/collapse layout so expanded panels stay
+  compact, revealed children stay anchored near their parent, and surrounding
+  nodes move with predictable offsets.
+- Fixed collapse behavior so nested descendant expansion state is cleared when
+  a parent jobnet is collapsed.
+
 ## [1.13.0]
 
 - Expanded the flow viewer with inline nested jobnet expansion, including

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -170,6 +170,17 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
 - 2026-04-19 follow-up decision:
   keep broader flow-search behavior deferred for now and move the next active
   SDD slice to JP1/AJS3 version 13 parameter and command-reference alignment.
+- 2026-04-21 nested expansion fix focus:
+  preserve the current flow scope model, but make inline collapse discard
+  descendant expansion state so reopening a parent jobnet starts from the
+  expected one-level reveal. Treat recovery jobnet variants that already map
+  to flow `jobnet` nodes as expandable when they have nested children.
+- 2026-04-21 offset-layout refinement:
+  replace nested-expansion collision handling with a display-position model:
+  each visible node keeps an initial position plus accumulated x/y offsets,
+  expansion adds vertical offsets to nodes below the expanded node and
+  horizontal offsets to nodes to its right regardless of nesting, and expanded
+  panel boundaries are rebuilt from final display positions.
 
 ## Validation
 

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -64,6 +64,11 @@
 
 ## Release Note
 
+- 2026-04-21: the flow-view expand/collapse correction is complete for the
+  `1.13.1` release line:
+  nested panels now use display-position offsets, revealed children stay
+  anchored near the expanded jobnet, parent collapse clears descendant
+  expansion state, and the release note is recorded in `CHANGELOG.md`.
 - 2026-04-21: this flow-view usability slice is complete for the `1.13.0`
   release line:
   visual refresh, nested expansion, current-scope search refinement, and

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-ajsbutler",
   "displayName": "vscode-ajsbutler",
   "description": "Support tool for JP1/AJS3",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",

--- a/src/test/suite/buildExpandedFlowGraph.test.ts
+++ b/src/test/suite/buildExpandedFlowGraph.test.ts
@@ -175,6 +175,28 @@ unit=root,,jp1admin,;
 }
 `;
 
+const recoveryJobnetDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=recovery-net,rn,+240+144;
+    unit=recovery-net,,jp1admin,;
+    {
+      ty=rn;
+      el=leaf-job,j,+240+144;
+      unit=leaf-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+  }
+}
+`;
+
 suite("Build Expanded Flow Graph", () => {
   test("reveals nested jobnets only after their parent scope is expanded", () => {
     const result = parseAjs(nestedDefinition);
@@ -287,7 +309,7 @@ suite("Build Expanded Flow Graph", () => {
     assert.ok(fullyExpandedSiblingPosition!.x > childPanelRight);
   });
 
-  test("moves colliding siblings and their nearby incoming sources below the expanded panel", () => {
+  test("adds offsets to visible nodes below or right of the expanded node", () => {
     const result = parseAjs(overlappingSiblingDefinition);
     assert.deepStrictEqual(result.errors, []);
     const document = normalizeAjsDocument(result.rootUnits);
@@ -330,9 +352,42 @@ suite("Build Expanded Flow Graph", () => {
 
     const panelBottom =
       childExpanded!.y + decoration!.panelOffsetYPx + decoration!.panelHeightPx;
+    assert.ok(orjExpanded!.x > orjCollapsed!.x);
     assert.ok(orjExpanded!.y > panelBottom);
-    assert.ok(flwjExpanded!.y > flwjCollapsed!.y);
+    assert.deepStrictEqual(flwjExpanded, flwjCollapsed);
+    assert.strictEqual(ntwjExpanded!.x, ntwjCollapsed!.x);
     assert.ok(ntwjExpanded!.y > ntwjCollapsed!.y);
+  });
+
+  test("keeps revealed children anchored near the expanded node origin", () => {
+    const result = parseAjs(overlappingSiblingDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const childNetId = document.rootUnits[0].children[0].children[0].id;
+    const grandNetId =
+      document.rootUnits[0].children[0].children[0].children[0].id;
+    const nestedJobId =
+      document.rootUnits[0].children[0].children[0].children[1].id;
+
+    const expanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([childNetId]),
+      16,
+    );
+
+    const childPosition = expanded.positionOverrides.get(childNetId);
+    const grandNetPosition = expanded.positionOverrides.get(grandNetId);
+    const nestedJobPosition = expanded.positionOverrides.get(nestedJobId);
+
+    assert.ok(childPosition);
+    assert.ok(grandNetPosition);
+    assert.ok(nestedJobPosition);
+    assert.ok(grandNetPosition!.x - childPosition!.x < 160);
+    assert.ok(grandNetPosition!.y - childPosition!.y < 320);
+    assert.ok(nestedJobPosition!.x - childPosition!.x < 240);
+    assert.ok(nestedJobPosition!.y - childPosition!.y < 320);
   });
 
   test("expands nested jobnets level by level when a newly visible child is also expanded", () => {
@@ -443,5 +498,29 @@ suite("Build Expanded Flow Graph", () => {
 
     assert.ok(deepSiblingPosition!.x > shallowSiblingPosition!.x);
     assert.ok(deepSiblingPosition!.x > deepLevel2PanelRight);
+  });
+
+  test("expands recovery jobnet variants with nested children", () => {
+    const result = parseAjs(recoveryJobnetDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const recoveryNetId = document.rootUnits[0].children[0].children[0].id;
+    const leafJobId =
+      document.rootUnits[0].children[0].children[0].children[0].id;
+
+    const expanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([recoveryNetId]),
+      16,
+    );
+
+    assert.ok(expanded.graph);
+    assert.strictEqual(
+      expanded.graph?.nodes.some((node) => node.id === leafJobId),
+      true,
+    );
+    assert.ok(expanded.nodeDecorations.get(recoveryNetId));
   });
 });

--- a/src/test/suite/flowGraphView.test.ts
+++ b/src/test/suite/flowGraphView.test.ts
@@ -53,7 +53,7 @@ suite("Flow Graph View", () => {
           type: "jobnet",
           metadata: {
             absolutePath: "/root/jobnet/child-net",
-            ty: "n",
+            ty: "rn",
             comment: "nested child",
             isAncestor: false,
             isCurrent: false,
@@ -157,7 +157,7 @@ suite("Flow Graph View", () => {
               id: "/root/jobnet/child-net",
               name: "child-net",
               unitAttribute: "",
-              unitType: "n",
+              unitType: "rn",
               absolutePath: "/root/jobnet/child-net",
               depth: 2,
               parentId: "/root/jobnet",

--- a/src/test/suite/nestedExpansion.test.ts
+++ b/src/test/suite/nestedExpansion.test.ts
@@ -2,9 +2,12 @@ import * as assert from "assert";
 import { parseAjs } from "../../domain/services/parser/AjsParser";
 import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
 import {
+  collapseExpandedNestedUnitIds,
   collectExpandableNestedUnitIds,
   hasExpandedAllNestedUnitIds,
+  isExpandableNestedUnit,
 } from "../../ui-component/editor/ajsFlow/nestedExpansion";
+import { AjsUnit } from "../../domain/models/ajs/AjsDocument";
 
 const nestedDefinition = `
 unit=root,,jp1admin,;
@@ -58,6 +61,64 @@ suite("Nested Expansion", () => {
       childNetId,
       grandNetId,
     ]);
+  });
+
+  test("treats recovery jobnet variants as expandable nested jobnets", () => {
+    const unit: AjsUnit = {
+      id: "/root/jobnet/recovery-net",
+      name: "recovery-net",
+      unitAttribute: "",
+      unitType: "rn",
+      absolutePath: "/root/jobnet/recovery-net",
+      depth: 2,
+      parentId: "/root/jobnet",
+      isRoot: false,
+      isRootJobnet: false,
+      hasSchedule: false,
+      hasWaitedFor: false,
+      layout: { h: 240, v: 144 },
+      parameters: [],
+      relations: [],
+      children: [
+        {
+          id: "/root/jobnet/recovery-net/leaf",
+          name: "leaf",
+          unitAttribute: "",
+          unitType: "j",
+          absolutePath: "/root/jobnet/recovery-net/leaf",
+          depth: 3,
+          parentId: "/root/jobnet/recovery-net",
+          isRoot: false,
+          isRootJobnet: false,
+          hasSchedule: false,
+          hasWaitedFor: false,
+          layout: { h: 240, v: 144 },
+          parameters: [],
+          relations: [],
+          children: [],
+        },
+      ],
+    };
+
+    assert.strictEqual(isExpandableNestedUnit(unit), true);
+  });
+
+  test("collapsing a nested jobnet also clears expanded descendants", () => {
+    const result = parseAjs(nestedDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnit = document.rootUnits[0].children[0];
+    const childNet = currentUnit.children[0];
+    const grandNet = childNet.children[0];
+
+    assert.deepStrictEqual(
+      collapseExpandedNestedUnitIds(
+        [childNet.id, grandNet.id],
+        childNet.id,
+        childNet,
+      ),
+      [],
+    );
   });
 
   test("detects when the current scope is already fully expanded", () => {

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -47,6 +47,7 @@ import FlowSelector from "./FlowSelector";
 import { buildExpandedFlowGraph } from "./buildExpandedFlowGraph";
 import { createReactFlowData } from "./flowGraphView";
 import {
+  collapseExpandedNestedUnitIds,
   collectExpandableNestedUnitIds,
   hasExpandedAllNestedUnitIds,
 } from "./nestedExpansion";
@@ -134,13 +135,22 @@ const FlowContents: FC = () => {
     () => (currentUnitId ? unitById.get(currentUnitId) : undefined),
     [currentUnitId, unitById],
   );
-  const toggleExpandedUnitId = useCallback((unitId: string) => {
-    setExpandedUnitIds((prev) =>
-      prev.includes(unitId)
-        ? prev.filter((id) => id !== unitId)
-        : [...prev, unitId],
-    );
-  }, []);
+  const toggleExpandedUnitId = useCallback(
+    (unitId: string) => {
+      setExpandedUnitIds((prev) => {
+        if (!prev.includes(unitId)) {
+          return [...prev, unitId];
+        }
+
+        return collapseExpandedNestedUnitIds(
+          prev,
+          unitId,
+          unitById.get(unitId),
+        );
+      });
+    },
+    [unitById],
+  );
   const expandedUnitIdSet = useMemo(
     () => new Set(expandedUnitIds),
     [expandedUnitIds],

--- a/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
+++ b/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
@@ -18,6 +18,7 @@ import {
   createFlowGraphMetrics,
   FlowGraphPosition,
 } from "./flowGraphPosition";
+import { isNestedJobnetUnit } from "./nestedExpansion";
 
 export type ExpandedNodeDecoration = {
   panelOffsetXPx: number;
@@ -48,10 +49,11 @@ type ExpandedFlowGraphBuildContext = {
   nodeIds: Set<string>;
   edgeIds: Set<string>;
   visibleUnitIds: Set<string>;
+  initialPositions: Map<string, FlowGraphPosition>;
+  offsets: Map<string, FlowGraphPosition>;
   positionOverrides: Map<string, FlowGraphPosition>;
   nodeDecorations: Map<string, ExpandedNodeDecoration>;
   unitById: ReadonlyMap<string, AjsUnit>;
-  incomingSourcesByTarget: ReadonlyMap<string, string[]>;
   metrics: FlowGraphMetrics;
 };
 
@@ -165,39 +167,68 @@ const includeDecorationBounds = (
   );
 };
 
-const intersectsBounds = (
+const addPositions = (
   position: FlowGraphPosition,
-  width: number,
-  height: number,
-  bounds: FlowGraphBounds,
-): boolean =>
-  position.x < bounds.maxX &&
-  position.x + width > bounds.minX &&
-  position.y < bounds.maxY &&
-  position.y + height > bounds.minY;
+  offset: FlowGraphPosition,
+): FlowGraphPosition => ({
+  x: position.x + offset.x,
+  y: position.y + offset.y,
+});
 
-const buildIncomingSourcesByTarget = (
-  edges: ReadonlyArray<FlowGraphEdgeDto>,
-): Map<string, string[]> => {
-  const incomingSourcesByTarget = new Map<string, string[]>();
-  for (const edge of edges) {
-    const sources = incomingSourcesByTarget.get(edge.target) ?? [];
-    sources.push(edge.source);
-    incomingSourcesByTarget.set(edge.target, sources);
+const getOffset = (
+  context: ExpandedFlowGraphBuildContext,
+  unitId: string,
+): FlowGraphPosition => context.offsets.get(unitId) ?? { x: 0, y: 0 };
+
+const getDisplayPosition = (
+  context: ExpandedFlowGraphBuildContext,
+  unitId: string,
+): FlowGraphPosition | undefined => {
+  const initialPosition = context.initialPositions.get(unitId);
+  if (!initialPosition) {
+    return undefined;
   }
-  return incomingSourcesByTarget;
+  return addPositions(initialPosition, getOffset(context, unitId));
+};
+
+const syncPositionOverride = (
+  context: ExpandedFlowGraphBuildContext,
+  unitId: string,
+) => {
+  const displayPosition = getDisplayPosition(context, unitId);
+  if (displayPosition) {
+    context.positionOverrides.set(unitId, displayPosition);
+  }
+};
+
+const addOffset = (
+  context: ExpandedFlowGraphBuildContext,
+  unitId: string,
+  delta: FlowGraphPosition,
+) => {
+  if (delta.x === 0 && delta.y === 0) {
+    return;
+  }
+
+  const offset = getOffset(context, unitId);
+  context.offsets.set(unitId, {
+    x: offset.x + delta.x,
+    y: offset.y + delta.y,
+  });
+  syncPositionOverride(context, unitId);
 };
 
 const addVisibleNode = (
   context: ExpandedFlowGraphBuildContext,
   unit: AjsUnit,
   node: FlowGraphNodeDto,
-  position: FlowGraphPosition,
+  initialPosition: FlowGraphPosition,
 ) => {
   context.nodes.push(node);
   context.nodeIds.add(unit.id);
   context.visibleUnitIds.add(unit.id);
-  context.positionOverrides.set(unit.id, position);
+  context.initialPositions.set(unit.id, initialPosition);
+  syncPositionOverride(context, unit.id);
 };
 
 const ensureChildNodeVisible = (
@@ -205,7 +236,7 @@ const ensureChildNodeVisible = (
   expandedUnitPosition: FlowGraphPosition,
   child: AjsUnit,
 ): FlowGraphPosition | undefined => {
-  const existingPosition = context.positionOverrides.get(child.id);
+  const existingPosition = context.initialPositions.get(child.id);
   if (existingPosition) {
     return existingPosition;
   }
@@ -228,7 +259,7 @@ const ensureConditionNodeVisible = (
   expandedUnitPosition: FlowGraphPosition,
   conditionUnit: AjsUnit,
 ): FlowGraphPosition | undefined => {
-  const existingPosition = context.positionOverrides.get(conditionUnit.id);
+  const existingPosition = context.initialPositions.get(conditionUnit.id);
   if (existingPosition) {
     return existingPosition;
   }
@@ -289,16 +320,15 @@ const buildPanelBoundsFromSubtreeBounds = (
   };
 };
 
-const buildExpandedUnitSubtreeBounds = (
+const buildExpandedUnitRevealBounds = (
   context: ExpandedFlowGraphBuildContext,
   expandedUnit: AjsUnit,
-): { bounds: FlowGraphBounds; subtreeUnitIds: Set<string> } | undefined => {
-  const expandedUnitPosition = context.positionOverrides.get(expandedUnit.id);
+): FlowGraphBounds | undefined => {
+  const expandedUnitPosition = getDisplayPosition(context, expandedUnit.id);
   if (!expandedUnitPosition) {
     return undefined;
   }
 
-  const subtreeUnitIds = new Set<string>([expandedUnit.id]);
   const bounds: FlowGraphBounds = {
     minX: expandedUnitPosition.x,
     maxX: expandedUnitPosition.x + context.metrics.width,
@@ -309,7 +339,6 @@ const buildExpandedUnitSubtreeBounds = (
   for (const child of expandedUnit.children.filter(
     (unit) => unit.unitType !== "rc",
   )) {
-    subtreeUnitIds.add(child.id);
     const childPosition = ensureChildNodeVisible(
       context,
       expandedUnitPosition,
@@ -318,216 +347,84 @@ const buildExpandedUnitSubtreeBounds = (
     if (!childPosition) {
       continue;
     }
+    const childDisplayPosition = getDisplayPosition(context, child.id);
+    if (!childDisplayPosition) {
+      continue;
+    }
     includeNodeBounds(
       bounds,
-      childPosition,
+      childDisplayPosition,
       context.metrics.width,
       context.metrics.height,
     );
-    const childDecoration = context.nodeDecorations.get(child.id);
-    if (childDecoration) {
-      includeDecorationBounds(bounds, childPosition, childDecoration);
-    }
   }
 
   const conditionUnit = expandedUnit.children.find(
     (child) => child.unitType === "rc",
   );
   if (conditionUnit) {
-    subtreeUnitIds.add(conditionUnit.id);
     const conditionPosition = ensureConditionNodeVisible(
       context,
       expandedUnitPosition,
       conditionUnit,
     );
-    if (conditionPosition) {
+    const conditionDisplayPosition = getDisplayPosition(
+      context,
+      conditionUnit.id,
+    );
+    if (conditionPosition && conditionDisplayPosition) {
       includeNodeBounds(
         bounds,
-        conditionPosition,
+        conditionDisplayPosition,
         context.metrics.width,
         context.metrics.height,
       );
     }
   }
 
-  return { bounds, subtreeUnitIds };
+  return bounds;
 };
 
-const shiftNodeByDelta = (
+const applyExpansionOffsets = (
   context: ExpandedFlowGraphBuildContext,
-  unitId: string,
-  dy: number,
-) => {
-  const position = context.positionOverrides.get(unitId);
-  if (!position || dy <= 0) {
-    return;
-  }
-  context.positionOverrides.set(unitId, {
-    x: position.x,
-    y: position.y + dy,
-  });
-};
-
-const cascadeShiftToIncomingSources = (
-  context: ExpandedFlowGraphBuildContext,
-  unitId: string,
-  dy: number,
-  subtreeUnitIds: ReadonlySet<string>,
+  expandedUnitPosition: FlowGraphPosition,
   panelBounds: FlowGraphBounds,
-  visited: Set<string>,
+  excludedUnitIds: ReadonlySet<string>,
 ) => {
-  if (visited.has(unitId)) {
-    return;
-  }
-  visited.add(unitId);
-  const incomingSources = context.incomingSourcesByTarget.get(unitId) ?? [];
-  for (const sourceUnitId of incomingSources) {
-    if (subtreeUnitIds.has(sourceUnitId)) {
-      continue;
-    }
-    const sourcePosition = context.positionOverrides.get(sourceUnitId);
-    const targetPosition = context.positionOverrides.get(unitId);
-    if (!sourcePosition || !targetPosition) {
-      continue;
-    }
-    if (sourcePosition.x >= targetPosition.x) {
-      continue;
-    }
-    if (sourcePosition.y + context.metrics.height < panelBounds.minY) {
-      continue;
-    }
-    shiftNodeByDelta(context, sourceUnitId, dy);
-    cascadeShiftToIncomingSources(
-      context,
-      sourceUnitId,
-      dy,
-      subtreeUnitIds,
-      panelBounds,
-      visited,
-    );
-  }
-};
-
-const shiftSiblingNodesRight = (
-  context: ExpandedFlowGraphBuildContext,
-  targetUnit: AjsUnit,
-  targetMinX: number,
-  excludes: ReadonlySet<string>,
-) => {
-  const targetPosition = context.positionOverrides.get(targetUnit.id);
-  if (!targetPosition) {
-    return;
-  }
-
-  let minSiblingX = Number.POSITIVE_INFINITY;
-  for (const unitId of context.visibleUnitIds) {
-    if (excludes.has(unitId)) {
-      continue;
-    }
-    const unit = context.unitById.get(unitId);
-    const position = context.positionOverrides.get(unitId);
-    if (!unit || !position) {
-      continue;
-    }
-    if (unit.parentId !== targetUnit.parentId) {
-      continue;
-    }
-    if (position.x <= targetPosition.x) {
-      continue;
-    }
-    minSiblingX = Math.min(minSiblingX, position.x);
-  }
-
-  const dx = Number.isFinite(minSiblingX)
-    ? Math.max(0, targetMinX - minSiblingX)
-    : 0;
-  if (dx <= 0) {
-    return;
-  }
-
-  for (const unitId of context.visibleUnitIds) {
-    if (excludes.has(unitId)) {
-      continue;
-    }
-    const unit = context.unitById.get(unitId);
-    const position = context.positionOverrides.get(unitId);
-    if (!unit || !position) {
-      continue;
-    }
-    if (unit.parentId !== targetUnit.parentId) {
-      continue;
-    }
-    if (position.x <= targetPosition.x) {
-      continue;
-    }
-    context.positionOverrides.set(unitId, {
-      x: position.x + dx,
-      y: position.y,
-    });
-  }
-};
-
-const collectCollidingSiblingIds = (
-  context: ExpandedFlowGraphBuildContext,
-  subtreeUnitIds: ReadonlySet<string>,
-  panelBounds: FlowGraphBounds,
-): string[] =>
-  [...context.visibleUnitIds]
-    .filter((unitId) => !subtreeUnitIds.has(unitId))
-    .filter((unitId) => {
-      const position = context.positionOverrides.get(unitId);
-      return (
-        !!position &&
-        intersectsBounds(
-          position,
-          context.metrics.width,
-          context.metrics.height,
-          panelBounds,
-        )
-      );
-    })
-    .sort(
-      (left, right) =>
-        (context.positionOverrides.get(left)?.y ?? 0) -
-        (context.positionOverrides.get(right)?.y ?? 0),
-    );
-
-const shiftCollidingSiblingsBelowPanel = (
-  context: ExpandedFlowGraphBuildContext,
-  subtreeUnitIds: ReadonlySet<string>,
-  panelBounds: FlowGraphBounds,
-) => {
-  const collidingSiblingIds = collectCollidingSiblingIds(
-    context,
-    subtreeUnitIds,
-    panelBounds,
+  const clearanceX = context.metrics.width * 0.12;
+  const clearanceY = context.metrics.height * 0.12;
+  const horizontalOffset = Math.max(
+    0,
+    panelBounds.maxX -
+      (expandedUnitPosition.x + context.metrics.width) +
+      clearanceX,
+  );
+  const verticalOffset = Math.max(
+    0,
+    panelBounds.maxY -
+      (expandedUnitPosition.y + context.metrics.height) +
+      clearanceY,
   );
 
-  let nextAvailableY = panelBounds.maxY + context.metrics.marginY;
-  for (const siblingId of collidingSiblingIds) {
-    const siblingPosition = context.positionOverrides.get(siblingId);
-    if (!siblingPosition) {
+  const positionsBeforeExpansionOffset = new Map<string, FlowGraphPosition>();
+  for (const unitId of context.visibleUnitIds) {
+    const displayPosition = getDisplayPosition(context, unitId);
+    if (displayPosition) {
+      positionsBeforeExpansionOffset.set(unitId, displayPosition);
+    }
+  }
+
+  for (const [unitId, displayPosition] of positionsBeforeExpansionOffset) {
+    if (excludedUnitIds.has(unitId)) {
       continue;
     }
-    const dy = Math.max(0, nextAvailableY - siblingPosition.y);
-    if (dy <= 0) {
-      nextAvailableY =
-        siblingPosition.y + context.metrics.height + context.metrics.marginY;
+    const dx =
+      displayPosition.x > expandedUnitPosition.x ? horizontalOffset : 0;
+    const dy = displayPosition.y > expandedUnitPosition.y ? verticalOffset : 0;
+    if (dx === 0 && dy === 0) {
       continue;
     }
-    shiftNodeByDelta(context, siblingId, dy);
-    cascadeShiftToIncomingSources(
-      context,
-      siblingId,
-      dy,
-      subtreeUnitIds,
-      panelBounds,
-      new Set<string>(),
-    );
-    nextAvailableY =
-      (context.positionOverrides.get(siblingId)?.y ?? siblingPosition.y) +
-      context.metrics.height +
-      context.metrics.marginY;
+    addOffset(context, unitId, { x: dx, y: dy });
   }
 };
 
@@ -535,82 +432,28 @@ const expandVisibleNestedUnit = (
   context: ExpandedFlowGraphBuildContext,
   expandedUnit: AjsUnit,
 ) => {
-  const subtreeLayout = buildExpandedUnitSubtreeBounds(context, expandedUnit);
-  const expandedUnitPosition = context.positionOverrides.get(expandedUnit.id);
-  if (!subtreeLayout || !expandedUnitPosition) {
+  const expandedUnitPosition = getDisplayPosition(context, expandedUnit.id);
+  const revealBounds = buildExpandedUnitRevealBounds(context, expandedUnit);
+  if (!revealBounds || !expandedUnitPosition) {
     return;
   }
 
   appendExpandedUnitEdges(context, expandedUnit);
 
   const panelBounds = buildPanelBoundsFromSubtreeBounds(
-    subtreeLayout.bounds,
+    revealBounds,
     context.metrics,
   );
-  shiftSiblingNodesRight(
+  applyExpansionOffsets(
     context,
-    expandedUnit,
-    panelBounds.maxX + context.metrics.marginX,
-    subtreeLayout.subtreeUnitIds,
-  );
-  shiftCollidingSiblingsBelowPanel(
-    context,
-    subtreeLayout.subtreeUnitIds,
+    expandedUnitPosition,
     panelBounds,
+    collectVisibleSubtreeUnitIds(
+      expandedUnit,
+      context.visibleUnitIds,
+      context.unitById,
+    ),
   );
-  context.nodeDecorations.set(
-    expandedUnit.id,
-    toDecorationFromBounds(expandedUnitPosition, panelBounds),
-  );
-};
-
-const relayoutExpandedAncestorPanels = (
-  context: ExpandedFlowGraphBuildContext,
-  expandedUnits: ReadonlyArray<AjsUnit>,
-) => {
-  for (const expandedUnit of [...expandedUnits].reverse()) {
-    const expandedUnitPosition = context.positionOverrides.get(expandedUnit.id);
-    const panelBounds = buildExpandedPanelBounds(
-      expandedUnit,
-      context.visibleUnitIds,
-      context.unitById,
-      context.positionOverrides,
-      context.nodeDecorations,
-      context.metrics,
-    );
-    if (!expandedUnitPosition || !panelBounds) {
-      continue;
-    }
-    const subtreeUnitIds = collectVisibleSubtreeUnitIds(
-      expandedUnit,
-      context.visibleUnitIds,
-      context.unitById,
-    );
-
-    shiftSiblingNodesRight(
-      context,
-      expandedUnit,
-      panelBounds.maxX + context.metrics.marginX,
-      subtreeUnitIds,
-    );
-    shiftCollidingSiblingsBelowPanel(context, subtreeUnitIds, panelBounds);
-
-    const updatedPanelBounds = buildExpandedPanelBounds(
-      expandedUnit,
-      context.visibleUnitIds,
-      context.unitById,
-      context.positionOverrides,
-      context.nodeDecorations,
-      context.metrics,
-    );
-    if (!updatedPanelBounds) {
-      continue;
-    }
-    context.nodeDecorations.set(
-      expandedUnit.id,
-      toDecorationFromBounds(expandedUnitPosition, updatedPanelBounds),
-    );
-  }
 };
 
 const buildExpandedPanelBounds = (
@@ -664,6 +507,31 @@ const buildExpandedPanelBounds = (
   };
 };
 
+const updateExpandedNodeDecorations = (
+  context: ExpandedFlowGraphBuildContext,
+  expandedUnits: ReadonlyArray<AjsUnit>,
+) => {
+  context.nodeDecorations.clear();
+  for (const expandedUnit of [...expandedUnits].reverse()) {
+    const expandedUnitPosition = context.positionOverrides.get(expandedUnit.id);
+    const panelBounds = buildExpandedPanelBounds(
+      expandedUnit,
+      context.visibleUnitIds,
+      context.unitById,
+      context.positionOverrides,
+      context.nodeDecorations,
+      context.metrics,
+    );
+    if (!expandedUnitPosition || !panelBounds) {
+      continue;
+    }
+    context.nodeDecorations.set(
+      expandedUnit.id,
+      toDecorationFromBounds(expandedUnitPosition, panelBounds),
+    );
+  }
+};
+
 const collectVisibleSubtreeUnitIds = (
   expandedUnit: AjsUnit,
   visibleUnitIds: ReadonlySet<string>,
@@ -705,14 +573,16 @@ export const buildExpandedFlowGraph = (
   const edges = [...baseGraph.edges];
   const nodeIds = new Set(nodes.map((node) => node.id));
   const edgeIds = new Set(edges.map((edge) => `${edge.source}-${edge.target}`));
+  const initialPositions = new Map<string, FlowGraphPosition>();
+  const offsets = new Map<string, FlowGraphPosition>();
   const positionOverrides = new Map<string, FlowGraphPosition>();
   const nodeDecorations = new Map<string, ExpandedNodeDecoration>();
 
   for (const node of baseGraph.nodes) {
-    positionOverrides.set(
-      node.id,
-      calculateFlowGraphNodePosition(node, basePx),
-    );
+    const initialPosition = calculateFlowGraphNodePosition(node, basePx);
+    initialPositions.set(node.id, initialPosition);
+    offsets.set(node.id, { x: 0, y: 0 });
+    positionOverrides.set(node.id, initialPosition);
   }
 
   const allUnits = flattenAjsUnits(document.rootUnits);
@@ -723,7 +593,6 @@ export const buildExpandedFlowGraph = (
   }
 
   const visibleUnitIds = new Set(nodes.map((node) => node.id));
-  const incomingSourcesByTarget = buildIncomingSourcesByTarget(edges);
   const context: ExpandedFlowGraphBuildContext = {
     basePx,
     nodes,
@@ -731,10 +600,11 @@ export const buildExpandedFlowGraph = (
     nodeIds,
     edgeIds,
     visibleUnitIds,
+    initialPositions,
+    offsets,
     positionOverrides,
     nodeDecorations,
     unitById,
-    incomingSourcesByTarget,
     metrics,
   };
 
@@ -744,7 +614,7 @@ export const buildExpandedFlowGraph = (
       (unit): unit is AjsUnit =>
         !!unit &&
         unit.id !== currentUnitId &&
-        unit.unitType === "n" &&
+        isNestedJobnetUnit(unit) &&
         isDescendantOf(unit, currentUnitId, unitById),
     )
     .sort((left, right) => left.depth - right.depth);
@@ -753,7 +623,7 @@ export const buildExpandedFlowGraph = (
     expandVisibleNestedUnit(context, expandedUnit);
   }
 
-  relayoutExpandedAncestorPanels(context, sortedExpandedUnits);
+  updateExpandedNodeDecorations(context, sortedExpandedUnits);
 
   return {
     graph: {

--- a/src/ui-component/editor/ajsFlow/flowGraphView.ts
+++ b/src/ui-component/editor/ajsFlow/flowGraphView.ts
@@ -15,6 +15,7 @@ import {
 import { ExpandedNodeDecoration } from "./buildExpandedFlowGraph";
 import { AjsNode } from "./nodes/AjsNode";
 import { calculateFlowGraphNodePosition } from "./flowGraphPosition";
+import { isExpandableNestedUnit } from "./nestedExpansion";
 
 type CreateReactFlowDataOptions = {
   searchMatchedUnitIds?: ReadonlySet<string>;
@@ -24,9 +25,6 @@ type CreateReactFlowDataOptions = {
   positionOverrides?: ReadonlyMap<string, { x: number; y: number }>;
   searchedUnitId?: string;
 };
-
-const hasExpandableChildren = (unit?: AjsUnit): boolean =>
-  !!unit && unit.unitType === "n" && unit.children.length > 0;
 
 const toNodeData = (
   node: FlowGraphNodeDto,
@@ -61,7 +59,8 @@ const toNodeData = (
     canExpandNested:
       !node.metadata.isCurrent &&
       !node.metadata.isAncestor &&
-      hasExpandableChildren(unit),
+      !!unit &&
+      isExpandableNestedUnit(unit),
     isExpandedNested: options?.nestedExpansionState?.expandedUnitIds.has(
       node.id,
     ),

--- a/src/ui-component/editor/ajsFlow/nestedExpansion.ts
+++ b/src/ui-component/editor/ajsFlow/nestedExpansion.ts
@@ -1,11 +1,17 @@
 import { AjsUnit } from "../../../domain/models/ajs/AjsDocument";
 
+export const isNestedJobnetUnit = (unit: AjsUnit): boolean =>
+  ["n", "rn", "rm", "rr"].includes(unit.unitType);
+
+export const isExpandableNestedUnit = (unit: AjsUnit): boolean =>
+  isNestedJobnetUnit(unit) && unit.children.length > 0;
+
 const appendExpandableDescendants = (
   unit: AjsUnit,
   expandableUnitIds: string[],
 ) => {
   for (const child of unit.children) {
-    if (child.unitType === "n" && child.children.length > 0) {
+    if (isExpandableNestedUnit(child)) {
       expandableUnitIds.push(child.id);
     }
     if (child.children.length > 0) {
@@ -23,6 +29,23 @@ export const collectExpandableNestedUnitIds = (
   const expandableUnitIds: string[] = [];
   appendExpandableDescendants(currentUnit, expandableUnitIds);
   return expandableUnitIds;
+};
+
+export const collapseExpandedNestedUnitIds = (
+  expandedUnitIds: readonly string[],
+  collapsedUnitId: string,
+  collapsedUnit?: AjsUnit,
+): string[] => {
+  if (!collapsedUnit) {
+    return expandedUnitIds.filter((unitId) => unitId !== collapsedUnitId);
+  }
+
+  const descendantUnitIds = new Set(
+    collectExpandableNestedUnitIds(collapsedUnit),
+  );
+  return expandedUnitIds.filter(
+    (unitId) => unitId !== collapsedUnitId && !descendantUnitIds.has(unitId),
+  );
 };
 
 export const hasExpandedAllNestedUnitIds = (


### PR DESCRIPTION
## Summary

- Fix flow-view nested expand/collapse layout so revealed children stay anchored near the expanded jobnet.
- Rework expanded-node positioning around initial position plus accumulated offsets, while keeping expanded panel boundaries based on final display positions.
- Clear descendant expansion state when collapsing a parent jobnet and include recovery jobnet variants in nested expansion handling.
- Add the 1.13.1 changelog entry and mark the SDD follow-up complete.

## Validation

- npm test
- npm run qlty
- npm run test:web
- npm run build

## Notes

npm run build still reports the existing webpack bundle-size warnings for viewer/web bundles.