### PR TITLE
[codex] Refine flow expansion offset targets

### DIFF
--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -181,6 +181,11 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
   expansion adds vertical offsets to nodes below the expanded node and
   horizontal offsets to nodes to its right regardless of nesting, and expanded
   panel boundaries are rebuilt from final display positions.
+- 2026-04-23 offset-target refinement:
+  make nested-expansion re-layout position-aware:
+  lower-right units receive both x/y offsets, units in the same x column below
+  the expanded unit receive only y offsets, and units in the same y row to the
+  right receive only x offsets.
 
 ## Validation
 

--- a/src/test/suite/buildExpandedFlowGraph.test.ts
+++ b/src/test/suite/buildExpandedFlowGraph.test.ts
@@ -309,7 +309,7 @@ suite("Build Expanded Flow Graph", () => {
     assert.ok(fullyExpandedSiblingPosition!.x > childPanelRight);
   });
 
-  test("adds offsets to visible nodes below or right of the expanded node", () => {
+  test("adds offsets by row, column, and lower-right position around the expanded node", () => {
     const result = parseAjs(overlappingSiblingDefinition);
     assert.deepStrictEqual(result.errors, []);
     const document = normalizeAjsDocument(result.rootUnits);
@@ -354,7 +354,8 @@ suite("Build Expanded Flow Graph", () => {
       childExpanded!.y + decoration!.panelOffsetYPx + decoration!.panelHeightPx;
     assert.ok(orjExpanded!.x > orjCollapsed!.x);
     assert.ok(orjExpanded!.y > panelBottom);
-    assert.deepStrictEqual(flwjExpanded, flwjCollapsed);
+    assert.ok(flwjExpanded!.x > flwjCollapsed!.x);
+    assert.strictEqual(flwjExpanded!.y, flwjCollapsed!.y);
     assert.strictEqual(ntwjExpanded!.x, ntwjCollapsed!.x);
     assert.ok(ntwjExpanded!.y > ntwjCollapsed!.y);
   });

--- a/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
+++ b/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
@@ -418,9 +418,12 @@ const applyExpansionOffsets = (
     if (excludedUnitIds.has(unitId)) {
       continue;
     }
-    const dx =
-      displayPosition.x > expandedUnitPosition.x ? horizontalOffset : 0;
-    const dy = displayPosition.y > expandedUnitPosition.y ? verticalOffset : 0;
+    const isRight = displayPosition.x > expandedUnitPosition.x;
+    const isBelow = displayPosition.y > expandedUnitPosition.y;
+    const isSameX = displayPosition.x === expandedUnitPosition.x;
+    const isSameY = displayPosition.y === expandedUnitPosition.y;
+    const dx = isRight && (isBelow || isSameY) ? horizontalOffset : 0;
+    const dy = isBelow && (isRight || isSameX) ? verticalOffset : 0;
     if (dx === 0 && dy === 0) {
       continue;
     }


### PR DESCRIPTION
## Summary

- Refine flow-view nested expansion re-layout so offsets depend on the expanded node's relative row and column.
- Apply both x/y offsets to lower-right units, y-only offsets to units directly below, and x-only offsets to units directly to the right.
- Update focused regression coverage and the flow-graph experience SDD plan note for the clarified rule.

## Why

The previous expand re-layout rule moved units based on independent right/below checks. The desired behavior is more precise: direct row and column neighbors should only move along the axis needed to preserve their alignment, while lower-right units move on both axes.

## Validation

- pnpm test
- pnpm run build

pnpm run build completed with existing webpack bundle-size warnings for viewer bundles.