### PR TITLE
Fix flow expansion layout and viewport refit

### DIFF
--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -10,182 +10,40 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
 - nested graph expansion inside one screen
 - jump actions between list and flow viewers
 
-## Milestones
+## Current Design
 
-1. Confirm viewer-facing requirements and stable navigation identity
-2. Document the visual refresh target and its non-goals
-3. Add progressive nested-expansion behavior
-4. Add explicit list-to-flow and flow-to-list navigation actions
-5. Validate desktop and web viewer behavior
-
-## Current Slice
-
-- 2026-04-18 implementation result:
-  the flow viewer now gives the active node, ancestor chain, and root jobnet a
-  stronger visual hierarchy while keeping the existing graph DTOs, selection
-  state, and dialog-open actions unchanged.
-- 2026-04-18 validation focus:
-  preserve the DTO-to-node identity mapping in `flowGraphView.test.ts`, then
-  confirm both desktop and web preview hosts still open and render the updated
-  flow view through the standard serial quality baseline.
-- 2026-04-19 next slice decision:
-  move to progressive nested expansion while keeping flow DTO construction,
-  current-unit selection, and desktop/web host behavior unchanged until the
-  interaction seam is proven.
-- 2026-04-19 expand-all decision:
-  do not force one-click expand-all into the first incremental-expansion
-  implementation; instead, keep that control as the immediate follow-up so the
-  first behavior slice can validate identity, rendering, and host compatibility
-  with less UI and state-synchronization risk.
-- 2026-04-19 navigation fallback decision:
-  when a counterpart list or flow view is unavailable, keep the current viewer
-  state stable and make the jump action fail predictably through hidden or
-  disabled affordances plus a no-op command path, rather than changing
-  selection opportunistically.
-- 2026-04-19 implementation focus:
-  start with user-driven incremental reveal of nested jobnets in one screen,
-  preserve the existing `currentUnitId`-driven selection contract, and leave
-  cross-view jump actions as the next slice once nested expansion semantics are
-  established.
-- 2026-04-19 implementation result:
-  child jobnets in the flow canvas can now reveal their nested scope in place
-  without replacing the current viewer scope; the existing "open jobnet" action
-  still re-scopes the viewer, while a separate expand/collapse affordance adds
-  or removes nested children progressively.
-- 2026-04-19 validation result:
-  focused regression coverage now verifies that nested descendants appear only
-  after their visible parent jobnet is expanded, keyboard and click handling
-  toggle the nested reveal affordance predictably, and the standard desktop,
-  web, and production-build baseline still passes.
-- 2026-04-19 next slice:
-  keep one-click expand-all as the immediate follow-up before cross-view
-  navigation so the newly introduced nested-expansion state model can be reused
-  instead of replaced.
-- 2026-04-19 implementation result:
-  the flow header now exposes a one-click nested-scope control that expands
-  every expandable descendant jobnet in the current scope and collapses the
-  same scope back to baseline once everything is open, while keeping the
-  existing `currentUnitId`-driven selection contract unchanged.
-- 2026-04-19 validation result:
-  focused helper coverage now verifies which nested jobnets qualify for the
-  scope-wide action and when the current scope should be treated as fully
-  expanded, alongside the existing graph expansion regression coverage and the
-  standard desktop, web, and build baseline.
-- 2026-04-19 next slice:
-  move from scope-wide expansion to deeper nested reveal and search behavior,
-  reusing the same expansion-state model rather than replacing it for each
-  follow-up interaction.
-- 2026-04-19 implementation result:
-  visible nested jobnets are no longer limited to direct-child expansion
-  controls. Once a nested jobnet appears in the current canvas and has nested
-  children of its own, the same inline expand/collapse affordance can reveal
-  the next level without requiring a separate scope change.
-- 2026-04-19 validation result:
-  the flow-view mapping regression now verifies that expandable deeper nested
-  jobnets keep their inline toggle affordance once visible, alongside the
-  existing expanded-graph layout coverage and the standard desktop, web, and
-  build baseline.
-- 2026-04-19 next slice:
-  move from deeper nested reveal to flow-view search, then layer explicit
-  list/flow navigation on top of the established expansion-state model.
-- 2026-04-19 maintenance slice:
-  keep the new deeper nested-expansion behavior, but refactor
-  `buildExpandedFlowGraph.ts` so expansion, panel sizing, and sibling
-  re-layout steps are separated into focused helpers before adding more
-  interaction on top.
-- 2026-04-19 search slice decision:
-  start with search inside the current flow scope only, keep
-  `currentUnitId` as the stable base scope, reveal collapsed ancestor jobnets
-  through the existing nested-expansion state, and use a presentation-local
-  visual focus marker for the first match instead of changing the graph DTO
-  contract or adding cross-scope camera navigation in the same slice.
-- 2026-04-19 implementation result:
-  the flow header now exposes a search box for the current scope; submitting a
-  query finds the first matching unit by visible JP1/AJS labels and paths,
-  expands the collapsed ancestor jobnets needed to reveal it in the current
-  canvas, and visually highlights the matching node without re-scoping the
-  viewer away from the current unit.
-- 2026-04-19 validation result:
-  focused helper coverage now verifies current-scope search matching and
-  ancestor expansion decisions, flow-node mapping coverage verifies the new
-  search-match decoration path, and the standard desktop, web, and build
-  baseline should continue to validate host compatibility.
-- 2026-04-19 next slice:
-  keep the first flow-view search slice as the stable baseline, defer broader
-  search behavior for now, and move next to explicit unit-list and flow-graph
-  navigation on top of the same identity and expansion-state model.
-- 2026-04-19 next slice decision:
-  do not add multi-match stepping, explicit camera centering, or cross-scope
-  search before cross-view navigation. Those search follow-ups stay deferred
-  until a later slice shows that the first current-scope search behavior is
-  insufficient for real navigation needs.
-- 2026-04-21 refinement focus:
-  keep the first-match, current-scope search interaction unchanged, but widen
-  the matcher so it stays case-insensitive and contiguous, preserves internal
-  spaces for comment/path fragments, and still chooses a visibly focused
-  descendant when the current scope root also matches the same query.
-- 2026-04-21 refinement result:
-  flow search now preserves internal spaces in the query, treats the whole
-  normalized input as one contiguous partial match against the existing
-  searchable unit text, and prefers the first descendant over the scope root
-  when multiple current-scope units match the same query.
-- 2026-04-21 refinement follow-up:
-  current-scope search should not stop visual feedback at the first chosen
-  match. Keep first-match focus and ancestor expansion for stability, but pass
-  the full visible match set through the presentation layer so every matching
-  node is highlighted.
-- 2026-04-21 refinement correction:
-  first-match focus stays useful, but ancestor expansion should not stay
-  first-match-only. Expand the combined ancestor jobnet set for every current-
-  scope match so all matching nodes that can be revealed in the current canvas
-  become visible after one search submit.
-- 2026-04-21 refinement validation result:
-  focused flow-search regression coverage now verifies preserved-space comment
-  matching, descendant-priority focus, and all-match ancestor expansion
-  alongside the existing blank-query and current-scope boundary checks;
-  desktop, web, and production-build validation remain the expected
-  compatibility baseline for this viewer-facing refinement.
-- 2026-04-19 navigation implementation focus:
-  use stable normalized identity that already exists in both viewers
-  (`absolutePath` for unit-list rows and the flow viewer's current-unit scope
-  contract) to open or focus the counterpart viewer without importing the
-  other viewer's internal component state. Keep unavailable-counterpart paths
-  as hidden, disabled, or no-op behaviors rather than mutating the current
-  viewer opportunistically.
-- 2026-04-19 navigation validation focus:
-  add focused regression coverage for list-to-flow target resolution and
-  flow-to-list target resolution, then re-run the standard desktop, web, and
-  production-build baseline to confirm the navigation wiring behaves the same
-  in both hosts.
-- 2026-04-19 navigation implementation result:
-  explicit bridge actions now connect the table and flow viewers through shared
-  navigation events keyed by normalized `absolutePath`. The table can request
-  the matching flow scope, and flow nodes can request the matching table row,
-  while each viewer keeps ownership of its own local selection state.
-- 2026-04-19 navigation validation result:
-  shared viewer-message routing coverage now exercises navigation events,
-  reveal-helper coverage verifies flow target and table row resolution by
-  stable path, and viewer-factory coverage confirms the injected navigation
-  handler receives the expected target view plus absolute path.
-- 2026-04-19 follow-up decision:
-  keep broader flow-search behavior deferred for now and move the next active
-  SDD slice to JP1/AJS3 version 13 parameter and command-reference alignment.
-- 2026-04-21 nested expansion fix focus:
-  preserve the current flow scope model, but make inline collapse discard
-  descendant expansion state so reopening a parent jobnet starts from the
-  expected one-level reveal. Treat recovery jobnet variants that already map
-  to flow `jobnet` nodes as expandable when they have nested children.
-- 2026-04-21 offset-layout refinement:
-  replace nested-expansion collision handling with a display-position model:
-  each visible node keeps an initial position plus accumulated x/y offsets,
-  expansion adds vertical offsets to nodes below the expanded node and
-  horizontal offsets to nodes to its right regardless of nesting, and expanded
-  panel boundaries are rebuilt from final display positions.
-- 2026-04-23 offset-target refinement:
-  make nested-expansion re-layout position-aware:
-  lower-right units receive both x/y offsets, units in the same x column below
-  the expanded unit receive only y offsets, and units in the same y row to the
-  right receive only x offsets.
+- flow styling keeps the existing graph DTO, current-unit selection contract,
+  and dialog-open behavior intact.
+- nested jobnets can expand progressively in the current canvas, including
+  deeper visible descendants and a scope-wide expand-all path.
+- nested expansion layout uses display positions plus accumulated offsets so
+  sibling panels can push nearby units without rebuilding the base graph DTO.
+- revealed descendants keep parent-relative anchors, so if a later sibling
+  expansion moves their parent jobnet they move with it instead of staying at
+  stale absolute coordinates.
+- each nested panel remains anchored to its expanded unit and grows only
+  rightward and downward from that visible origin.
+- sibling panel push rules are resolved from the currently visible panel
+  bounds in the same immediate scope:
+  horizontal growth uses only the amount that exceeds the maximum right edge
+  already occupied by expanded panels above, and vertical growth uses only the
+  missing downward distance a target still needs.
+- when an upper panel newly intrudes into a lower expanded panel, the lower
+  panel origin may be pushed downward, but the inverse case of opening the
+  lower panel itself does not trigger that same downward correction.
+- collapsing a parent jobnet clears descendant expansion state so reopening the
+  same branch returns to the expected one-level reveal.
+- recovery jobnet variants that render as flow `jobnet` nodes stay expandable
+  when they have nested children.
+- flow search stays within the current scope, performs case-insensitive
+  contiguous partial matching across unit name, comment, and path, prefers a
+  descendant over the scope root when both match, highlights every visible
+  match, and expands the combined ancestor set needed to reveal them.
+- list/flow bridge navigation uses stable `absolutePath` identity and keeps
+  missing-counterpart paths as hidden, disabled, or no-op behavior.
+- when nested expansion or collapse changes visible bounds, the viewer refits
+  the current React Flow viewport to the latest rendered nodes instead of
+  relying on initial mount-time `fitView` behavior.
 
 ## Validation
 

--- a/docs/specs/features/enhance-flow-graph-experience/SPECS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/SPECS.md
@@ -17,14 +17,27 @@ navigation from and to the unit list.
 - flow-graph presentation goals are described as visual resemblance to
   JP1/AJS View, not full interaction parity in one slice
 - nested graphs can be revealed progressively in the same screen
-- the first flow-view search slice may stay within the current flow scope
-  if it reveals collapsed ancestors needed to show the first match before
-  visually focusing that match
+- each revealed nested panel stays anchored to the expanded unit that owns it
+  and grows only to the right and downward from that unit
+- when a nested panel enlarges its parent scope, sibling offsets are derived
+  from current visible panel bounds within the same immediate scope rather
+  than by replaying historical expansion deltas
+- horizontal offset propagation uses only the portion of a lower panel that
+  extends beyond the maximum right edge already occupied by expanded panels
+  above it in the same scope
+- vertical offset propagation applies only the missing downward distance needed
+  to clear the relevant visible panel bounds, so already-offset targets are
+  not pushed again unnecessarily
+- when an upper panel newly intrudes into a lower expanded panel, the lower
+  panel origin may be pushed downward, but reopening the lower panel itself
+  does not trigger that same intrusion rule against the lower panel
+- flow-view search may stay within the current scope if it reveals collapsed
+  ancestors needed to show matching units before visually focusing them
 - current-scope flow search supports case-insensitive contiguous partial
-  matches across unit name, comment, and path so users do not need exact
-  full-label input to find the first match
-- a one-click expand-all path is considered in the design, even if it lands
-  after the first incremental expansion slice
+  matches across unit name, comment, and path
+- a one-click expand-all path is available for the current scope
+- when nested expansion changes the visible graph bounds, the viewer recomputes
+  the viewport so fit-to-view behavior still reaches the expanded nodes
 - explicit navigation between unit-list and flow-graph units is defined when
   the counterpart view exists
 - desktop and web compatibility remain explicit for all viewer-facing work
@@ -34,13 +47,16 @@ navigation from and to the unit list.
 - keep graph DTO construction separate from viewer styling and interaction
   controls
 - prefer stable unit identity or path when coordinating list/flow navigation
-- for the first flow-view search slice, prefer reusing the existing
-  nested-expansion state and a presentation-local focus marker instead of
-  introducing a new graph DTO contract or a second scope-selection model
-- keep current-scope search matching presentation-local:
-  normalize the query, preserve internal spaces, and treat the full query as a
-  case-insensitive contiguous partial match against the existing unit search
-  text
+- reuse the existing nested-expansion state and a presentation-local focus
+  marker instead of introducing a second scope-selection model
+- keep viewport fitting presentation-local: when visible flow bounds change
+  after nested expansion or collapse, recompute the React Flow viewport from
+  the latest rendered nodes instead of encoding graph bounds into DTO shape
+- when nested expansion layout needs ordering-sensitive behavior, use the
+  current expansion order from presentation state instead of reconstructing a
+  synthetic order from a set alone
+- keep current-scope search matching presentation-local and treat the full
+  normalized query as a case-insensitive contiguous partial match
 - when more than one unit matches inside the current scope, prefer the first
   descendant match over the scope root itself so search still produces a
   visible focus change

--- a/docs/specs/features/enhance-flow-graph-experience/TASKS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/TASKS.md
@@ -2,160 +2,32 @@
 
 ## Sync Rule
 
-- Update this file in the same commit whenever one task or follow-up is
-  completed, re-scoped, or intentionally dropped.
+- Update this file in the same commit whenever a durable requirement or
+  follow-up decision changes.
 - If that change affects branch priorities or repository sequencing, update
   `docs/specs/plans.md` and `docs/specs/roadmap.md` in the same commit.
 
-## Completed
+## Delivered
 
-- [x] Record the new SDD scope for flow-graph visual refresh, nested expansion,
-      and list/flow navigation
-- [x] Implement the first progressive nested-expansion slice without changing
-      the current viewer selection contract:
-      child jobnets can now expand or collapse nested content inline while the
-      existing scope-changing open action remains available
-- [x] Add explicit bridge actions between the unit list and flow graph using
-      stable `absolutePath`-based navigation events and reveal helpers:
-      the table can request the matching flow scope, and the flow view can
-      request the matching table row without importing the other viewer's
-      internal state
+- [x] Refresh flow-view presentation toward JP1/AJS View without changing the
+      graph DTO contract
+- [x] Support progressive nested expansion in the current canvas, including
+      expand-all and deeper visible descendants
+- [x] Keep nested layout stable when expanded panels push sibling nodes
+- [x] Keep descendant expansion state predictable across parent collapse and
+      recovery-jobnet expansion
+- [x] Add current-scope flow search with multi-match reveal and highlighting
+- [x] Add explicit bridge navigation between the unit list and flow graph
 
-## Remaining Follow-up
+## Durable Notes
 
-- [x] Add a one-click expand-all path on top of the new nested-expansion state
-- [x] Add a deeper nested-expansion slice after the direct-child path is stable:
-      reopen support for nested-in-nested jobnets only when the viewer can
-      render and re-layout those deeper scopes predictably instead of exposing
-      non-working controls
-- [x] Refactor `buildExpandedFlowGraph.ts` after the deeper nested-expansion
-      fixes so expansion, panel sizing, and sibling collision handling are
-      easier to extend without changing behavior
-- [x] Add the first flow-view search slice inside the current scope:
-      search by unit name, comment, or path from the flow header, reveal the
-      collapsed ancestor hierarchy needed to show the first match, and
-      visually focus that match without changing the current scope
-- [x] Decide whether flow-view search needs follow-up work beyond the first
-      current-scope slice:
-      broader search behavior is intentionally deferred for now so the next
-      viewer-facing slice can focus on explicit list/flow navigation first
-- [x] Refine current-scope flow search matching:
-      preserve space-containing query text, keep ancestor reveal semantics,
-      and prefer a descendant focus target when the current scope root also
-      matches
-- [x] Highlight all visible flow-search matches while preserving first-match
-      focus:
-      keep selected/focused state on the first chosen match, but decorate every
-      visible node that matches the current-scope query
-- [x] Expand all matched flow-search results in the current scope:
-      keep first-match focus, but reveal every matching node by expanding the
-      combined ancestor jobnet set for all matches
-- [x] Define the visual cues that most matter for JP1/AJS View resemblance
-- [x] Decide whether expand-all ships in the same slice as incremental
-      expansion or immediately after
-- [x] Document the target behavior when a counterpart list or flow view is not
-      available
-- [x] Add focused validation plans for selection, navigation, and nested
-      expansion state:
-      keep current-selection regression coverage at the flow-graph DTO mapping
-      seam, verify both desktop and web preview opening still succeed, and
-      reserve nested-expansion plus cross-view navigation behavior for the
-      follow-up slices that introduce those interactions
-
-## Release Note
-
-- 2026-04-21: the flow-view expand/collapse correction is complete for the
-  `1.13.1` release line:
-  nested panels now use display-position offsets, revealed children stay
-  anchored near the expanded jobnet, parent collapse clears descendant
-  expansion state, and the release note is recorded in `CHANGELOG.md`.
-- 2026-04-21: this flow-view usability slice is complete for the `1.13.0`
-  release line:
-  visual refresh, nested expansion, current-scope search refinement, and
-  list/flow bridge navigation are now recorded in SDD, covered by focused
-  regression tests, and ready for release packaging.
-
-## Notes
-
-- 2026-04-18: user intent is visual resemblance first; full interaction parity
-  is explicitly out of scope for the initial slice.
-- 2026-04-18: the first visual-refresh slice should prioritize recognizable
-  JP1/AJS View cues over broad interaction changes:
-  compact graph chrome, clearer current/ancestor emphasis, stronger root-jobnet
-  readability, minimap or overview treatment that feels secondary to the main
-  graph, and status indicators that stay legible in both desktop and web hosts.
-- 2026-04-18: the visual-refresh slice should keep the existing graph DTO
-  contract intact and focus on presentation concerns such as node silhouette,
-  spacing, contrast, and action affordances rather than reworking graph
-  semantics in the same change.
-- 2026-04-18: the first implemented visual-refresh pass now emphasizes the
-  current node, ancestor chain, and root jobnet more clearly while making the
-  selector drawer and canvas chrome feel more secondary to the main graph.
-- 2026-04-18: focused validation for this slice stays on identity-preserving
-  behavior rather than pixel snapshots:
-  `flowGraphView.test.ts` continues to assert current and ancestor metadata
-  mapping, desktop `pnpm test` still opens the viewers, and `pnpm run test:web`
-  confirms the web preview wiring remains intact after the presentation-only
-  restyle.
-- 2026-04-19: the next implementation slice is progressive nested expansion
-  first; one-click expand-all remains in scope but is intentionally sequenced
-  as the immediate follow-up so the first interaction change stays smaller and
-  easier to validate across desktop and web hosts.
-- 2026-04-19: when a counterpart view is unavailable, navigation must leave the
-  current view and selection unchanged; UI affordances should be hidden or
-  disabled when availability is known up front, and any remaining command path
-  should degrade to a predictable no-op instead of mutating local viewer state.
-- 2026-04-19: the first incremental nested-expansion implementation keeps
-  `currentUnitId` as the viewer's base scope and layers additional nested
-  content on top through separate expand/collapse state, so the follow-up
-  expand-all and later navigation slices can reuse the same scope model.
-- 2026-04-19: one-click expand-all now reuses the same nested-expansion state
-  model instead of introducing a separate graph mode; when every expandable
-  nested jobnet in the current scope is already open, the same control
-  collapses that scope back to the current baseline.
-- 2026-04-19: deeper nested expand/collapse remains intentionally deferred.
-  The current UI now hides those controls below the first nested level until
-  the viewer can reveal multi-level nested scopes with stable layout and
-  collision handling.
-- 2026-04-19: deeper nested expand/collapse now reuses the same visible-node
-  affordance as the direct-child slice. Once a nested jobnet is revealed in
-  the current flow canvas and it has nested children of its own, the same
-  expand/collapse control stays available without forcing a scope change back
-  through "open jobnet".
-- 2026-04-19: flow-view search is a planned usability follow-up. The desired
-  behavior is to search units from the flow surface, reveal any collapsed
-  ancestors needed to show the match, and then focus the matching unit without
-  requiring manual hierarchy expansion first.
-- 2026-04-19: the first implemented flow-view search slice intentionally stays
-  inside the current flow scope. It searches current-scope descendants by
-  unit name, comment, and absolute path, expands any collapsed ancestor
-  jobnets needed to reveal the first match, and uses a presentation-local
-  focus marker rather than rebasing `currentUnitId` or adding camera control
-  in the same change.
-- 2026-04-19: after the nested-expansion bug fixes, `buildExpandedFlowGraph.ts`
-  should keep the same layout semantics but separate node reveal, panel-bounds
-  calculation, and sibling re-layout so the next flow-view interactions do not
-  pile more stateful logic into one long function.
-- 2026-04-19: broader flow-search follow-up is intentionally deferred after the
-  first current-scope slice. Multi-match stepping, explicit camera centering,
-  and cross-scope search remain valid future ideas, but the next active
-  implementation slice should be explicit unit-list and flow-graph navigation
-  because that use case is already specified and benefits from the stable
-  `absolutePath` / `currentUnitId` identity seams now in place.
-- 2026-04-19: explicit list/flow bridge navigation is now implemented in both
-  directions. Table rows post shared navigation events toward the flow viewer,
-  flow nodes post the symmetric table-navigation event, and focused helper plus
-  routing tests cover the identity-preserving reveal behavior.
-- 2026-04-21: current-scope flow search now keeps internal spaces in the query
-  and performs case-insensitive contiguous partial matching over the existing
-  unit search text. When the current scope root and its descendants both
-  match, the viewer prefers the first descendant so the highlighted result is
-  visibly useful without changing the collapsed-ancestor reveal behavior.
-- 2026-04-21: when one flow query matches multiple units in the current scope,
-  the viewer now keeps first-match selection semantics for focus and ancestor
-  reveal, but highlights every visible matching node instead of decorating only
-  the selected one.
-- 2026-04-21: when one flow query matches multiple units in the current scope,
-  ancestor expansion now uses the combined reveal path for every match instead
-  of only the first focused result, so one search submit can expose all
-  matching nodes that belong in the current canvas.
+- Keep visual resemblance as the goal; full JP1/AJS View parity remains out of
+  scope for this slice.
+- Keep viewer-facing behavior compatible with both desktop and web hosts.
+- Keep nested expansion behavior documented in terms of visible panel bounds
+  and immediate-scope siblings so later refactors do not reintroduce
+  historical-delta drift.
+- Keep viewport refit behavior tied to the latest rendered graph bounds so
+  nested expansion does not leave newly revealed nodes outside fit-to-view.
+- Keep broader flow-search follow-ups deferred unless current-scope search
+  proves insufficient for real navigation needs.

--- a/sample/sample_ref_deep_jobnets_utf8
+++ b/sample/sample_ref_deep_jobnets_utf8
@@ -1,46 +1,615 @@
-unit=deep_jobnet_root,,jp1admin,;
+unit=viewer_root,,jp1admin,;
 {
         ty=g;
-        cm="deep jobnet root group";
-        el=jn_lv1,n,+0+0;
-        unit=jn_lv1,,jp1admin,;
+        cm="nested and wide expandable sample";
+        el=top_main,n,+0+0;
+        unit=top_main,,jp1admin,;
         {
                 ty=n;
-                cm="jobnet level 1";
-                sz=6x3;
-                el=jn_lv2,n,+240+144;
-                unit=jn_lv2,,jp1admin,;
+                cm="top main";
+                sz=18x8;
+
+                el=top_left_a,j,+240+144;
+                el=branch_alpha,n,+560+144;
+                el=top_mid_a,j,+880+144;
+                el=branch_beta,n,+1200+144;
+                el=top_right_a,j,+1520+144;
+
+                el=top_left_b,j,+240+432;
+                el=branch_gamma,n,+560+432;
+                el=top_mid_b,j,+880+432;
+                el=branch_delta,n,+1200+432;
+                el=top_right_b,j,+1520+432;
+
+                ar=(f=top_left_a,t=branch_alpha,seq);
+                ar=(f=branch_alpha,t=top_mid_a,seq);
+                ar=(f=top_mid_a,t=branch_beta,seq);
+                ar=(f=branch_beta,t=top_right_a,seq);
+
+                ar=(f=top_left_b,t=branch_gamma,seq);
+                ar=(f=branch_gamma,t=top_mid_b,seq);
+                ar=(f=top_mid_b,t=branch_delta,seq);
+                ar=(f=branch_delta,t=top_right_b,seq);
+
+                ar=(f=branch_alpha,t=branch_gamma,con);
+                ar=(f=branch_beta,t=branch_delta,con);
+
+                unit=top_left_a,,jp1admin,;
+                {
+                        ty=j;
+                        sc="echo";
+                        prm="top-left-a";
+                        tho=0;
+                }
+
+                unit=top_mid_a,,jp1admin,;
+                {
+                        ty=j;
+                        sc="echo";
+                        prm="top-mid-a";
+                        tho=0;
+                }
+
+                unit=top_right_a,,jp1admin,;
+                {
+                        ty=j;
+                        sc="echo";
+                        prm="top-right-a";
+                        tho=0;
+                }
+
+                unit=top_left_b,,jp1admin,;
+                {
+                        ty=j;
+                        sc="echo";
+                        prm="top-left-b";
+                        tho=0;
+                }
+
+                unit=top_mid_b,,jp1admin,;
+                {
+                        ty=j;
+                        sc="echo";
+                        prm="top-mid-b";
+                        tho=0;
+                }
+
+                unit=top_right_b,,jp1admin,;
+                {
+                        ty=j;
+                        sc="echo";
+                        prm="top-right-b";
+                        tho=0;
+                }
+
+                unit=branch_alpha,,jp1admin,;
                 {
                         ty=n;
-                        cm="jobnet level 2";
-                        sz=6x3;
-                        el=jn_lv3,n,+240+144;
-                        unit=jn_lv3,,jp1admin,;
+                        cm="branch alpha";
+                        sz=14x6;
+
+                        el=alpha_job_a,j,+240+144;
+                        el=alpha_nested_1,n,+560+144;
+                        el=alpha_job_b,j,+880+144;
+                        el=alpha_nested_2,n,+1200+144;
+
+                        el=alpha_job_c,j,+240+432;
+                        el=alpha_job_d,j,+880+432;
+
+                        ar=(f=alpha_job_a,t=alpha_nested_1,seq);
+                        ar=(f=alpha_nested_1,t=alpha_job_b,seq);
+                        ar=(f=alpha_job_b,t=alpha_nested_2,seq);
+                        ar=(f=alpha_nested_2,t=alpha_job_d,seq);
+                        ar=(f=alpha_job_c,t=alpha_nested_1,con);
+
+                        unit=alpha_job_a,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="alpha-a";
+                                tho=0;
+                        }
+
+                        unit=alpha_job_b,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="alpha-b";
+                                tho=0;
+                        }
+
+                        unit=alpha_job_c,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="alpha-c";
+                                tho=0;
+                        }
+
+                        unit=alpha_job_d,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="alpha-d";
+                                tho=0;
+                        }
+
+                        unit=alpha_nested_1,,jp1admin,;
                         {
                                 ty=n;
-                                cm="jobnet level 3";
-                                sz=6x3;
-                                el=jn_lv4,n,+240+144;
-                                unit=jn_lv4,,jp1admin,;
+                                cm="alpha nested 1";
+                                sz=10x4;
+
+                                el=alpha1_job_a,j,+240+144;
+                                el=alpha1_deep,n,+560+144;
+                                el=alpha1_job_b,j,+880+144;
+                                ar=(f=alpha1_job_a,t=alpha1_deep,seq);
+                                ar=(f=alpha1_deep,t=alpha1_job_b,seq);
+
+                                unit=alpha1_job_a,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="alpha1-a";
+                                        tho=0;
+                                }
+
+                                unit=alpha1_job_b,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="alpha1-b";
+                                        tho=0;
+                                }
+
+                                unit=alpha1_deep,,jp1admin,;
                                 {
                                         ty=n;
-                                        cm="jobnet level 4";
-                                        sz=6x3;
-                                        el=jn_lv5,n,+240+144;
-                                        unit=jn_lv5,,jp1admin,;
+                                        cm="alpha1 deep";
+                                        sz=8x3;
+
+                                        el=alpha1_deep_job1,j,+240+144;
+                                        el=alpha1_deep_job2,j,+560+144;
+                                        el=alpha1_deep_job3,j,+880+144;
+                                        ar=(f=alpha1_deep_job1,t=alpha1_deep_job2,seq);
+                                        ar=(f=alpha1_deep_job2,t=alpha1_deep_job3,seq);
+
+                                        unit=alpha1_deep_job1,,jp1admin,;
                                         {
-                                                ty=n;
-                                                cm="jobnet level 5";
-                                                sz=6x3;
-                                                el=leaf_job,j,+240+144;
-                                                unit=leaf_job,,jp1admin,;
-                                                {
-                                                        ty=j;
-                                                        sc="echo";
-                                                        prm="leaf";
-                                                        tho=0;
-                                                }
+                                                ty=j;
+                                                sc="echo";
+                                                prm="alpha1-deep-1";
+                                                tho=0;
                                         }
+
+                                        unit=alpha1_deep_job2,,jp1admin,;
+                                        {
+                                                ty=j;
+                                                sc="echo";
+                                                prm="alpha1-deep-2";
+                                                tho=0;
+                                        }
+
+                                        unit=alpha1_deep_job3,,jp1admin,;
+                                        {
+                                                ty=j;
+                                                sc="echo";
+                                                prm="alpha1-deep-3";
+                                                tho=0;
+                                        }
+                                }
+                        }
+
+                        unit=alpha_nested_2,,jp1admin,;
+                        {
+                                ty=n;
+                                cm="alpha nested 2";
+                                sz=12x4;
+
+                                el=alpha2_job_a,j,+240+144;
+                                el=alpha2_job_b,j,+560+144;
+                                el=alpha2_job_c,j,+880+144;
+                                el=alpha2_job_d,j,+1200+144;
+                                ar=(f=alpha2_job_a,t=alpha2_job_b,seq);
+                                ar=(f=alpha2_job_b,t=alpha2_job_c,seq);
+                                ar=(f=alpha2_job_c,t=alpha2_job_d,seq);
+
+                                unit=alpha2_job_a,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="alpha2-a";
+                                        tho=0;
+                                }
+
+                                unit=alpha2_job_b,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="alpha2-b";
+                                        tho=0;
+                                }
+
+                                unit=alpha2_job_c,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="alpha2-c";
+                                        tho=0;
+                                }
+
+                                unit=alpha2_job_d,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="alpha2-d";
+                                        tho=0;
+                                }
+                        }
+                }
+
+                unit=branch_beta,,jp1admin,;
+                {
+                        ty=n;
+                        cm="branch beta";
+                        sz=14x5;
+
+                        el=beta_job_a,j,+240+144;
+                        el=beta_nested_1,n,+560+144;
+                        el=beta_nested_2,n,+880+144;
+                        el=beta_job_b,j,+1200+144;
+
+                        el=beta_job_c,j,+240+432;
+                        el=beta_job_d,j,+1200+432;
+
+                        ar=(f=beta_job_a,t=beta_nested_1,seq);
+                        ar=(f=beta_nested_1,t=beta_nested_2,seq);
+                        ar=(f=beta_nested_2,t=beta_job_b,seq);
+                        ar=(f=beta_job_c,t=beta_nested_2,con);
+                        ar=(f=beta_nested_1,t=beta_job_d,con);
+
+                        unit=beta_job_a,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="beta-a";
+                                tho=0;
+                        }
+
+                        unit=beta_job_b,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="beta-b";
+                                tho=0;
+                        }
+
+                        unit=beta_job_c,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="beta-c";
+                                tho=0;
+                        }
+
+                        unit=beta_job_d,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="beta-d";
+                                tho=0;
+                        }
+
+                        unit=beta_nested_1,,jp1admin,;
+                        {
+                                ty=n;
+                                cm="beta nested 1";
+                                sz=8x3;
+
+                                el=beta1_job1,j,+240+144;
+                                el=beta1_job2,j,+560+144;
+                                el=beta1_job3,j,+880+144;
+                                ar=(f=beta1_job1,t=beta1_job2,seq);
+                                ar=(f=beta1_job2,t=beta1_job3,seq);
+
+                                unit=beta1_job1,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="beta1-1";
+                                        tho=0;
+                                }
+
+                                unit=beta1_job2,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="beta1-2";
+                                        tho=0;
+                                }
+
+                                unit=beta1_job3,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="beta1-3";
+                                        tho=0;
+                                }
+                        }
+
+                        unit=beta_nested_2,,jp1admin,;
+                        {
+                                ty=n;
+                                cm="beta nested 2";
+                                sz=10x4;
+
+                                el=beta2_job1,j,+240+144;
+                                el=beta2_deep,n,+560+144;
+                                el=beta2_job2,j,+880+144;
+                                ar=(f=beta2_job1,t=beta2_deep,seq);
+                                ar=(f=beta2_deep,t=beta2_job2,seq);
+
+                                unit=beta2_job1,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="beta2-1";
+                                        tho=0;
+                                }
+
+                                unit=beta2_job2,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="beta2-2";
+                                        tho=0;
+                                }
+
+                                unit=beta2_deep,,jp1admin,;
+                                {
+                                        ty=n;
+                                        cm="beta2 deep";
+                                        sz=8x3;
+
+                                        el=beta2_deep_job1,j,+240+144;
+                                        el=beta2_deep_job2,j,+560+144;
+                                        el=beta2_deep_job3,j,+880+144;
+                                        ar=(f=beta2_deep_job1,t=beta2_deep_job2,seq);
+                                        ar=(f=beta2_deep_job2,t=beta2_deep_job3,seq);
+
+                                        unit=beta2_deep_job1,,jp1admin,;
+                                        {
+                                                ty=j;
+                                                sc="echo";
+                                                prm="beta2-deep-1";
+                                                tho=0;
+                                        }
+
+                                        unit=beta2_deep_job2,,jp1admin,;
+                                        {
+                                                ty=j;
+                                                sc="echo";
+                                                prm="beta2-deep-2";
+                                                tho=0;
+                                        }
+
+                                        unit=beta2_deep_job3,,jp1admin,;
+                                        {
+                                                ty=j;
+                                                sc="echo";
+                                                prm="beta2-deep-3";
+                                                tho=0;
+                                        }
+                                }
+                        }
+                }
+
+                unit=branch_gamma,,jp1admin,;
+                {
+                        ty=n;
+                        cm="branch gamma";
+                        sz=12x4;
+
+                        el=gamma_job_a,j,+240+144;
+                        el=gamma_nested_1,n,+560+144;
+                        el=gamma_job_b,j,+880+144;
+                        el=gamma_nested_2,n,+1200+144;
+                        ar=(f=gamma_job_a,t=gamma_nested_1,seq);
+                        ar=(f=gamma_nested_1,t=gamma_job_b,seq);
+                        ar=(f=gamma_job_b,t=gamma_nested_2,seq);
+
+                        unit=gamma_job_a,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="gamma-a";
+                                tho=0;
+                        }
+
+                        unit=gamma_job_b,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="gamma-b";
+                                tho=0;
+                        }
+
+                        unit=gamma_nested_1,,jp1admin,;
+                        {
+                                ty=n;
+                                cm="gamma nested 1";
+                                sz=8x3;
+
+                                el=gamma1_job1,j,+240+144;
+                                el=gamma1_job2,j,+560+144;
+                                el=gamma1_job3,j,+880+144;
+                                ar=(f=gamma1_job1,t=gamma1_job2,seq);
+                                ar=(f=gamma1_job2,t=gamma1_job3,seq);
+
+                                unit=gamma1_job1,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="gamma1-1";
+                                        tho=0;
+                                }
+
+                                unit=gamma1_job2,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="gamma1-2";
+                                        tho=0;
+                                }
+
+                                unit=gamma1_job3,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="gamma1-3";
+                                        tho=0;
+                                }
+                        }
+
+                        unit=gamma_nested_2,,jp1admin,;
+                        {
+                                ty=n;
+                                cm="gamma nested 2";
+                                sz=8x3;
+
+                                el=gamma2_job1,j,+240+144;
+                                el=gamma2_job2,j,+560+144;
+                                el=gamma2_job3,j,+880+144;
+                                ar=(f=gamma2_job1,t=gamma2_job2,seq);
+                                ar=(f=gamma2_job2,t=gamma2_job3,seq);
+
+                                unit=gamma2_job1,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="gamma2-1";
+                                        tho=0;
+                                }
+
+                                unit=gamma2_job2,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="gamma2-2";
+                                        tho=0;
+                                }
+
+                                unit=gamma2_job3,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="gamma2-3";
+                                        tho=0;
+                                }
+                        }
+                }
+
+                unit=branch_delta,,jp1admin,;
+                {
+                        ty=n;
+                        cm="branch delta";
+                        sz=14x4;
+
+                        el=delta_nested_1,n,+240+144;
+                        el=delta_job_a,j,+560+144;
+                        el=delta_nested_2,n,+880+144;
+                        el=delta_job_b,j,+1200+144;
+                        ar=(f=delta_nested_1,t=delta_job_a,seq);
+                        ar=(f=delta_job_a,t=delta_nested_2,seq);
+                        ar=(f=delta_nested_2,t=delta_job_b,seq);
+
+                        unit=delta_job_a,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="delta-a";
+                                tho=0;
+                        }
+
+                        unit=delta_job_b,,jp1admin,;
+                        {
+                                ty=j;
+                                sc="echo";
+                                prm="delta-b";
+                                tho=0;
+                        }
+
+                        unit=delta_nested_1,,jp1admin,;
+                        {
+                                ty=n;
+                                cm="delta nested 1";
+                                sz=10x3;
+
+                                el=delta1_job1,j,+240+144;
+                                el=delta1_job2,j,+560+144;
+                                el=delta1_job3,j,+880+144;
+                                ar=(f=delta1_job1,t=delta1_job2,seq);
+                                ar=(f=delta1_job2,t=delta1_job3,seq);
+
+                                unit=delta1_job1,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="delta1-1";
+                                        tho=0;
+                                }
+
+                                unit=delta1_job2,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="delta1-2";
+                                        tho=0;
+                                }
+
+                                unit=delta1_job3,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="delta1-3";
+                                        tho=0;
+                                }
+                        }
+
+                        unit=delta_nested_2,,jp1admin,;
+                        {
+                                ty=n;
+                                cm="delta nested 2";
+                                sz=10x3;
+
+                                el=delta2_job1,j,+240+144;
+                                el=delta2_job2,j,+560+144;
+                                el=delta2_job3,j,+880+144;
+                                ar=(f=delta2_job1,t=delta2_job2,seq);
+                                ar=(f=delta2_job2,t=delta2_job3,seq);
+
+                                unit=delta2_job1,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="delta2-1";
+                                        tho=0;
+                                }
+
+                                unit=delta2_job2,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="delta2-2";
+                                        tho=0;
+                                }
+
+                                unit=delta2_job3,,jp1admin,;
+                                {
+                                        ty=j;
+                                        sc="echo";
+                                        prm="delta2-3";
+                                        tho=0;
                                 }
                         }
                 }

--- a/src/test/suite/buildExpandedFlowGraph.test.ts
+++ b/src/test/suite/buildExpandedFlowGraph.test.ts
@@ -197,6 +197,304 @@ unit=root,,jp1admin,;
 }
 `;
 
+const siblingExpandedJobnetsDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=left-net,n,+240+144;
+    el=right-net,n,+560+144;
+    unit=left-net,,jp1admin,;
+    {
+      ty=n;
+      el=left-grand,n,+240+144;
+      el=left-job,j,+560+144;
+      ar=(f=left-grand,t=left-job);
+      unit=left-grand,,jp1admin,;
+      {
+        ty=n;
+      }
+      unit=left-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=right-net,,jp1admin,;
+    {
+      ty=n;
+      el=right-grand,n,+240+144;
+      el=right-job,j,+560+144;
+      ar=(f=right-grand,t=right-job);
+      unit=right-grand,,jp1admin,;
+      {
+        ty=n;
+      }
+      unit=right-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+  }
+}
+`;
+
+const parentRowPropagationDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=parent-net,n,+240+144;
+    el=sibling-right,j,+880+144;
+    unit=parent-net,,jp1admin,;
+    {
+      ty=n;
+      el=child-net,n,+240+144;
+      unit=child-net,,jp1admin,;
+      {
+        ty=n;
+        el=child-job,j,+560+144;
+        unit=child-job,,jp1admin,;
+        {
+          ty=j;
+        }
+      }
+    }
+    unit=sibling-right,,jp1admin,;
+    {
+      ty=j;
+    }
+  }
+}
+`;
+
+const upperPanelCoversLowerWidthDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=upper-net,n,+240+144;
+    el=lower-net,n,+240+432;
+    el=right-lower,j,+880+432;
+    unit=upper-net,,jp1admin,;
+    {
+      ty=n;
+      el=upper-wide-job,j,+880+144;
+      unit=upper-wide-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=lower-net,,jp1admin,;
+    {
+      ty=n;
+      el=lower-job,j,+560+144;
+      unit=lower-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=right-lower,,jp1admin,;
+    {
+      ty=j;
+    }
+  }
+}
+`;
+
+const lowerPanelExceedsUpperWidthDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=upper-net,n,+240+144;
+    el=lower-net,n,+240+432;
+    el=right-lower,j,+880+432;
+    unit=upper-net,,jp1admin,;
+    {
+      ty=n;
+      el=upper-wide-job,j,+560+144;
+      unit=upper-wide-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=lower-net,,jp1admin,;
+    {
+      ty=n;
+      el=lower-wide-job,j,+880+144;
+      unit=lower-wide-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=right-lower,,jp1admin,;
+    {
+      ty=j;
+    }
+  }
+}
+`;
+
+const upperPanelIntrudesLowerPanelDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=upper-net,n,+240+144;
+    el=lower-net,n,+240+432;
+    unit=upper-net,,jp1admin,;
+    {
+      ty=n;
+      el=upper-deep-job,j,+240+432;
+      unit=upper-deep-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=lower-net,,jp1admin,;
+    {
+      ty=n;
+      el=lower-job,j,+240+144;
+      unit=lower-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+  }
+}
+`;
+
+const alreadyOffsetTargetDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=upper-net,n,+240+144;
+    el=lower-net,n,+560+432;
+    el=target-job,j,+880+720;
+    unit=upper-net,,jp1admin,;
+    {
+      ty=n;
+      el=upper-deep-job,j,+240+720;
+      unit=upper-deep-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=lower-net,,jp1admin,;
+    {
+      ty=n;
+      el=lower-job,j,+240+144;
+      unit=lower-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=target-job,,jp1admin,;
+    {
+      ty=j;
+    }
+  }
+}
+`;
+
+const verticallyOffsetTargetNeedsHorizontalOffsetDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=upper-net,n,+880+144;
+    el=lower-net,n,+560+432;
+    el=target-job,j,+880+720;
+    unit=upper-net,,jp1admin,;
+    {
+      ty=n;
+      el=upper-deep-job,j,+240+720;
+      unit=upper-deep-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=lower-net,,jp1admin,;
+    {
+      ty=n;
+      el=lower-wide-job,j,+880+144;
+      unit=lower-wide-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=target-job,,jp1admin,;
+    {
+      ty=j;
+    }
+  }
+}
+`;
+
+const nestedExpansionExceedsUpperWidthDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    el=upper-net,n,+240+144;
+    el=lower-net,n,+240+432;
+    el=right-lower,j,+880+432;
+    unit=upper-net,,jp1admin,;
+    {
+      ty=n;
+      el=upper-wide-job,j,+560+144;
+      unit=upper-wide-job,,jp1admin,;
+      {
+        ty=j;
+      }
+    }
+    unit=lower-net,,jp1admin,;
+    {
+      ty=n;
+      el=lower-child,n,+240+144;
+      unit=lower-child,,jp1admin,;
+      {
+        ty=n;
+        el=lower-wide-job,j,+1120+144;
+        unit=lower-wide-job,,jp1admin,;
+        {
+          ty=j;
+        }
+      }
+    }
+    unit=right-lower,,jp1admin,;
+    {
+      ty=j;
+    }
+  }
+}
+`;
+
 suite("Build Expanded Flow Graph", () => {
   test("reveals nested jobnets only after their parent scope is expanded", () => {
     const result = parseAjs(nestedDefinition);
@@ -501,6 +799,54 @@ suite("Build Expanded Flow Graph", () => {
     assert.ok(deepSiblingPosition!.x > deepLevel2PanelRight);
   });
 
+  test("keeps panel origin anchored to the expanded unit while deeper descendants grow it", () => {
+    const result = parseAjs(deepNestedJobnetDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const level2Id = document.rootUnits[0].children[0].children[0].id;
+    const level3Id =
+      document.rootUnits[0].children[0].children[0].children[0].id;
+    const level4Id =
+      document.rootUnits[0].children[0].children[0].children[0].children[0].id;
+
+    const shallowExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([level2Id]),
+      16,
+    );
+    const deepExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([level2Id, level3Id, level4Id]),
+      16,
+    );
+
+    const shallowLevel2Decoration =
+      shallowExpanded.nodeDecorations.get(level2Id);
+    const deepLevel2Decoration = deepExpanded.nodeDecorations.get(level2Id);
+
+    assert.ok(shallowLevel2Decoration);
+    assert.ok(deepLevel2Decoration);
+    assert.strictEqual(
+      deepLevel2Decoration!.panelOffsetXPx,
+      shallowLevel2Decoration!.panelOffsetXPx,
+    );
+    assert.strictEqual(
+      deepLevel2Decoration!.panelOffsetYPx,
+      shallowLevel2Decoration!.panelOffsetYPx,
+    );
+    assert.ok(
+      deepLevel2Decoration!.panelWidthPx >
+        shallowLevel2Decoration!.panelWidthPx,
+    );
+    assert.ok(
+      deepLevel2Decoration!.panelHeightPx >
+        shallowLevel2Decoration!.panelHeightPx,
+    );
+  });
+
   test("expands recovery jobnet variants with nested children", () => {
     const result = parseAjs(recoveryJobnetDefinition);
     assert.deepStrictEqual(result.errors, []);
@@ -523,5 +869,654 @@ suite("Build Expanded Flow Graph", () => {
       true,
     );
     assert.ok(expanded.nodeDecorations.get(recoveryNetId));
+  });
+
+  test("keeps expanded descendants anchored when a sibling expansion later moves their parent", () => {
+    const result = parseAjs(siblingExpandedJobnetsDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const leftNetId = document.rootUnits[0].children[0].children[0].id;
+    const rightNetId = document.rootUnits[0].children[0].children[1].id;
+    const rightGrandId =
+      document.rootUnits[0].children[0].children[1].children[0].id;
+    const rightJobId =
+      document.rootUnits[0].children[0].children[1].children[1].id;
+
+    const rightExpandedOnly = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([rightNetId]),
+      16,
+    );
+    const siblingExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([rightNetId, leftNetId]),
+      16,
+    );
+
+    const rightOnlyParentPosition =
+      rightExpandedOnly.positionOverrides.get(rightNetId);
+    const rightOnlyGrandPosition =
+      rightExpandedOnly.positionOverrides.get(rightGrandId);
+    const rightOnlyJobPosition =
+      rightExpandedOnly.positionOverrides.get(rightJobId);
+    const movedParentPosition =
+      siblingExpanded.positionOverrides.get(rightNetId);
+    const movedGrandPosition =
+      siblingExpanded.positionOverrides.get(rightGrandId);
+    const movedJobPosition = siblingExpanded.positionOverrides.get(rightJobId);
+
+    assert.ok(rightOnlyParentPosition);
+    assert.ok(rightOnlyGrandPosition);
+    assert.ok(rightOnlyJobPosition);
+    assert.ok(movedParentPosition);
+    assert.ok(movedGrandPosition);
+    assert.ok(movedJobPosition);
+
+    assert.ok(movedParentPosition!.x > rightOnlyParentPosition!.x);
+    assert.strictEqual(
+      movedGrandPosition!.x - movedParentPosition!.x,
+      rightOnlyGrandPosition!.x - rightOnlyParentPosition!.x,
+    );
+    assert.strictEqual(
+      movedGrandPosition!.y - movedParentPosition!.y,
+      rightOnlyGrandPosition!.y - rightOnlyParentPosition!.y,
+    );
+    assert.strictEqual(
+      movedJobPosition!.x - movedParentPosition!.x,
+      rightOnlyJobPosition!.x - rightOnlyParentPosition!.x,
+    );
+    assert.strictEqual(
+      movedJobPosition!.y - movedParentPosition!.y,
+      rightOnlyJobPosition!.y - rightOnlyParentPosition!.y,
+    );
+  });
+
+  test("keeps a later expanded sibling panel aligned with descendants after sibling offsets", () => {
+    const result = parseAjs(siblingExpandedJobnetsDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const leftNetId = document.rootUnits[0].children[0].children[0].id;
+    const rightNetId = document.rootUnits[0].children[0].children[1].id;
+    const rightGrandId =
+      document.rootUnits[0].children[0].children[1].children[0].id;
+    const rightJobId =
+      document.rootUnits[0].children[0].children[1].children[1].id;
+
+    const expanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([leftNetId, rightNetId]),
+      16,
+    );
+
+    const rightParentPosition = expanded.positionOverrides.get(rightNetId);
+    const rightGrandPosition = expanded.positionOverrides.get(rightGrandId);
+    const rightJobPosition = expanded.positionOverrides.get(rightJobId);
+    const rightDecoration = expanded.nodeDecorations.get(rightNetId);
+
+    assert.ok(rightParentPosition);
+    assert.ok(rightGrandPosition);
+    assert.ok(rightJobPosition);
+    assert.ok(rightDecoration);
+
+    const panelLeft = rightParentPosition!.x + rightDecoration!.panelOffsetXPx;
+    const panelRight = panelLeft + rightDecoration!.panelWidthPx;
+    const panelTop = rightParentPosition!.y + rightDecoration!.panelOffsetYPx;
+    const panelBottom = panelTop + rightDecoration!.panelHeightPx;
+
+    assert.ok(rightGrandPosition!.x >= panelLeft);
+    assert.ok(rightGrandPosition!.x + 160 <= panelRight);
+    assert.ok(rightGrandPosition!.y >= panelTop);
+    assert.ok(rightGrandPosition!.y + 96 <= panelBottom);
+    assert.ok(rightJobPosition!.x >= panelLeft);
+    assert.ok(rightJobPosition!.x + 160 <= panelRight);
+    assert.ok(rightJobPosition!.y >= panelTop);
+    assert.ok(rightJobPosition!.y + 96 <= panelBottom);
+  });
+
+  test("pushes units on the parent row when a nested expansion enlarges that parent scope", () => {
+    const result = parseAjs(parentRowPropagationDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const parentNetId = document.rootUnits[0].children[0].children[0].id;
+    const childNetId =
+      document.rootUnits[0].children[0].children[0].children[0].id;
+    const siblingRightId = document.rootUnits[0].children[0].children[1].id;
+
+    const parentOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([parentNetId]),
+      16,
+    );
+    const childExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([parentNetId, childNetId]),
+      16,
+    );
+
+    const siblingBefore =
+      parentOnlyExpanded.positionOverrides.get(siblingRightId);
+    const siblingAfter = childExpanded.positionOverrides.get(siblingRightId);
+    const parentBefore = parentOnlyExpanded.positionOverrides.get(parentNetId);
+    const parentAfter = childExpanded.positionOverrides.get(parentNetId);
+    const parentDecorationBefore =
+      parentOnlyExpanded.nodeDecorations.get(parentNetId);
+    const parentDecorationAfter =
+      childExpanded.nodeDecorations.get(parentNetId);
+
+    assert.ok(siblingBefore);
+    assert.ok(siblingAfter);
+    assert.ok(parentBefore);
+    assert.ok(parentAfter);
+    assert.ok(parentDecorationBefore);
+    assert.ok(parentDecorationAfter);
+    assert.strictEqual(siblingBefore!.y, parentBefore!.y);
+    assert.strictEqual(siblingAfter!.y, parentAfter!.y);
+    assert.ok(siblingAfter!.x > siblingBefore!.x);
+    const parentPanelRightBefore =
+      parentBefore!.x +
+      parentDecorationBefore!.panelOffsetXPx +
+      parentDecorationBefore!.panelWidthPx;
+    const parentPanelRightAfter =
+      parentAfter!.x +
+      parentDecorationAfter!.panelOffsetXPx +
+      parentDecorationAfter!.panelWidthPx;
+    assert.ok(siblingAfter!.x > parentPanelRightAfter);
+    assert.strictEqual(
+      siblingAfter!.x - siblingBefore!.x,
+      parentPanelRightAfter - parentPanelRightBefore,
+    );
+  });
+
+  test("does not propagate horizontal growth when an upper expanded panel already covers it", () => {
+    const result = parseAjs(upperPanelCoversLowerWidthDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const upperNetId = document.rootUnits[0].children[0].children[0].id;
+    const lowerNetId = document.rootUnits[0].children[0].children[1].id;
+    const rightLowerId = document.rootUnits[0].children[0].children[2].id;
+
+    const upperOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([upperNetId]),
+      16,
+    );
+    const upperAndLowerExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([upperNetId, lowerNetId]),
+      16,
+    );
+
+    const rightLowerBefore =
+      upperOnlyExpanded.positionOverrides.get(rightLowerId);
+    const rightLowerAfter =
+      upperAndLowerExpanded.positionOverrides.get(rightLowerId);
+    const upperPosition =
+      upperAndLowerExpanded.positionOverrides.get(upperNetId);
+    const lowerPosition =
+      upperAndLowerExpanded.positionOverrides.get(lowerNetId);
+    const upperDecoration =
+      upperAndLowerExpanded.nodeDecorations.get(upperNetId);
+    const lowerDecoration =
+      upperAndLowerExpanded.nodeDecorations.get(lowerNetId);
+
+    assert.ok(rightLowerBefore);
+    assert.ok(rightLowerAfter);
+    assert.ok(upperPosition);
+    assert.ok(lowerPosition);
+    assert.ok(upperDecoration);
+    assert.ok(lowerDecoration);
+
+    const upperPanelRight =
+      upperPosition!.x +
+      upperDecoration!.panelOffsetXPx +
+      upperDecoration!.panelWidthPx;
+    const lowerPanelRight =
+      lowerPosition!.x +
+      lowerDecoration!.panelOffsetXPx +
+      lowerDecoration!.panelWidthPx;
+
+    assert.ok(upperPosition!.y < lowerPosition!.y);
+    assert.ok(upperPanelRight > lowerPanelRight);
+    assert.strictEqual(rightLowerAfter!.x, rightLowerBefore!.x);
+  });
+
+  test("propagates only the horizontal growth beyond the upper expanded panel", () => {
+    const result = parseAjs(lowerPanelExceedsUpperWidthDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const upperNetId = document.rootUnits[0].children[0].children[0].id;
+    const lowerNetId = document.rootUnits[0].children[0].children[1].id;
+    const rightLowerId = document.rootUnits[0].children[0].children[2].id;
+
+    const upperOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([upperNetId]),
+      16,
+    );
+    const upperAndLowerExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([upperNetId, lowerNetId]),
+      16,
+    );
+
+    const rightLowerBefore =
+      upperOnlyExpanded.positionOverrides.get(rightLowerId);
+    const rightLowerAfter =
+      upperAndLowerExpanded.positionOverrides.get(rightLowerId);
+    const upperPosition =
+      upperAndLowerExpanded.positionOverrides.get(upperNetId);
+    const lowerPosition =
+      upperAndLowerExpanded.positionOverrides.get(lowerNetId);
+    const upperDecoration =
+      upperAndLowerExpanded.nodeDecorations.get(upperNetId);
+    const lowerDecoration =
+      upperAndLowerExpanded.nodeDecorations.get(lowerNetId);
+
+    assert.ok(rightLowerBefore);
+    assert.ok(rightLowerAfter);
+    assert.ok(upperPosition);
+    assert.ok(lowerPosition);
+    assert.ok(upperDecoration);
+    assert.ok(lowerDecoration);
+
+    const upperPanelRight =
+      upperPosition!.x +
+      upperDecoration!.panelOffsetXPx +
+      upperDecoration!.panelWidthPx;
+    const lowerPanelRight =
+      lowerPosition!.x +
+      lowerDecoration!.panelOffsetXPx +
+      lowerDecoration!.panelWidthPx;
+
+    assert.ok(upperPosition!.y < lowerPosition!.y);
+    assert.ok(lowerPanelRight > upperPanelRight);
+    assert.strictEqual(
+      rightLowerAfter!.x - rightLowerBefore!.x,
+      lowerPanelRight - upperPanelRight,
+    );
+  });
+
+  test("propagates horizontal growth beyond the upper panel when lower is expanded after upper", () => {
+    const result = parseAjs(lowerPanelExceedsUpperWidthDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const upperNetId = document.rootUnits[0].children[0].children[0].id;
+    const lowerNetId = document.rootUnits[0].children[0].children[1].id;
+    const rightLowerId = document.rootUnits[0].children[0].children[2].id;
+
+    const upperOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId],
+      16,
+    );
+    const lowerExpandedAfterUpper = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId, lowerNetId],
+      16,
+    );
+
+    const rightLowerBefore =
+      upperOnlyExpanded.positionOverrides.get(rightLowerId);
+    const rightLowerAfter =
+      lowerExpandedAfterUpper.positionOverrides.get(rightLowerId);
+    const upperPosition =
+      lowerExpandedAfterUpper.positionOverrides.get(upperNetId);
+    const lowerPosition =
+      lowerExpandedAfterUpper.positionOverrides.get(lowerNetId);
+    const upperDecoration =
+      lowerExpandedAfterUpper.nodeDecorations.get(upperNetId);
+    const lowerDecoration =
+      lowerExpandedAfterUpper.nodeDecorations.get(lowerNetId);
+
+    assert.ok(rightLowerBefore);
+    assert.ok(rightLowerAfter);
+    assert.ok(upperPosition);
+    assert.ok(lowerPosition);
+    assert.ok(upperDecoration);
+    assert.ok(lowerDecoration);
+
+    const upperPanelRight =
+      upperPosition!.x +
+      upperDecoration!.panelOffsetXPx +
+      upperDecoration!.panelWidthPx;
+    const lowerPanelRight =
+      lowerPosition!.x +
+      lowerDecoration!.panelOffsetXPx +
+      lowerDecoration!.panelWidthPx;
+
+    assert.ok(lowerPanelRight > upperPanelRight);
+    assert.strictEqual(
+      rightLowerAfter!.x - rightLowerBefore!.x,
+      lowerPanelRight - upperPanelRight,
+    );
+  });
+
+  test("pushes a lower expanded panel origin when an upper expanded panel intrudes into it", () => {
+    const result = parseAjs(upperPanelIntrudesLowerPanelDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const upperNetId = document.rootUnits[0].children[0].children[0].id;
+    const lowerNetId = document.rootUnits[0].children[0].children[1].id;
+
+    const lowerOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([lowerNetId]),
+      16,
+    );
+    const upperAndLowerExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [lowerNetId, upperNetId],
+      16,
+    );
+
+    const lowerBefore = lowerOnlyExpanded.positionOverrides.get(lowerNetId);
+    const upperPosition =
+      upperAndLowerExpanded.positionOverrides.get(upperNetId);
+    const lowerAfter = upperAndLowerExpanded.positionOverrides.get(lowerNetId);
+    const upperDecoration =
+      upperAndLowerExpanded.nodeDecorations.get(upperNetId);
+    const lowerDecoration =
+      upperAndLowerExpanded.nodeDecorations.get(lowerNetId);
+
+    assert.ok(lowerBefore);
+    assert.ok(upperPosition);
+    assert.ok(lowerAfter);
+    assert.ok(upperDecoration);
+    assert.ok(lowerDecoration);
+
+    const upperPanelBottom =
+      upperPosition!.y +
+      upperDecoration!.panelOffsetYPx +
+      upperDecoration!.panelHeightPx;
+    const lowerPanelTop = lowerAfter!.y + lowerDecoration!.panelOffsetYPx;
+
+    assert.ok(lowerAfter!.y > lowerBefore!.y);
+    assert.ok(upperPanelBottom <= lowerPanelTop);
+  });
+
+  test("does not push a lower panel origin when that lower unit is the newly expanded unit", () => {
+    const result = parseAjs(upperPanelIntrudesLowerPanelDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const upperNetId = document.rootUnits[0].children[0].children[0].id;
+    const lowerNetId = document.rootUnits[0].children[0].children[1].id;
+
+    const upperOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId],
+      16,
+    );
+    const lowerExpandedAfterUpper = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId, lowerNetId],
+      16,
+    );
+
+    const lowerBefore = upperOnlyExpanded.positionOverrides.get(lowerNetId);
+    const lowerAfter =
+      lowerExpandedAfterUpper.positionOverrides.get(lowerNetId);
+
+    assert.ok(lowerBefore);
+    assert.ok(lowerAfter);
+    assert.strictEqual(lowerAfter!.y, lowerBefore!.y);
+  });
+
+  test("does not apply vertical growth again when a target already has enough y offset", () => {
+    const result = parseAjs(alreadyOffsetTargetDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const upperNetId = document.rootUnits[0].children[0].children[0].id;
+    const lowerNetId = document.rootUnits[0].children[0].children[1].id;
+    const targetJobId = document.rootUnits[0].children[0].children[2].id;
+
+    const upperOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId],
+      16,
+    );
+    const upperAndLowerExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId, lowerNetId],
+      16,
+    );
+
+    const targetBefore = upperOnlyExpanded.positionOverrides.get(targetJobId);
+    const targetAfter =
+      upperAndLowerExpanded.positionOverrides.get(targetJobId);
+    const lowerPosition =
+      upperAndLowerExpanded.positionOverrides.get(lowerNetId);
+    const lowerDecoration =
+      upperAndLowerExpanded.nodeDecorations.get(lowerNetId);
+
+    assert.ok(targetBefore);
+    assert.ok(targetAfter);
+    assert.ok(lowerPosition);
+    assert.ok(lowerDecoration);
+
+    const lowerPanelBottom =
+      lowerPosition!.y +
+      lowerDecoration!.panelOffsetYPx +
+      lowerDecoration!.panelHeightPx;
+
+    assert.ok(targetBefore!.y >= lowerPanelBottom);
+    assert.strictEqual(targetAfter!.x, targetBefore!.x);
+    assert.strictEqual(targetAfter!.y, targetBefore!.y);
+  });
+
+  test("keeps horizontal growth when vertical growth is already covered", () => {
+    const result = parseAjs(
+      verticallyOffsetTargetNeedsHorizontalOffsetDefinition,
+    );
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const upperNetId = document.rootUnits[0].children[0].children[0].id;
+    const lowerNetId = document.rootUnits[0].children[0].children[1].id;
+    const targetJobId = document.rootUnits[0].children[0].children[2].id;
+
+    const upperOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId],
+      16,
+    );
+    const upperAndLowerExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId, lowerNetId],
+      16,
+    );
+
+    const targetBefore = upperOnlyExpanded.positionOverrides.get(targetJobId);
+    const targetAfter =
+      upperAndLowerExpanded.positionOverrides.get(targetJobId);
+    const lowerPosition =
+      upperAndLowerExpanded.positionOverrides.get(lowerNetId);
+    const upperPosition =
+      upperAndLowerExpanded.positionOverrides.get(upperNetId);
+    const upperDecoration =
+      upperAndLowerExpanded.nodeDecorations.get(upperNetId);
+    const lowerDecoration =
+      upperAndLowerExpanded.nodeDecorations.get(lowerNetId);
+
+    assert.ok(targetBefore);
+    assert.ok(targetAfter);
+    assert.ok(lowerPosition);
+    assert.ok(upperPosition);
+    assert.ok(upperDecoration);
+    assert.ok(lowerDecoration);
+
+    const upperPanelRight =
+      upperPosition!.x +
+      upperDecoration!.panelOffsetXPx +
+      upperDecoration!.panelWidthPx;
+    const lowerPanelRight =
+      lowerPosition!.x +
+      lowerDecoration!.panelOffsetXPx +
+      lowerDecoration!.panelWidthPx;
+    const lowerPanelBottom =
+      lowerPosition!.y +
+      lowerDecoration!.panelOffsetYPx +
+      lowerDecoration!.panelHeightPx;
+
+    assert.ok(targetBefore!.y >= lowerPanelBottom);
+    assert.ok(lowerPanelRight > upperPanelRight);
+    assert.strictEqual(
+      targetAfter!.x - targetBefore!.x,
+      lowerPanelRight - upperPanelRight,
+    );
+    assert.strictEqual(targetAfter!.y, targetBefore!.y);
+  });
+
+  test("propagates horizontal growth when a nested expansion makes the parent exceed the upper panel", () => {
+    const result = parseAjs(nestedExpansionExceedsUpperWidthDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const upperNetId = document.rootUnits[0].children[0].children[0].id;
+    const lowerNetId = document.rootUnits[0].children[0].children[1].id;
+    const lowerChildId =
+      document.rootUnits[0].children[0].children[1].children[0].id;
+    const rightLowerId = document.rootUnits[0].children[0].children[2].id;
+
+    const lowerOnlyExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId, lowerNetId],
+      16,
+    );
+    const lowerChildExpanded = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [upperNetId, lowerNetId, lowerChildId],
+      16,
+    );
+
+    const rightLowerBefore =
+      lowerOnlyExpanded.positionOverrides.get(rightLowerId);
+    const rightLowerAfter =
+      lowerChildExpanded.positionOverrides.get(rightLowerId);
+    const upperPosition = lowerChildExpanded.positionOverrides.get(upperNetId);
+    const lowerPosition = lowerChildExpanded.positionOverrides.get(lowerNetId);
+    const upperDecoration = lowerChildExpanded.nodeDecorations.get(upperNetId);
+    const lowerDecoration = lowerChildExpanded.nodeDecorations.get(lowerNetId);
+
+    assert.ok(rightLowerBefore);
+    assert.ok(rightLowerAfter);
+    assert.ok(upperPosition);
+    assert.ok(lowerPosition);
+    assert.ok(upperDecoration);
+    assert.ok(lowerDecoration);
+
+    const upperPanelRight =
+      upperPosition!.x +
+      upperDecoration!.panelOffsetXPx +
+      upperDecoration!.panelWidthPx;
+    const lowerPanelRight =
+      lowerPosition!.x +
+      lowerDecoration!.panelOffsetXPx +
+      lowerDecoration!.panelWidthPx;
+
+    assert.ok(lowerPanelRight > upperPanelRight);
+    assert.strictEqual(
+      rightLowerAfter!.x - rightLowerBefore!.x,
+      lowerPanelRight - upperPanelRight,
+    );
+  });
+
+  test("keeps the same layout when the same-depth expanded order changes", () => {
+    const result = parseAjs(siblingExpandedJobnetsDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const leftNetId = document.rootUnits[0].children[0].children[0].id;
+    const rightNetId = document.rootUnits[0].children[0].children[1].id;
+    const rightJobId =
+      document.rootUnits[0].children[0].children[1].children[1].id;
+
+    const leftThenRight = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([leftNetId, rightNetId]),
+      16,
+    );
+    const rightThenLeft = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([rightNetId, leftNetId]),
+      16,
+    );
+
+    assert.deepStrictEqual(
+      leftThenRight.positionOverrides.get(rightNetId),
+      rightThenLeft.positionOverrides.get(rightNetId),
+    );
+    assert.deepStrictEqual(
+      leftThenRight.positionOverrides.get(rightJobId),
+      rightThenLeft.positionOverrides.get(rightJobId),
+    );
+    assert.deepStrictEqual(
+      leftThenRight.nodeDecorations.get(leftNetId),
+      rightThenLeft.nodeDecorations.get(leftNetId),
+    );
+    assert.deepStrictEqual(
+      leftThenRight.nodeDecorations.get(rightNetId),
+      rightThenLeft.nodeDecorations.get(rightNetId),
+    );
+  });
+
+  test("rebuilding the same expanded state keeps panel bounds stable", () => {
+    const result = parseAjs(deepNestedJobnetDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const currentUnitId = document.rootUnits[0].children[0].id;
+    const level2Id = document.rootUnits[0].children[0].children[0].id;
+    const level3Id =
+      document.rootUnits[0].children[0].children[0].children[0].id;
+    const level4Id =
+      document.rootUnits[0].children[0].children[0].children[0].children[0].id;
+
+    const expandedUnitIds = new Set<string>([level2Id, level3Id, level4Id]);
+    const first = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      expandedUnitIds,
+      16,
+    );
+    const second = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      new Set<string>([level2Id, level3Id, level4Id]),
+      16,
+    );
+
+    assert.deepStrictEqual(first.positionOverrides, second.positionOverrides);
+    assert.deepStrictEqual(first.nodeDecorations, second.nodeDecorations);
   });
 });

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -23,6 +23,7 @@ import {
   Node,
   NodeTypes,
   ReactFlow,
+  ReactFlowInstance,
   ReactFlowProvider,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -109,6 +110,10 @@ const FlowContents: FC = () => {
   const [searchMatchedUnitIds, setSearchMatchedUnitIds] = useState<string[]>(
     [],
   );
+  const reactFlowInstanceRef = useRef<ReactFlowInstance<Node, Edge> | null>(
+    null,
+  );
+  const fitViewFrameRef = useRef<number | undefined>(undefined);
   const preserveSearchOnNextScopeChange = useRef<boolean>(false);
   const prevUnitEntityId = useRef<string | undefined>(undefined);
   const [nodes, setNodes] = useState<Node[]>([]);
@@ -231,7 +236,7 @@ const FlowContents: FC = () => {
         buildExpandedFlowGraph(
           ajsDocument,
           selectedUnitId,
-          nestedExpansionState.expandedUnitIds,
+          expandedUnitIds,
           theme.typography.htmlFontSize,
         );
       if (!graph) {
@@ -261,6 +266,7 @@ const FlowContents: FC = () => {
       ajsDocument,
       currentUnitIdState,
       dialogDataState,
+      expandedUnitIds,
       nestedExpansionState,
       theme,
       unitDefinitionByPath,
@@ -315,6 +321,28 @@ const FlowContents: FC = () => {
     updateNodesAndEdges(currentUnitId);
     prevUnitEntityId.current = currentUnitId;
   }, [currentUnitId, updateNodesAndEdges]);
+
+  useEffect(() => {
+    if (!reactFlowInstanceRef.current || nodes.length === 0) {
+      return undefined;
+    }
+
+    if (fitViewFrameRef.current) {
+      window.cancelAnimationFrame(fitViewFrameRef.current);
+    }
+
+    fitViewFrameRef.current = window.requestAnimationFrame(() => {
+      void reactFlowInstanceRef.current?.fitView({ padding: 0.22 });
+      fitViewFrameRef.current = undefined;
+    });
+
+    return () => {
+      if (fitViewFrameRef.current) {
+        window.cancelAnimationFrame(fitViewFrameRef.current);
+        fitViewFrameRef.current = undefined;
+      }
+    };
+  }, [nodes, edges]);
 
   useEffect(() => {
     setExpandedUnitIds((prev) => (prev.length === 0 ? prev : []));
@@ -465,6 +493,9 @@ const FlowContents: FC = () => {
                   defaultViewport={defaultViewport}
                   colorMode={theme.palette.mode}
                   nodeTypes={nodeTypes}
+                  onInit={(instance) => {
+                    reactFlowInstanceRef.current = instance;
+                  }}
                   fitView
                   fitViewOptions={{ padding: 0.22 }}
                 >

--- a/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
+++ b/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
@@ -50,12 +50,19 @@ type ExpandedFlowGraphBuildContext = {
   edgeIds: Set<string>;
   visibleUnitIds: Set<string>;
   initialPositions: Map<string, FlowGraphPosition>;
+  parentAnchors: Map<string, string>;
   offsets: Map<string, FlowGraphPosition>;
   positionOverrides: Map<string, FlowGraphPosition>;
   nodeDecorations: Map<string, ExpandedNodeDecoration>;
   unitById: ReadonlyMap<string, AjsUnit>;
   metrics: FlowGraphMetrics;
 };
+
+const compareExpandedUnits = (left: AjsUnit, right: AjsUnit): number =>
+  left.depth - right.depth ||
+  left.layout.v - right.layout.v ||
+  left.layout.h - right.layout.h ||
+  left.absolutePath.localeCompare(right.absolutePath);
 
 const toNodeType = (unit: AjsUnit): FlowGraphNodeType => {
   switch (unit.unitType) {
@@ -188,7 +195,14 @@ const getDisplayPosition = (
   if (!initialPosition) {
     return undefined;
   }
-  return addPositions(initialPosition, getOffset(context, unitId));
+  const parentAnchorId = context.parentAnchors.get(unitId);
+  const anchoredOrigin = parentAnchorId
+    ? getDisplayPosition(context, parentAnchorId)
+    : undefined;
+  return addPositions(
+    addPositions(anchoredOrigin ?? { x: 0, y: 0 }, initialPosition),
+    getOffset(context, unitId),
+  );
 };
 
 const syncPositionOverride = (
@@ -201,13 +215,26 @@ const syncPositionOverride = (
   }
 };
 
+const syncAnchoredDescendantOverrides = (
+  context: ExpandedFlowGraphBuildContext,
+  unitId: string,
+) => {
+  for (const visibleUnitId of context.visibleUnitIds) {
+    if (context.parentAnchors.get(visibleUnitId) !== unitId) {
+      continue;
+    }
+    syncPositionOverride(context, visibleUnitId);
+    syncAnchoredDescendantOverrides(context, visibleUnitId);
+  }
+};
+
 const addOffset = (
   context: ExpandedFlowGraphBuildContext,
   unitId: string,
   delta: FlowGraphPosition,
 ) => {
   if (delta.x === 0 && delta.y === 0) {
-    return;
+    return false;
   }
 
   const offset = getOffset(context, unitId);
@@ -216,6 +243,8 @@ const addOffset = (
     y: offset.y + delta.y,
   });
   syncPositionOverride(context, unitId);
+  syncAnchoredDescendantOverrides(context, unitId);
+  return true;
 };
 
 const addVisibleNode = (
@@ -223,18 +252,22 @@ const addVisibleNode = (
   unit: AjsUnit,
   node: FlowGraphNodeDto,
   initialPosition: FlowGraphPosition,
+  parentAnchorId?: string,
 ) => {
   context.nodes.push(node);
   context.nodeIds.add(unit.id);
   context.visibleUnitIds.add(unit.id);
   context.initialPositions.set(unit.id, initialPosition);
+  if (parentAnchorId) {
+    context.parentAnchors.set(unit.id, parentAnchorId);
+  }
   syncPositionOverride(context, unit.id);
 };
 
 const ensureChildNodeVisible = (
   context: ExpandedFlowGraphBuildContext,
-  expandedUnitPosition: FlowGraphPosition,
   child: AjsUnit,
+  parentUnitId: string,
 ): FlowGraphPosition | undefined => {
   const existingPosition = context.initialPositions.get(child.id);
   if (existingPosition) {
@@ -245,19 +278,25 @@ const ensureChildNodeVisible = (
   }
 
   const childPosition = calculateNestedChildPosition(
-    expandedUnitPosition,
+    { x: 0, y: 0 },
     child.layout.h,
     child.layout.v,
     context.basePx,
   );
-  addVisibleNode(context, child, toGridNode(child), childPosition);
+  addVisibleNode(
+    context,
+    child,
+    toGridNode(child),
+    childPosition,
+    parentUnitId,
+  );
   return childPosition;
 };
 
 const ensureConditionNodeVisible = (
   context: ExpandedFlowGraphBuildContext,
-  expandedUnitPosition: FlowGraphPosition,
   conditionUnit: AjsUnit,
+  parentUnitId: string,
 ): FlowGraphPosition | undefined => {
   const existingPosition = context.initialPositions.get(conditionUnit.id);
   if (existingPosition) {
@@ -268,7 +307,7 @@ const ensureConditionNodeVisible = (
   }
 
   const conditionPosition = calculateNestedConditionPosition(
-    expandedUnitPosition,
+    { x: 0, y: 0 },
     context.basePx,
   );
   addVisibleNode(
@@ -276,6 +315,7 @@ const ensureConditionNodeVisible = (
     conditionUnit,
     toConditionNode(conditionUnit),
     conditionPosition,
+    parentUnitId,
   );
   return conditionPosition;
 };
@@ -305,6 +345,7 @@ const toDecorationFromBounds = (
 });
 
 const buildPanelBoundsFromSubtreeBounds = (
+  position: FlowGraphPosition,
   bounds: FlowGraphBounds,
   metrics: FlowGraphMetrics,
 ): FlowGraphBounds => {
@@ -313,150 +354,303 @@ const buildPanelBoundsFromSubtreeBounds = (
   const panelPaddingBottom = metrics.height * 0.35;
 
   return {
-    minX: bounds.minX - panelPaddingX,
+    minX: position.x - panelPaddingX,
     maxX: bounds.maxX + panelPaddingX,
-    minY: bounds.minY - panelPaddingTop,
+    minY: position.y - panelPaddingTop,
     maxY: bounds.maxY + panelPaddingBottom,
   };
 };
 
-const buildExpandedUnitRevealBounds = (
+const buildUnitBaseBounds = (
+  position: FlowGraphPosition,
+  metrics: FlowGraphMetrics,
+): FlowGraphBounds => ({
+  minX: position.x - metrics.width * 0.3,
+  maxX: position.x + metrics.width * 1.3,
+  minY: position.y - metrics.height * 0.2,
+  maxY: position.y + metrics.height * 1.35,
+});
+
+const revealVisibleNestedUnit = (
   context: ExpandedFlowGraphBuildContext,
   expandedUnit: AjsUnit,
-): FlowGraphBounds | undefined => {
-  const expandedUnitPosition = getDisplayPosition(context, expandedUnit.id);
-  if (!expandedUnitPosition) {
-    return undefined;
+) => {
+  if (!getDisplayPosition(context, expandedUnit.id)) {
+    return;
   }
-
-  const bounds: FlowGraphBounds = {
-    minX: expandedUnitPosition.x,
-    maxX: expandedUnitPosition.x + context.metrics.width,
-    minY: expandedUnitPosition.y,
-    maxY: expandedUnitPosition.y + context.metrics.height,
-  };
 
   for (const child of expandedUnit.children.filter(
     (unit) => unit.unitType !== "rc",
   )) {
-    const childPosition = ensureChildNodeVisible(
-      context,
-      expandedUnitPosition,
-      child,
-    );
-    if (!childPosition) {
-      continue;
-    }
-    const childDisplayPosition = getDisplayPosition(context, child.id);
-    if (!childDisplayPosition) {
-      continue;
-    }
-    includeNodeBounds(
-      bounds,
-      childDisplayPosition,
-      context.metrics.width,
-      context.metrics.height,
-    );
+    ensureChildNodeVisible(context, child, expandedUnit.id);
   }
 
   const conditionUnit = expandedUnit.children.find(
     (child) => child.unitType === "rc",
   );
   if (conditionUnit) {
-    const conditionPosition = ensureConditionNodeVisible(
-      context,
-      expandedUnitPosition,
-      conditionUnit,
-    );
-    const conditionDisplayPosition = getDisplayPosition(
-      context,
-      conditionUnit.id,
-    );
-    if (conditionPosition && conditionDisplayPosition) {
-      includeNodeBounds(
-        bounds,
-        conditionDisplayPosition,
-        context.metrics.width,
-        context.metrics.height,
-      );
-    }
+    ensureConditionNodeVisible(context, conditionUnit, expandedUnit.id);
   }
 
-  return bounds;
+  appendExpandedUnitEdges(context, expandedUnit);
 };
 
-const applyExpansionOffsets = (
+const buildExpandedUnitPanelBounds = (
+  context: ExpandedFlowGraphBuildContext,
+  expandedUnit: AjsUnit,
+): FlowGraphBounds | undefined => {
+  const expandedUnitPosition = getDisplayPosition(context, expandedUnit.id);
+  const decoration = context.nodeDecorations.get(expandedUnit.id);
+  if (!expandedUnitPosition) {
+    return undefined;
+  }
+  if (!decoration) {
+    return buildUnitBaseBounds(expandedUnitPosition, context.metrics);
+  }
+  return {
+    minX: expandedUnitPosition.x + decoration.panelOffsetXPx,
+    maxX:
+      expandedUnitPosition.x +
+      decoration.panelOffsetXPx +
+      decoration.panelWidthPx,
+    minY: expandedUnitPosition.y + decoration.panelOffsetYPx,
+    maxY:
+      expandedUnitPosition.y +
+      decoration.panelOffsetYPx +
+      decoration.panelHeightPx,
+  };
+};
+
+const applyGrowthOffsets = (
   context: ExpandedFlowGraphBuildContext,
   expandedUnitPosition: FlowGraphPosition,
-  panelBounds: FlowGraphBounds,
-  excludedUnitIds: ReadonlySet<string>,
+  horizontalGrowth: number,
+  verticalGrowth: number,
+  targetUnitIds: ReadonlySet<string>,
 ) => {
-  const clearanceX = context.metrics.width * 0.12;
-  const clearanceY = context.metrics.height * 0.12;
-  const horizontalOffset = Math.max(
-    0,
-    panelBounds.maxX -
-      (expandedUnitPosition.x + context.metrics.width) +
-      clearanceX,
-  );
-  const verticalOffset = Math.max(
-    0,
-    panelBounds.maxY -
-      (expandedUnitPosition.y + context.metrics.height) +
-      clearanceY,
-  );
+  if (horizontalGrowth === 0 && verticalGrowth === 0) {
+    return false;
+  }
 
-  const positionsBeforeExpansionOffset = new Map<string, FlowGraphPosition>();
+  const positionsBeforeOffset = new Map<string, FlowGraphPosition>();
   for (const unitId of context.visibleUnitIds) {
     const displayPosition = getDisplayPosition(context, unitId);
     if (displayPosition) {
-      positionsBeforeExpansionOffset.set(unitId, displayPosition);
+      positionsBeforeOffset.set(unitId, displayPosition);
     }
   }
 
-  for (const [unitId, displayPosition] of positionsBeforeExpansionOffset) {
-    if (excludedUnitIds.has(unitId)) {
+  let changed = false;
+  for (const [unitId, displayPosition] of positionsBeforeOffset) {
+    if (!targetUnitIds.has(unitId)) {
       continue;
     }
     const isRight = displayPosition.x > expandedUnitPosition.x;
     const isBelow = displayPosition.y > expandedUnitPosition.y;
     const isSameX = displayPosition.x === expandedUnitPosition.x;
     const isSameY = displayPosition.y === expandedUnitPosition.y;
-    const dx = isRight && (isBelow || isSameY) ? horizontalOffset : 0;
-    const dy = isBelow && (isRight || isSameX) ? verticalOffset : 0;
+    const dx = isRight && (isBelow || isSameY) ? horizontalGrowth : 0;
+    const dy =
+      isBelow && (isRight || isSameX)
+        ? Math.max(0, verticalGrowth - getOffset(context, unitId).y)
+        : 0;
     if (dx === 0 && dy === 0) {
       continue;
     }
-    addOffset(context, unitId, { x: dx, y: dy });
+    changed = addOffset(context, unitId, { x: dx, y: dy }) || changed;
   }
+
+  return changed;
 };
 
-const expandVisibleNestedUnit = (
+const getVisibleImmediateChildren = (
+  context: ExpandedFlowGraphBuildContext,
+  containerUnitId: string,
+): AjsUnit[] =>
+  [...context.visibleUnitIds]
+    .map((unitId) => context.unitById.get(unitId))
+    .filter(
+      (unit): unit is AjsUnit => !!unit && unit.parentId === containerUnitId,
+    )
+    .sort(compareExpandedUnits);
+
+const updateExpandedNodeDecoration = (
   context: ExpandedFlowGraphBuildContext,
   expandedUnit: AjsUnit,
 ) => {
-  const expandedUnitPosition = getDisplayPosition(context, expandedUnit.id);
-  const revealBounds = buildExpandedUnitRevealBounds(context, expandedUnit);
-  if (!revealBounds || !expandedUnitPosition) {
+  const expandedUnitPosition = context.positionOverrides.get(expandedUnit.id);
+  const panelBounds = buildExpandedPanelBounds(
+    expandedUnit,
+    context.visibleUnitIds,
+    context.unitById,
+    context.positionOverrides,
+    context.nodeDecorations,
+    context.metrics,
+  );
+  if (!expandedUnitPosition || !panelBounds) {
+    return;
+  }
+  context.nodeDecorations.set(
+    expandedUnit.id,
+    toDecorationFromBounds(expandedUnitPosition, panelBounds),
+  );
+};
+
+const getUpperExpandedPanelMaxRight = (
+  context: ExpandedFlowGraphBuildContext,
+  expandedChildren: ReadonlyArray<AjsUnit>,
+  expandedChild: AjsUnit,
+  expandedChildPosition: FlowGraphPosition,
+): number | undefined => {
+  let maxRight: number | undefined;
+  for (const upperCandidate of expandedChildren) {
+    if (upperCandidate.id === expandedChild.id) {
+      continue;
+    }
+    const upperPosition = getDisplayPosition(context, upperCandidate.id);
+    const upperPanelBounds = buildExpandedUnitPanelBounds(
+      context,
+      upperCandidate,
+    );
+    if (
+      !upperPosition ||
+      !upperPanelBounds ||
+      upperPosition.y >= expandedChildPosition.y
+    ) {
+      continue;
+    }
+    maxRight =
+      maxRight === undefined
+        ? upperPanelBounds.maxX
+        : Math.max(maxRight, upperPanelBounds.maxX);
+  }
+  return maxRight;
+};
+
+const doBoundsOverlapHorizontally = (
+  upperBounds: FlowGraphBounds,
+  lowerBounds: FlowGraphBounds,
+) => upperBounds.minX < lowerBounds.maxX && lowerBounds.minX < upperBounds.maxX;
+
+const resolveLowerExpandedPanelIntrusions = (
+  context: ExpandedFlowGraphBuildContext,
+  expandedChildren: ReadonlyArray<AjsUnit>,
+  activeExpandedUnitId: string | undefined,
+) => {
+  if (!activeExpandedUnitId) {
     return;
   }
 
-  appendExpandedUnitEdges(context, expandedUnit);
+  for (const upperChild of expandedChildren) {
+    if (upperChild.id !== activeExpandedUnitId) {
+      continue;
+    }
 
-  const panelBounds = buildPanelBoundsFromSubtreeBounds(
-    revealBounds,
-    context.metrics,
-  );
-  applyExpansionOffsets(
+    const upperPosition = getDisplayPosition(context, upperChild.id);
+    const upperPanelBounds = buildExpandedUnitPanelBounds(context, upperChild);
+    if (!upperPosition || !upperPanelBounds) {
+      continue;
+    }
+
+    for (const lowerChild of expandedChildren) {
+      if (upperChild.id === lowerChild.id) {
+        continue;
+      }
+
+      const lowerPosition = getDisplayPosition(context, lowerChild.id);
+      const lowerPanelBounds = buildExpandedUnitPanelBounds(
+        context,
+        lowerChild,
+      );
+      if (
+        !lowerPosition ||
+        !lowerPanelBounds ||
+        upperPosition.y >= lowerPosition.y ||
+        upperPanelBounds.maxY <= lowerPanelBounds.minY ||
+        !doBoundsOverlapHorizontally(upperPanelBounds, lowerPanelBounds)
+      ) {
+        continue;
+      }
+
+      addOffset(context, lowerChild.id, {
+        x: 0,
+        y: upperPanelBounds.maxY - lowerPanelBounds.minY,
+      });
+    }
+  }
+};
+
+const relayoutExpandedScope = (
+  context: ExpandedFlowGraphBuildContext,
+  containerUnit: AjsUnit,
+  expandedUnitIdSet: ReadonlySet<string>,
+  activeExpandedUnitId: string | undefined,
+) => {
+  const expandedChildren = containerUnit.children
+    .filter(
+      (unit): unit is AjsUnit =>
+        expandedUnitIdSet.has(unit.id) && isNestedJobnetUnit(unit),
+    )
+    .sort(compareExpandedUnits);
+
+  for (const expandedChild of expandedChildren) {
+    revealVisibleNestedUnit(context, expandedChild);
+    relayoutExpandedScope(
+      context,
+      expandedChild,
+      expandedUnitIdSet,
+      activeExpandedUnitId,
+    );
+    updateExpandedNodeDecoration(context, expandedChild);
+  }
+
+  resolveLowerExpandedPanelIntrusions(
     context,
-    expandedUnitPosition,
-    panelBounds,
-    collectVisibleSubtreeUnitIds(
-      expandedUnit,
-      context.visibleUnitIds,
-      context.unitById,
-    ),
+    expandedChildren,
+    activeExpandedUnitId,
   );
+
+  const immediateVisibleChildren = getVisibleImmediateChildren(
+    context,
+    containerUnit.id,
+  );
+
+  for (const expandedChild of expandedChildren) {
+    const expandedChildPosition = getDisplayPosition(context, expandedChild.id);
+    const panelBounds = buildExpandedUnitPanelBounds(context, expandedChild);
+    if (!expandedChildPosition || !panelBounds) {
+      continue;
+    }
+
+    const baseBounds = buildUnitBaseBounds(
+      expandedChildPosition,
+      context.metrics,
+    );
+    const upperPanelMaxRight = getUpperExpandedPanelMaxRight(
+      context,
+      expandedChildren,
+      expandedChild,
+      expandedChildPosition,
+    );
+    const horizontalGrowth =
+      upperPanelMaxRight === undefined
+        ? Math.max(0, panelBounds.maxX - baseBounds.maxX)
+        : Math.max(0, panelBounds.maxX - upperPanelMaxRight);
+    const verticalGrowth = Math.max(0, panelBounds.maxY - baseBounds.maxY);
+    const targetUnitIds = new Set(
+      immediateVisibleChildren
+        .filter((unit) => unit.id !== expandedChild.id)
+        .map((unit) => unit.id),
+    );
+
+    applyGrowthOffsets(
+      context,
+      expandedChildPosition,
+      horizontalGrowth,
+      verticalGrowth,
+      targetUnitIds,
+    );
+  }
 };
 
 const buildExpandedPanelBounds = (
@@ -498,68 +692,17 @@ const buildExpandedPanelBounds = (
     }
   }
 
-  const panelPaddingX = metrics.width * 0.3;
-  const panelPaddingTop = metrics.height * 0.2;
-  const panelPaddingBottom = metrics.height * 0.35;
-
-  return {
-    minX: subtreeBounds.minX - panelPaddingX,
-    maxX: subtreeBounds.maxX + panelPaddingX,
-    minY: subtreeBounds.minY - panelPaddingTop,
-    maxY: subtreeBounds.maxY + panelPaddingBottom,
-  };
-};
-
-const updateExpandedNodeDecorations = (
-  context: ExpandedFlowGraphBuildContext,
-  expandedUnits: ReadonlyArray<AjsUnit>,
-) => {
-  context.nodeDecorations.clear();
-  for (const expandedUnit of [...expandedUnits].reverse()) {
-    const expandedUnitPosition = context.positionOverrides.get(expandedUnit.id);
-    const panelBounds = buildExpandedPanelBounds(
-      expandedUnit,
-      context.visibleUnitIds,
-      context.unitById,
-      context.positionOverrides,
-      context.nodeDecorations,
-      context.metrics,
-    );
-    if (!expandedUnitPosition || !panelBounds) {
-      continue;
-    }
-    context.nodeDecorations.set(
-      expandedUnit.id,
-      toDecorationFromBounds(expandedUnitPosition, panelBounds),
-    );
-  }
-};
-
-const collectVisibleSubtreeUnitIds = (
-  expandedUnit: AjsUnit,
-  visibleUnitIds: ReadonlySet<string>,
-  unitById: ReadonlyMap<string, AjsUnit>,
-): Set<string> => {
-  const subtreeUnitIds = new Set<string>();
-  for (const unitId of visibleUnitIds) {
-    const unit = unitById.get(unitId);
-    if (!unit) {
-      continue;
-    }
-    if (
-      unit.id === expandedUnit.id ||
-      isDescendantOf(unit, expandedUnit.id, unitById)
-    ) {
-      subtreeUnitIds.add(unitId);
-    }
-  }
-  return subtreeUnitIds;
+  return buildPanelBoundsFromSubtreeBounds(
+    parentPosition,
+    subtreeBounds,
+    metrics,
+  );
 };
 
 export const buildExpandedFlowGraph = (
   document: AjsDocument,
   currentUnitId: string,
-  expandedUnitIds: ReadonlySet<string>,
+  expandedUnitIds: ReadonlySet<string> | readonly string[],
   basePx: number,
 ): ExpandedFlowGraphResult => {
   const baseGraph = buildFlowGraph(document, currentUnitId);
@@ -578,6 +721,7 @@ export const buildExpandedFlowGraph = (
   const edgeIds = new Set(edges.map((edge) => `${edge.source}-${edge.target}`));
   const initialPositions = new Map<string, FlowGraphPosition>();
   const offsets = new Map<string, FlowGraphPosition>();
+  const parentAnchors = new Map<string, string>();
   const positionOverrides = new Map<string, FlowGraphPosition>();
   const nodeDecorations = new Map<string, ExpandedNodeDecoration>();
 
@@ -604,6 +748,7 @@ export const buildExpandedFlowGraph = (
     edgeIds,
     visibleUnitIds,
     initialPositions,
+    parentAnchors,
     offsets,
     positionOverrides,
     nodeDecorations,
@@ -611,22 +756,28 @@ export const buildExpandedFlowGraph = (
     metrics,
   };
 
-  const sortedExpandedUnits = [...expandedUnitIds]
-    .map((unitId) => unitById.get(unitId))
-    .filter(
-      (unit): unit is AjsUnit =>
+  const expandedUnitIdList = [...expandedUnitIds];
+  const activeExpandedUnitId = Array.isArray(expandedUnitIds)
+    ? expandedUnitIds.at(-1)
+    : undefined;
+  const expandedUnitIdSet = new Set(
+    expandedUnitIdList.filter((unitId) => {
+      const unit = unitById.get(unitId);
+      return (
         !!unit &&
         unit.id !== currentUnitId &&
         isNestedJobnetUnit(unit) &&
-        isDescendantOf(unit, currentUnitId, unitById),
-    )
-    .sort((left, right) => left.depth - right.depth);
+        isDescendantOf(unit, currentUnitId, unitById)
+      );
+    }),
+  );
 
-  for (const expandedUnit of sortedExpandedUnits) {
-    expandVisibleNestedUnit(context, expandedUnit);
-  }
-
-  updateExpandedNodeDecorations(context, sortedExpandedUnits);
+  relayoutExpandedScope(
+    context,
+    currentUnit,
+    expandedUnitIdSet,
+    activeExpandedUnitId,
+  );
 
   return {
     graph: {


### PR DESCRIPTION
## Summary
- fix nested flow expansion layout so panel growth and sibling offsets follow the current visible bounds rules
- keep flow viewport fit-to-view responsive after expand and collapse by refitting to the latest rendered nodes
- refresh the flow-graph SDD and sample/test coverage to match the current nested expansion behavior

## Validation
- npm run build
- npm test
- npm run qlty
- npm run lint:md