### PR TITLE
[codex] Document JP1 WebAPI import boundary

### DIFF
--- a/docs/requirements/use-cases/uc-import-ajs-definition-via-webapi.md
+++ b/docs/requirements/use-cases/uc-import-ajs-definition-via-webapi.md
@@ -7,7 +7,8 @@ the extension is not limited to local definition files.
 
 ## Trigger
 
-- the user requests server-side JP1/AJS definition data
+- the user runs a read-only import command from VS Code to request server-side
+  JP1/AJS definition data
 - the application needs to load a definition source exposed by the JP1/AJS
   WebAPI
 
@@ -15,20 +16,37 @@ the extension is not limited to local definition files.
 
 - target server or connection context
 - API request parameters needed to identify the definition scope to load
-- authentication context required by the JP1/AJS WebAPI
+- authentication reference required by the JP1/AJS WebAPI, resolved by
+  infrastructure rather than passed through domain logic
 
 ## Outputs
 
 - read-only definition data that downstream parsing, normalization, list, or
   flow features can consume
+- structured import errors for cancellation, unsupported host, authentication,
+  authorization, network, timeout, unexpected-status, and response-shape
+  failures
 
 ## Rules
 
 - initial scope is read-only import only
+- initial availability is beta until real JP1/AJS3 environment verification is
+  recorded and beta exit criteria are met
+- request construction, authentication, response parsing, and error mapping
+  must follow the JP1/AJS3 version 13 API reference unless a documented product
+  or host compatibility constraint requires a narrower first slice
+- a repository-local OpenAPI contract may define the supported subset for
+  generated mocks and stubs, but it must remain traceable to the JP1/AJS3
+  version 13 API reference
 - WebAPI transport, authentication, and endpoint details must remain behind an
   infrastructure boundary
 - imported definition data should be converted to stable application-facing
   structures before presentation-specific handling
+- webview modules must not perform WebAPI transport or credential handling
+- browser-hosted execution must not rely on Node-only APIs; if a browser-safe
+  adapter is not available, the import result must report unsupported host
+- server responses must not be exposed directly to list, flow, CSV,
+  diagnostics, hover, or unit-definition presentation code
 
 ## Acceptance Notes
 
@@ -38,6 +56,11 @@ the extension is not limited to local definition files.
   contracts instead of direct WebAPI response objects
 - desktop and web compatibility implications are documented explicitly for the
   chosen transport approach
+- authentication and error-reporting behavior is explicit before implementation
+  starts
+- generated mocks or stubs can exercise supported success and failure paths
+  without requiring a live JP1/AJS3 server for every test run
+- beta labeling makes limited real-environment validation visible to users
 
 ## Risks Or Edge Cases
 
@@ -47,3 +70,7 @@ the extension is not limited to local definition files.
   shape directly
 - read-only import scope can still require careful error handling, timeouts,
   and partial-data reporting
+- user-facing errors must not leak credentials, raw tokens, file content,
+  definition content, or server-provided secrets
+- generated mocks can hide server-specific behavior differences, so beta exit
+  requires recorded smoke verification against a real JP1/AJS3 environment

--- a/docs/specs/features/import-definition-via-webapi/PLANS.md
+++ b/docs/specs/features/import-definition-via-webapi/PLANS.md
@@ -10,13 +10,98 @@ Define and deliver the first read-only JP1/AJS WebAPI import slice.
 - define infrastructure boundaries for API access
 - clarify downstream mapping into existing parsing or normalization flows
 
+## Current Decision
+
+The first user-visible import trigger is a VS Code command contributed by the
+extension host. The command collects connection and definition-scope input,
+then calls an application use case through an infrastructure-backed WebAPI
+adapter. Webview modules remain consumers of imported results only; they do not
+own transport, authentication, endpoint selection, or response decoding.
+
+The JP1/AJS3 version 13 Command Reference, manual 3021-3-L49-20(E), Part 3 API
+is the normative source for API workflow, authentication, data types, request
+format, response format, configuration components, and API usage notes. The
+implementation should cite the specific manual section used when DTOs,
+transport behavior, authentication behavior, or error mapping are added.
+
+A repository-local OpenAPI contract should be created for the supported subset
+of the JP1/AJS3 WebAPI. The contract is derived from the normative manual and
+exists to stabilize generated mocks, client/test stubs, and compatibility
+tests. It is not an independent source of product truth.
+
+Imported WebAPI data should pass through a dedicated adapter-to-normalized
+definition seam before reaching list, flow, definition, diagnostics, hover, or
+CSV features. The existing local-file parser may be reused only when the API
+returns definition text with the same contract as local AJS definition input.
+
+Desktop support is the first implementation target. Browser-hosted extension
+support must either use an explicitly tested browser transport/authentication
+adapter or return a structured unsupported-host result without changing shared
+domain or application code.
+
+The initial user-facing feature should ship as beta because verification
+against real JP1/AJS3 environments is expected to be limited. OpenAPI-generated
+mocks and stubs stabilize the boundary, but they do not replace real server
+smoke evidence.
+
 ## Milestones
 
 1. Confirm WebAPI scope and host constraints
-2. Define import DTOs or equivalent application-facing results
-3. Design infrastructure adapters for transport and authentication
-4. Add focused integration and compatibility checks
-5. Update docs and remaining follow-up tasks
+2. Audit the JP1/AJS3 version 13 API reference sections needed by the first
+   import endpoint
+3. Define the first endpoint in OpenAPI with manual-section traceability
+4. Generate mock server and infrastructure/test stubs from the OpenAPI contract
+5. Define request, result, normalized-content, and error DTOs
+6. Design desktop infrastructure adapters for transport and authentication
+7. Add command registration and user input flow outside webview modules
+8. Add focused integration and compatibility checks
+9. Revisit browser-hosted transport only after the desktop slice is stable
+10. Update docs and remaining follow-up tasks
+
+## Boundary Sketch
+
+- presentation/extension command: prompts for import inputs and displays
+  recoverable errors
+- application use case: validates request DTOs, calls the import port, and
+  returns normalized definition content or structured errors
+- infrastructure adapter: resolves endpoint and credentials, performs WebAPI
+  requests, decodes responses, maps transport failures, and never leaks raw
+  response objects past the port
+- OpenAPI-generated mock/stub layer: supports infrastructure and integration
+  tests without becoming an application or domain dependency
+- domain/normalization: receives only product concepts that match existing AJS
+  document semantics
+
+## OpenAPI Workflow
+
+1. Trace the selected endpoint to JP1/AJS3 version 13 manual sections.
+2. Add or update the repository-local OpenAPI source for that endpoint under
+   `docs/specs/features/import-definition-via-webapi/openapi/`.
+3. Generate mock server and test/infrastructure stubs from the OpenAPI source.
+4. Add tests that exercise the application port through generated mocks.
+5. Verify generated artifacts are reproducible from the checked-in contract.
+
+## OpenAPI File Placement
+
+- OpenAPI source contracts live under
+  `docs/specs/features/import-definition-via-webapi/openapi/`.
+- Generated runtime or infrastructure artifacts should live outside `domain`
+  and `application`, for example under an infrastructure-specific generated
+  path.
+- Generated mock, fixture, or test stubs should live under test-oriented paths.
+- Generated files must be reproducible from checked-in OpenAPI sources and
+  should not be hand-edited.
+
+## Beta Exit Criteria
+
+- supported endpoint behavior is traced to JP1/AJS3 version 13 manual sections
+- generated OpenAPI mock/stub artifacts are reproducible
+- automated tests cover success, authentication failure, authorization failure,
+  timeout, unexpected status, malformed response, and unsupported host behavior
+- at least one real JP1/AJS3 environment smoke verification is recorded with
+  product version and tested scenario
+- release notes or user documentation no longer need to warn that the feature
+  has limited real-environment validation
 
 ## Validation
 

--- a/docs/specs/features/import-definition-via-webapi/SPECS.md
+++ b/docs/specs/features/import-definition-via-webapi/SPECS.md
@@ -8,22 +8,107 @@ Add a read-only JP1/AJS WebAPI import path for server-side definition data.
 
 - Source use case:
   docs/requirements/use-cases/uc-import-ajs-definition-via-webapi.md
+- Normative API reference:
+  JP1 Version 13 JP1/Automatic Job Management System 3 Command Reference,
+  manual 3021-3-L49-20(E), Part 3 API
+  (<https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/INDEX.HTM>)
 
 ## Acceptance Criteria
 
 - initial scope is explicitly read-only
+- initial user-facing availability is beta until real JP1/AJS3 environment
+  verification is sufficient
 - application and infrastructure responsibilities are named before
   implementation starts
 - downstream consumers do not depend directly on raw WebAPI transport objects
 - desktop and web compatibility risks are called out explicitly
+- the first user-visible trigger is a VS Code command that opens an import
+  input flow outside webview presentation code
+- authentication failures, connectivity failures, unsupported web-host access,
+  and malformed responses are reported as recoverable import errors
+- the first implemented endpoint has a repository-local OpenAPI contract that
+  traces back to the JP1/AJS3 version 13 API reference
+- mock server and client/test stubs are generated from the OpenAPI contract for
+  stable integration and compatibility testing
 
 ## Implementation Notes
 
+- implement request, authentication, response, and error handling according to
+  the JP1/AJS3 version 13 API chapters before adding repository-local
+  assumptions
+- present the feature as beta in command labels, release notes, or user-facing
+  documentation until the beta exit criteria are met
+- use OpenAPI as a derived, testable contract for the subset of JP1/AJS3 WebAPI
+  endpoints this extension supports; do not treat it as a replacement for the
+  normative manual
+- keep generated mock/stub code out of domain logic and avoid hand-editing
+  generated artifacts
 - keep network transport and authentication outside domain logic
 - design imported-data normalization so local-file and WebAPI-backed flows can
   converge on stable downstream contracts where practical
 - document host-specific constraints early because browser-hosted execution may
   not support the same connection model as desktop
+- expose the first import path through an extension command, then hand off to
+  an application use case such as `ImportAjsDefinitionViaWebApi`
+- keep endpoint construction, credential retrieval, request execution, timeout
+  handling, and response decoding in infrastructure adapters
+- keep the application boundary focused on request DTOs, read-only import
+  results, normalized definition content, and structured errors
+- prefer a separate WebAPI response-to-normalized-definition seam over feeding
+  raw WebAPI response objects directly into the existing local-file parser; use
+  the existing parser only if the API returns definition text that is explicitly
+  equivalent to local AJS definition input
+
+## Host Constraints
+
+- desktop extension execution may use VS Code secret storage and desktop-safe
+  HTTP transport adapters behind infrastructure
+- web extension execution must not assume Node-only networking, filesystem,
+  process, proxy, certificate, or credential-store APIs
+- web-host import should be disabled or reported as unsupported until a browser
+  transport and authentication model are explicitly implemented and tested
+- shared domain and application modules must stay free of direct `vscode`,
+  Node-only, or WebAPI transport imports
+
+## Error And Authentication Policy
+
+- credentials are configuration or secret-storage concerns, not DTO fields
+  passed into domain logic
+- error DTOs should distinguish cancellation, authentication failure,
+  authorization failure, network or timeout failure, unsupported host,
+  unexpected status, and response-shape mismatch
+- error messages shown to users must avoid echoing credentials, raw tokens,
+  server-provided secrets, or imported definition content
+
+## OpenAPI And Test Stability
+
+- add OpenAPI coverage endpoint by endpoint, starting with the first read-only
+  import endpoint rather than attempting the whole JP1/AJS3 API surface
+- keep OpenAPI source contracts under
+  `docs/specs/features/import-definition-via-webapi/openapi/`
+- record manual section references in the OpenAPI description, adjacent
+  traceability notes, or both
+- generate a mock server from the OpenAPI contract so extension-side tests can
+  cover success, authentication failure, authorization failure, timeout,
+  unexpected status, and malformed-response paths without a live JP1/AJS3
+  server
+- generate client or response stubs only at infrastructure/test boundaries;
+  application use cases should depend on repository-owned ports and DTOs
+- add validation that generated artifacts are reproducible from the checked-in
+  OpenAPI source
+
+## Beta Availability
+
+- provide the read-only WebAPI import path as beta while real JP1/AJS3
+  environment verification remains limited
+- beta scope still requires automated tests through generated mocks/stubs,
+  structured error handling, and explicit desktop/web compatibility behavior
+- do not advertise update/write scenarios or broad endpoint coverage during
+  beta
+- exit beta only after the first supported import path has documented manual
+  traceability, reproducible OpenAPI-generated artifacts, automated success and
+  failure-path coverage, and recorded smoke verification against a real JP1/AJS3
+  environment
 
 ## Non-Goals
 

--- a/docs/specs/features/import-definition-via-webapi/TASKS.md
+++ b/docs/specs/features/import-definition-via-webapi/TASKS.md
@@ -10,16 +10,60 @@
 ## Completed
 
 - [x] Record read-only JP1/AJS WebAPI import as a planned feature slice
+- [x] Identify the first user-visible import trigger
+- [x] Document desktop and web host constraints for WebAPI access
+- [x] Decide whether imported data feeds the existing parser directly or
+      requires a separate normalization seam
+- [x] Define authentication and error-reporting expectations
+- [x] Record the JP1/AJS3 version 13 API reference as the normative source for
+      implementation
+- [x] Record OpenAPI-generated mocks and stubs as the stability strategy for
+      the first import implementation
+- [x] Define the repository-local OpenAPI source placement
+- [x] Record beta availability until real JP1/AJS3 environment verification is
+      sufficient
 
 ## Follow-up
 
-- [ ] Identify the first user-visible import trigger
-- [ ] Document desktop and web host constraints for WebAPI access
-- [ ] Decide whether imported data feeds the existing parser directly or
-      requires a separate normalization seam
-- [ ] Define authentication and error-reporting expectations
+- [ ] Audit the JP1/AJS3 version 13 API reference sections needed by the first
+      import endpoint and record traceability before implementation
+- [ ] Define the first supported read-only import endpoint in a repository-local
+      OpenAPI contract under
+      `docs/specs/features/import-definition-via-webapi/openapi/`
+- [ ] Generate a mock server and infrastructure/test stubs from the OpenAPI
+      contract
+- [ ] Add reproducibility checks for generated OpenAPI artifacts
+- [ ] Define request, result, normalized-content, and error DTOs for the first
+      desktop read-only import slice
+- [ ] Implement the extension command and desktop infrastructure adapter behind
+      the application import port
+- [ ] Add compatibility tests that keep shared domain/application paths free of
+      WebAPI transport, Node-only, and webview dependencies
+- [ ] Add beta labeling to the command, release notes, or user-facing docs when
+      the first implementation ships
+- [ ] Record real JP1/AJS3 environment smoke verification before exiting beta
 
 ## Notes
 
 - 2026-04-18: scope is intentionally limited to loading server-side
   definitions; update and save scenarios are deferred.
+- 2026-04-26: the first user-visible trigger is a VS Code command that starts a
+  read-only import input flow. Desktop is the first supported host. Web-hosted
+  execution must use an explicitly tested browser adapter or return a
+  structured unsupported-host result. Raw WebAPI responses should map through a
+  dedicated normalization seam unless the API returns local-file-equivalent AJS
+  definition text.
+- 2026-04-26: API implementation should follow the JP1 Version 13
+  JP1/Automatic Job Management System 3 Command Reference, manual
+  3021-3-L49-20(E), Part 3 API.
+- 2026-04-26: OpenAPI should be used as a repository-local, manual-derived
+  contract for supported endpoints so mock servers and infrastructure/test
+  stubs can be generated reproducibly.
+- 2026-04-26: OpenAPI source contracts live under
+  `docs/specs/features/import-definition-via-webapi/openapi/`; generated
+  artifacts should live outside domain/application code and must be
+  reproducible from the checked-in contracts.
+- 2026-04-26: read-only WebAPI import should be offered as beta until real
+  JP1/AJS3 environment smoke verification is recorded. Generated mocks/stubs
+  stabilize automated tests but do not count as beta-exit evidence by
+  themselves.

--- a/docs/specs/features/import-definition-via-webapi/openapi/README.md
+++ b/docs/specs/features/import-definition-via-webapi/openapi/README.md
@@ -1,0 +1,37 @@
+# OpenAPI Contract: import-definition-via-webapi
+
+## Purpose
+
+This directory contains repository-local OpenAPI contracts for the supported
+subset of the JP1/AJS3 WebAPI used by the read-only import feature.
+
+The OpenAPI files are derived from the JP1 Version 13 JP1/Automatic Job
+Management System 3 Command Reference, manual 3021-3-L49-20(E), Part 3 API.
+They are testable contracts for this repository, not replacements for the
+normative product manual.
+
+## Layout
+
+- `jp1-ajs3-webapi.v13.openapi.yaml`: source contract for supported JP1/AJS3
+  version 13 WebAPI endpoints
+
+## Generation Policy
+
+- Hand-edit OpenAPI source files in this directory.
+- Do not hand-edit generated mock, client, or stub artifacts.
+- Keep generated runtime or infrastructure artifacts outside `domain` and
+  `application` modules.
+- Prefer generated test artifacts under a test or fixture path, and generated
+  infrastructure artifacts under an infrastructure-specific generated path.
+- Add or update generation scripts when generated artifacts are introduced so
+  the checked-in outputs can be reproduced from the OpenAPI source.
+
+## Traceability
+
+Each supported endpoint should record the JP1/AJS3 manual section used for:
+
+- API workflow and authentication
+- request path, method, headers, parameters, and body
+- response status, headers, and body
+- error response mapping
+- API usage notes and host constraints

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -45,17 +45,37 @@ under `docs/requirements/use-cases/`.
   product need appears.
 - Parameter-reference alignment should proceed in small JP1/AJS v13 slices
   with explicit manual coverage.
+- The first read-only JP1/AJS WebAPI import trigger is an extension command on
+  the desktop host. Imported data should cross an application import port and a
+  normalization seam before downstream list, flow, CSV, diagnostics, hover, or
+  unit-definition presentation code sees it.
+- JP1/AJS WebAPI implementation should follow JP1 Version 13
+  JP1/Automatic Job Management System 3 Command Reference, manual
+  3021-3-L49-20(E), Part 3 API.
+- OpenAPI should be used as a repository-local, manual-derived contract for the
+  supported WebAPI subset so mocks, infrastructure/test stubs, and
+  reproducibility checks can stabilize implementation. OpenAPI source contracts
+  live under `docs/specs/features/import-definition-via-webapi/openapi/`.
+- Read-only JP1/AJS WebAPI import should be offered as beta until real JP1/AJS3
+  environment smoke verification is recorded.
 
 ### Next Priority Tasks
 
 1. Align parameter parsing with JP1/Automatic Job Management System 3 version
    13 reference manuals when a behavior-changing parameter slice needs
    per-key coverage beyond the current audit summary.
-2. Define a read-only JP1/AJS WebAPI import boundary with clear application
-   and infrastructure responsibilities.
-3. Extend list-view search on the current presentation path so parameter key
+2. Audit the JP1/AJS3 version 13 API reference sections needed by the first
+   read-only WebAPI import endpoint and record traceability.
+3. Define the first supported endpoint in OpenAPI and generate mock/stub
+   artifacts for infrastructure and integration tests.
+4. Define request, result, normalized-content, and structured-error DTOs for
+   the first desktop read-only JP1/AJS WebAPI import slice.
+5. Implement the beta-labeled extension command and desktop infrastructure
+   adapter behind the application WebAPI import port.
+6. Record real JP1/AJS3 smoke verification before removing beta labeling.
+7. Extend list-view search on the current presentation path so parameter key
    and value queries complement existing rendered-row partial matching.
-4. Keep desktop and web compatibility explicit whenever bootstrap, preview,
+8. Keep desktop and web compatibility explicit whenever bootstrap, preview,
    parsing, shared adapters, or runtime behavior change.
 
 ## Wrapper Semantics Matrix

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -42,6 +42,7 @@
 1. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference, starting from the documented audit of
    current shared parameter-semantics seams.
+
    - Add traceability from JP1/AJS v13 manual sections to supported parameter
      keys, parser behavior, normalized model fields, use cases, and regression
      tests.
@@ -52,15 +53,29 @@
 
 2. Add a read-only JP1/AJS WebAPI import path for loading server-side
    definition data.
+
    - Keep transport, authentication, and endpoint details in infrastructure.
    - Expose imported definitions through application-facing DTOs or use cases.
    - Reuse the normalized AJS model where imported data represents the same
      product concept as parsed definition files.
    - Keep WebAPI import read-only until the initial boundary and tests are
      stable.
+   - Start with a desktop extension command, a structured application import
+     port, and an unsupported-host result for browser execution until a
+     browser-safe adapter is explicitly designed and tested.
+   - Follow JP1 Version 13 JP1/Automatic Job Management System 3 Command
+     Reference, manual 3021-3-L49-20(E), Part 3 API, and record section-level
+     traceability for the first endpoint implemented.
+   - Define supported endpoints in a repository-local OpenAPI contract derived
+     from the manual, then generate mock servers and infrastructure/test stubs
+     from that contract to keep integration tests stable. Keep OpenAPI source
+     files under `docs/specs/features/import-definition-via-webapi/openapi/`.
+   - Offer the feature as beta until smoke verification against a real JP1/AJS3
+     environment is recorded.
 
 3. Extend list-view search on the current presentation path with parameter key
    and parameter value matching.
+
    - Add parameter key and parameter value matching without prematurely
      introducing a shared search domain.
    - Revisit shared search only when flow, list, or another consumer requires
@@ -68,15 +83,18 @@
 
 4. Replace the custom `UnitEntity` hash implementation with a common algorithm
    only after identity and compatibility checks are refreshed.
+
    - Treat hash behavior as an implementation detail unless persisted or
      user-visible identity semantics are affected.
    - Add compatibility fixtures before changing the algorithm.
 
 5. Consolidate i18n translation files where duplication remains high enough to
    justify the change.
+
    - Keep this as a targeted cleanup, not a broad localization rewrite.
 
 6. Strengthen normalized-model convergence.
+
    - Reduce remaining raw `Unit` and wrapper-oriented dependencies in
      application-facing paths where a stable `AjsDocument` / `AjsUnit` contract
      already exists.
@@ -87,6 +105,7 @@
      and parameter interpretation rules.
 
 7. Introduce stricter parser/infrastructure boundaries.
+
    - Define an application-facing parser or document-loading port.
    - Move concrete parser orchestration behind an adapter boundary when
      practical.


### PR DESCRIPTION
## Summary
- Document the read-only JP1/AJS WebAPI import boundary and beta availability policy.
- Record the JP1/AJS3 v13 Command Reference Part 3 API as the normative source.
- Define OpenAPI contract placement and generated mock/stub stability expectations.

## Validation
- pnpm run lint:md

## Compatibility
- Docs-only change; no runtime behavior changes.
- Future implementation must preserve desktop/web extension boundaries and keep generated OpenAPI artifacts out of domain/application code.