### PR TITLE
[codex] Define JP1 AJS WebAPI import OpenAPI contract

### DIFF
--- a/docs/specs/features/import-definition-via-webapi/PLANS.md
+++ b/docs/specs/features/import-definition-via-webapi/PLANS.md
@@ -49,7 +49,7 @@ smoke evidence.
 1. Confirm WebAPI scope and host constraints
 2. Audit the JP1/AJS3 version 13 API reference sections needed by the first
    import endpoint
-3. Define the first endpoint in OpenAPI with manual-section traceability
+3. Define the first endpoint in OpenAPI from the recorded traceability
 4. Generate mock server and infrastructure/test stubs from the OpenAPI contract
 5. Define request, result, normalized-content, and error DTOs
 6. Design desktop infrastructure adapters for transport and authentication
@@ -57,6 +57,28 @@ smoke evidence.
 8. Add focused integration and compatibility checks
 9. Revisit browser-hosted transport only after the desktop slice is stable
 10. Update docs and remaining follow-up tasks
+
+## Traceability Snapshot
+
+The first endpoint audit is recorded in `TRACEABILITY.md`.
+
+The initial OpenAPI operation now models the JP1/AJS3 version 13 unit list
+acquisition API in `openapi/jp1-ajs3-webapi.v13.openapi.yaml`:
+
+- manual section: 7.1.1 Unit list acquisition API
+- API ID: SC-009
+- request:
+  `GET /ajs/api/v1/objects/statuses?{query}`
+- initial behavior:
+  request definition-only import with `searchTarget=DEFINITION`
+- response:
+  `200` with `statuses` and `all`
+- documented error responses:
+  `400`, `401`, `403`, `404`, `409`, `412`, `500`
+
+Unit information acquisition remains adjacent follow-up scope because it
+requires an execution ID and is better suited to detail retrieval after the
+unit-list import identifies units and generations.
 
 ## Boundary Sketch
 

--- a/docs/specs/features/import-definition-via-webapi/TASKS.md
+++ b/docs/specs/features/import-definition-via-webapi/TASKS.md
@@ -22,14 +22,14 @@
 - [x] Define the repository-local OpenAPI source placement
 - [x] Record beta availability until real JP1/AJS3 environment verification is
       sufficient
+- [x] Audit the JP1/AJS3 version 13 API reference sections needed by the first
+      import endpoint and record traceability before implementation
+- [x] Define the first supported read-only import endpoint in a repository-local
+      OpenAPI contract under
+      `docs/specs/features/import-definition-via-webapi/openapi/`
 
 ## Follow-up
 
-- [ ] Audit the JP1/AJS3 version 13 API reference sections needed by the first
-      import endpoint and record traceability before implementation
-- [ ] Define the first supported read-only import endpoint in a repository-local
-      OpenAPI contract under
-      `docs/specs/features/import-definition-via-webapi/openapi/`
 - [ ] Generate a mock server and infrastructure/test stubs from the OpenAPI
       contract
 - [ ] Add reproducibility checks for generated OpenAPI artifacts
@@ -67,3 +67,12 @@
   JP1/AJS3 environment smoke verification is recorded. Generated mocks/stubs
   stabilize automated tests but do not count as beta-exit evidence by
   themselves.
+- 2026-04-26: first-endpoint traceability is recorded in `TRACEABILITY.md`.
+  The first OpenAPI endpoint should model the unit list acquisition API
+  (`GET /ajs/api/v1/objects/statuses`) with definition-only import as the
+  initial application behavior. Unit information acquisition is deferred as
+  adjacent detail-retrieval scope.
+- 2026-04-26: the first OpenAPI source contract is recorded in
+  `openapi/jp1-ajs3-webapi.v13.openapi.yaml`. It covers the unit list
+  acquisition API request, success response, documented HTTP error responses,
+  and permissive status/release objects for definition-only beta import.

--- a/docs/specs/features/import-definition-via-webapi/TRACEABILITY.md
+++ b/docs/specs/features/import-definition-via-webapi/TRACEABILITY.md
@@ -1,0 +1,157 @@
+# TRACEABILITY: import-definition-via-webapi
+
+## Purpose
+
+Record the JP1/AJS3 version 13 API manual sections that constrain the first
+read-only WebAPI import endpoint.
+
+Normative source:
+
+- JP1 Version 13 JP1/Automatic Job Management System 3 Command Reference,
+  manual 3021-3-L49-20(E), Part 3 API
+  (<https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/INDEX.HTM>)
+
+## First Endpoint Decision
+
+The first OpenAPI endpoint should model the unit list acquisition API:
+
+- manual section: 7.1.1 Unit list acquisition API
+- API ID in component list: SC-009
+- method and resource:
+  `GET /ajs/api/v1/objects/statuses?{query}`
+- product purpose:
+  acquire information about job groups, jobnets, and jobs for a specified unit
+  or units under it
+- read-only fit:
+  the endpoint returns status-monitoring resources and does not register,
+  change, or delete JP1/AJS3 data
+
+Use this endpoint as the initial import surface because it can load a scoped
+server-side unit tree and includes unit definition information that downstream
+list, flow, CSV, diagnostics, hover, or unit-definition features can normalize
+without first requiring execution-changing operations.
+
+The unit information acquisition API is adjacent follow-up scope:
+
+- manual section: 7.1.2 Unit information acquisition API
+- method and resource:
+  `GET /ajs/api/v1/objects/statuses/{unitName}:{execID}?{query}`
+- reason to defer:
+  it requires a specific execution ID and is better suited to detail retrieval
+  after a unit-list import has established available units and generations
+
+## Manual Section Matrix
+
+- API workflow:
+  section 6.1 Workflow for using an API.
+  Requests pass through JP1/AJS3 - Web Console and JP1/AJS3 - Manager;
+  authentication occurs on each request.
+- Authentication:
+  section 6.2 Authentication when using an API.
+  Desktop infrastructure must set `X-AJS-Authorization` from a JP1 user and
+  password encoded outside domain/application logic.
+- Data types:
+  section 6.3 Data types usable for an API.
+  OpenAPI schemas should model booleans, integers, strings, and ISO 8601
+  date-times as documented.
+- Request format:
+  section 6.4 Request format.
+  Generated mocks and adapters must preserve `/ajs/api/v1`, required headers,
+  query parameters, and UTF-8 JSON handling.
+- Response format:
+  section 6.5 Response format.
+  Structured success and error DTOs must follow the manual response patterns
+  before repository-specific mapping.
+- API list:
+  section 6.6.1 List of API configuration components.
+  The first endpoint maps to Unit list acquisition, SC-009; write/update APIs
+  remain out of scope.
+- Usage notes:
+  section 6.7 Notes on using APIs.
+  Transport handling must leave room for SSL, permissions, argument-byte
+  limits, invalid request status codes, and manager connection restrictions.
+- Unit list endpoint:
+  section 7.1.1 Unit list acquisition API.
+  First OpenAPI operation should cover request path, query parameters, status
+  codes, response body, and the 1,000-result `all` behavior.
+- Status resource:
+  section 7.2.1 Resource for status monitoring.
+  Import normalization should treat each returned resource as a container for
+  definition, status, and release information.
+- Unit definition object:
+  section 7.3.1 Unit definition information object.
+  The definition object is the primary source for normalized server-side unit
+  identity and definition attributes.
+- Constants:
+  section 7.4.2 Constants used by the unit list acquisition API.
+  Query enums such as `LowerType`, `SearchTargetType`, `MatchMethods`,
+  `UnitType`, `GenerationType`, and status filters must come from the manual.
+- Unit information appendix:
+  Appendix D Unit Information that Can Be Acquired by the API.
+  The OpenAPI schema should include only members documented as acquirable for
+  the selected API/resource.
+
+## Initial OpenAPI Requirements
+
+The first OpenAPI source should define:
+
+- server-relative path:
+  `/ajs/api/v1/objects/statuses`
+- method:
+  `GET`
+- required query parameters:
+  `mode`, `manager`, `serviceName`, `location`
+- strongly recommended first-slice traversal value:
+  `searchLowerUnits=YES`
+- strongly recommended first-slice query value:
+  `searchTarget=DEFINITION`
+- optional query parameters from section 7.1.1 only when needed for scoped
+  import tests
+- required API request header:
+  `X-AJS-Authorization`
+- optional request header:
+  `Accept-Language`
+- success response:
+  `200` with `statuses` and `all`
+- documented error responses:
+  `400`, `401`, `403`, `404`, `409`, `412`, `500`
+
+The first implementation should request definition-only data by default. Status
+and release fields may remain in the response schema because the manual returns
+status-monitoring resources, but application normalization should not require
+status or release data for the initial read-only definition import.
+
+## DTO And Error Mapping Notes
+
+- `401` maps to an authentication failure.
+- `403` maps to an authorization failure.
+- `404` maps to unavailable resource or inaccessible resource.
+- `412` maps to Web Console unavailable.
+- `400`, `409`, and `500` map to structured recoverable import errors with
+  manual status detail preserved where safe.
+- Network failures, timeouts, cancellation, unsupported web-host access, and
+  malformed responses are repository-owned error categories layered around the
+  manual HTTP responses.
+- Error messages must not expose credentials, raw authorization headers, server
+  secrets, imported definition content, or local file paths.
+
+## Compatibility Notes
+
+- Desktop support may use VS Code-hosted credential retrieval and an
+  infrastructure HTTP adapter.
+- Shared domain and application DTOs must not import `vscode`, Node transport
+  modules, generated OpenAPI clients, or webview code.
+- Browser-hosted execution remains unsupported for this first slice unless a
+  browser-safe transport and authentication model is specified and tested.
+- Generated mocks and stubs must stay outside domain/application code and be
+  reproducible from the OpenAPI source.
+
+## Open Questions
+
+- Confirm with a real JP1/AJS3 environment whether `searchTarget=DEFINITION`
+  returns enough definition attributes for the extension's normalized model.
+- Confirm whether the returned `parameters` member is sufficient for current
+  parser-equivalent parameter interpretation, or whether additional API calls
+  are needed for full unit-definition parity.
+- Decide whether the first command asks for `searchLowerUnits` explicitly or
+  defaults to all units under the selected location for beta.

--- a/docs/specs/features/import-definition-via-webapi/openapi/README.md
+++ b/docs/specs/features/import-definition-via-webapi/openapi/README.md
@@ -35,3 +35,6 @@ Each supported endpoint should record the JP1/AJS3 manual section used for:
 - response status, headers, and body
 - error response mapping
 - API usage notes and host constraints
+
+The first endpoint audit is recorded in
+`docs/specs/features/import-definition-via-webapi/TRACEABILITY.md`.

--- a/docs/specs/features/import-definition-via-webapi/openapi/jp1-ajs3-webapi.v13.openapi.yaml
+++ b/docs/specs/features/import-definition-via-webapi/openapi/jp1-ajs3-webapi.v13.openapi.yaml
@@ -1,0 +1,565 @@
+---
+openapi: 3.0.3
+info:
+  title: JP1/AJS3 WebAPI subset for AJS Butler import
+  version: 0.1.0
+  description: >
+    Repository-local OpenAPI contract for the first read-only JP1/AJS3 WebAPI
+    import slice supported by vscode-ajsbutler. This contract is derived from
+    JP1 Version 13 JP1/Automatic Job Management System 3 Command Reference,
+    manual 3021-3-L49-20(E), Part 3 API. It is intended for generated mocks,
+    infrastructure stubs, and integration tests; the Hitachi manual remains the
+    normative product reference.
+  x-normative-source:
+    manual: >
+      JP1 Version 13 JP1/Automatic Job Management System 3 Command Reference
+    manualNumber: 3021-3-L49-20(E)
+    part: Part 3 API
+    url: https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/INDEX.HTM
+servers:
+  - url: "{scheme}://{webConsoleHost}:{webConsolePort}"
+    description: JP1/AJS3 - Web Console server
+    variables:
+      scheme:
+        default: https
+        enum:
+          - http
+          - https
+      webConsoleHost:
+        default: localhost
+        description: Host name or IP address of the Web Console server.
+      webConsolePort:
+        default: "22252"
+        description: Web Console server port. The manual examples use 22252.
+tags:
+  - name: status-monitoring
+    description: Read-only status-monitoring and unit-definition resources.
+paths:
+  /ajs/api/v1/objects/statuses:
+    get:
+      tags:
+        - status-monitoring
+      operationId: getUnitList
+      summary: Acquire a scoped unit list.
+      description: >
+        Acquires information about job groups, jobnets, and jobs for a
+        specified unit or for units under it. AJS Butler uses this read-only
+        endpoint as the first WebAPI import surface and should request
+        definition-only data with searchTarget=DEFINITION for the initial beta
+        import behavior.
+      externalDocs:
+        description: 7.1.1 Unit list acquisition API
+        url: https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0286.HTM
+      security:
+        - ajsAuthorization: []
+      x-jp1-ajs3-traceability:
+        manualSection: 7.1.1 Unit list acquisition API
+        apiId: SC-009
+        requestFormatSections:
+          - 6.2 Authentication when using an API
+          - 6.4 Request format
+        responseFormatSections:
+          - 6.5 Response format
+          - 7.2.1 Resource for status monitoring
+          - 7.3.1 Unit definition information object
+        constantsSections:
+          - 7.4.2 Constants used by the unit list acquisition API
+        notesSections:
+          - 6.7 Notes on using APIs
+        initialAjsButlerBehavior:
+          searchTarget: DEFINITION
+          readOnly: true
+      parameters:
+        - $ref: "#/components/parameters/AcceptLanguageHeader"
+        - $ref: "#/components/parameters/Mode"
+        - $ref: "#/components/parameters/Manager"
+        - $ref: "#/components/parameters/ServiceName"
+        - $ref: "#/components/parameters/Location"
+        - $ref: "#/components/parameters/SearchLowerUnits"
+        - $ref: "#/components/parameters/SearchTarget"
+        - $ref: "#/components/parameters/UnitName"
+        - $ref: "#/components/parameters/UnitNameMatchMethods"
+        - $ref: "#/components/parameters/UnitType"
+        - $ref: "#/components/parameters/Generation"
+        - $ref: "#/components/parameters/ExecId"
+        - $ref: "#/components/parameters/PeriodBegin"
+        - $ref: "#/components/parameters/PeriodEnd"
+        - $ref: "#/components/parameters/Status"
+        - $ref: "#/components/parameters/DelayStatus"
+        - $ref: "#/components/parameters/HoldPlan"
+        - $ref: "#/components/parameters/UnitComment"
+        - $ref: "#/components/parameters/UnitCommentMatchMethods"
+        - $ref: "#/components/parameters/ExecHost"
+        - $ref: "#/components/parameters/ExecHostMatchMethods"
+        - $ref: "#/components/parameters/ReleaseId"
+        - $ref: "#/components/parameters/ReleaseInfoSearchMethods"
+      responses:
+        "200":
+          description: The unit list was successfully acquired.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnitListResponse"
+              examples:
+                definitionOnly:
+                  summary: Definition-oriented import response
+                  value:
+                    statuses:
+                      - definition:
+                          owner: jp1admin
+                          customJobType: ""
+                          registerStatus: "YES"
+                          rootJobnetName: /JobGroup/Jobnet
+                          recoveryUnit: false
+                          unitType: ROOTNET
+                          unitComment: ""
+                          simpleUnitName: Jobnet
+                          parameters: ""
+                          execAgent: ""
+                          execFileName: ""
+                          wait: false
+                          jobnetReleaseUnit: false
+                          jp1ResourceGroup: ""
+                          unitName: /JobGroup/Jobnet
+                          unitID: 1560
+                        release: null
+                        unitStatus: null
+                    all: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "#/components/responses/ServerError"
+components:
+  securitySchemes:
+    ajsAuthorization:
+      type: apiKey
+      in: header
+      name: X-AJS-Authorization
+      description: >
+        Base64-encoded JP1 user name and password in the manual format
+        userName:password. Infrastructure must resolve and encode credentials
+        outside domain/application logic.
+  parameters:
+    AcceptLanguageHeader:
+      name: Accept-Language
+      in: header
+      required: false
+      description: >
+        Language code for response message bodies where JP1/AJS3 - Web Console
+        supports language selection.
+      schema:
+        type: string
+        enum:
+          - ja
+          - en
+          - zh
+    Mode:
+      name: mode
+      in: query
+      required: true
+      description: Fixed value search.
+      schema:
+        type: string
+        enum:
+          - search
+    Manager:
+      name: manager
+      in: query
+      required: true
+      description: Manager host name or IP address.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 255
+    ServiceName:
+      name: serviceName
+      in: query
+      required: true
+      description: Scheduler service name.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 30
+    Location:
+      name: location
+      in: query
+      required: true
+      description: Full name of the upper unit to acquire.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 930
+        example: /JobGroup
+    SearchLowerUnits:
+      name: searchLowerUnits
+      in: query
+      required: false
+      description: Whether to acquire all lower units or direct children only.
+      schema:
+        $ref: "#/components/schemas/LowerType"
+        default: "NO"
+    SearchTarget:
+      name: searchTarget
+      in: query
+      required: false
+      description: >
+        Range of information to acquire. AJS Butler should use DEFINITION for
+        the initial read-only import behavior.
+      schema:
+        $ref: "#/components/schemas/SearchTargetType"
+        default: DEFINITION_AND_STATUS
+    UnitName:
+      name: unitName
+      in: query
+      required: false
+      description: Unit name search value.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 64
+    UnitNameMatchMethods:
+      name: unitNameMatchMethods
+      in: query
+      required: false
+      description: Unit name comparison method.
+      schema:
+        $ref: "#/components/schemas/MatchMethods"
+        default: "NO"
+    UnitType:
+      name: unitType
+      in: query
+      required: false
+      description: Unit type filter from the JP1/AJS3 UnitType constant.
+      schema:
+        type: string
+        default: "NO"
+    Generation:
+      name: generation
+      in: query
+      required: false
+      description: Generation acquisition mode.
+      schema:
+        type: string
+        default: STATUS
+    ExecId:
+      name: execID
+      in: query
+      required: false
+      description: Execution ID used when generation=EXECID.
+      schema:
+        type: string
+        pattern: "^@([0-9]{1,4})?[A-Z][0-9]{1,4}$"
+        example: "@10A200"
+    PeriodBegin:
+      name: periodBegin
+      in: query
+      required: false
+      description: Period start time used when generation=PERIOD.
+      schema:
+        type: string
+        pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}$"
+        example: "2026-04-26T09:00"
+    PeriodEnd:
+      name: periodEnd
+      in: query
+      required: false
+      description: Period end time used when generation=PERIOD.
+      schema:
+        type: string
+        pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}$"
+        example: "2026-04-26T18:00"
+    Status:
+      name: status
+      in: query
+      required: false
+      description: Unit status filter from the JP1/AJS3 UnitStatus constant.
+      schema:
+        type: string
+        default: "NO"
+    DelayStatus:
+      name: delayStatus
+      in: query
+      required: false
+      description: Delay status filter from the JP1/AJS3 DelayType constant.
+      schema:
+        type: string
+        default: "NO"
+    HoldPlan:
+      name: holdPlan
+      in: query
+      required: false
+      description: Hold plan filter from the JP1/AJS3 HoldPlan constant.
+      schema:
+        type: string
+        default: "NO"
+    UnitComment:
+      name: unitComment
+      in: query
+      required: false
+      description: Unit comment search value.
+      schema:
+        type: string
+        minLength: 0
+        maxLength: 164
+    UnitCommentMatchMethods:
+      name: unitCommentMatchMethods
+      in: query
+      required: false
+      description: Unit comment comparison method.
+      schema:
+        $ref: "#/components/schemas/MatchMethods"
+        default: "NO"
+    ExecHost:
+      name: execHost
+      in: query
+      required: false
+      description: Execution host search value.
+      schema:
+        type: string
+        minLength: 0
+        maxLength: 514
+    ExecHostMatchMethods:
+      name: execHostMatchMethods
+      in: query
+      required: false
+      description: Execution host comparison method.
+      schema:
+        $ref: "#/components/schemas/MatchMethods"
+        default: "NO"
+    ReleaseId:
+      name: releaseID
+      in: query
+      required: false
+      description: Release ID used with releaseInfoSearchMethods=ID.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 30
+    ReleaseInfoSearchMethods:
+      name: releaseInfoSearchMethods
+      in: query
+      required: false
+      description: Release information acquisition method.
+      schema:
+        type: string
+        default: "NO"
+  responses:
+    BadRequest:
+      description: The query character string is invalid.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    Unauthorized:
+      description: Authentication is required.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    Forbidden:
+      description: The operator does not have execution permission.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    NotFound:
+      description: >
+        The operator does not have access permission for the resource, or the
+        resource does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    Conflict:
+      description: >
+        Processing cannot continue because the request is inconsistent with the
+        current resource status.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    PreconditionFailed:
+      description: The Web Console server is not available.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    ServerError:
+      description: A processing error occurred in the Web Console server.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+  schemas:
+    LowerType:
+      type: string
+      description: How to acquire units under the specified unit.
+      enum:
+        - "YES"
+        - "NO"
+    SearchTargetType:
+      type: string
+      description: Range of information to acquire.
+      enum:
+        - DEFINITION
+        - DEFINITION_AND_STATUS
+    MatchMethods:
+      type: string
+      description: Character string comparison method.
+      enum:
+        - "NO"
+        - EQ
+        - BW
+        - EW
+        - NE
+        - CO
+        - NC
+        - RE
+    UnitListResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - statuses
+        - all
+      properties:
+        statuses:
+          type: array
+          description: Resources for status monitoring.
+          items:
+            $ref: "#/components/schemas/StatusMonitoringResource"
+        all:
+          type: boolean
+          description: >
+            Whether all information sets could be acquired. The manual returns
+            false when more than 1,000 units match and the result is truncated.
+    StatusMonitoringResource:
+      type: object
+      additionalProperties: true
+      description: >
+        Resource for status monitoring. The first AJS Butler import path uses
+        the definition object as the normalization source.
+      properties:
+        definition:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/UnitDefinitionInformation"
+        unitStatus:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/StatusInformation"
+        release:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/ReleaseInformation"
+    UnitDefinitionInformation:
+      type: object
+      additionalProperties: true
+      description: Unit definition information object.
+      properties:
+        unitName:
+          type: string
+          minLength: 0
+          maxLength: 930
+        unitComment:
+          type: string
+          minLength: 0
+          maxLength: 80
+        unitType:
+          type: string
+          description: Unit type constant from section 7.4.4(1) Type.
+        owner:
+          type: string
+          minLength: 0
+          maxLength: 31
+        execAgent:
+          type: string
+          minLength: 0
+          maxLength: 255
+        execFileName:
+          type: string
+          minLength: 0
+          maxLength: 511
+        parameters:
+          type: string
+          minLength: 0
+          maxLength: 1023
+        customJobType:
+          type: string
+          minLength: 0
+        registerStatus:
+          type: string
+          description: RegisterStatus constant from section 7.4.4(2).
+        recoveryUnit:
+          type: boolean
+        unitID:
+          type: integer
+          format: int32
+        wait:
+          type: boolean
+        jobnetReleaseUnit:
+          type: boolean
+        jp1ResourceGroup:
+          type: string
+          minLength: 0
+          maxLength: 63
+        simpleUnitName:
+          type: string
+          minLength: 0
+          maxLength: 30
+        rootJobnetName:
+          type: string
+          minLength: 0
+          maxLength: 930
+    StatusInformation:
+      type: object
+      additionalProperties: true
+      description: >
+        Status information object. Kept permissive in the first contract
+        because definition-only import should not depend on status members.
+      properties:
+        status:
+          type: string
+        unitName:
+          type: string
+        simpleUnitName:
+          type: string
+        execID:
+          type: string
+        startTime:
+          type: string
+        endTime:
+          type: string
+        schStartTime:
+          type: string
+        execHost:
+          type: string
+    ReleaseInformation:
+      type: object
+      additionalProperties: true
+      description: >
+        Release information object. Kept permissive in the first contract
+        because definition-only import should not depend on release members.
+    ApiError:
+      type: object
+      additionalProperties: true
+      description: >
+        JP1/AJS3 WebAPI error response body. Repository-owned import errors
+        must map these responses without leaking credentials, tokens, imported
+        definition content, or local file paths.
+      properties:
+        message:
+          type: string
+        messageID:
+          type: string
+        maintenance:
+          type: string

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -64,18 +64,16 @@ under `docs/requirements/use-cases/`.
 1. Align parameter parsing with JP1/Automatic Job Management System 3 version
    13 reference manuals when a behavior-changing parameter slice needs
    per-key coverage beyond the current audit summary.
-2. Audit the JP1/AJS3 version 13 API reference sections needed by the first
-   read-only WebAPI import endpoint and record traceability.
-3. Define the first supported endpoint in OpenAPI and generate mock/stub
+2. Generate mock/stub
    artifacts for infrastructure and integration tests.
-4. Define request, result, normalized-content, and structured-error DTOs for
+3. Define request, result, normalized-content, and structured-error DTOs for
    the first desktop read-only JP1/AJS WebAPI import slice.
-5. Implement the beta-labeled extension command and desktop infrastructure
+4. Implement the beta-labeled extension command and desktop infrastructure
    adapter behind the application WebAPI import port.
-6. Record real JP1/AJS3 smoke verification before removing beta labeling.
-7. Extend list-view search on the current presentation path so parameter key
+5. Record real JP1/AJS3 smoke verification before removing beta labeling.
+6. Extend list-view search on the current presentation path so parameter key
    and value queries complement existing rendered-row partial matching.
-8. Keep desktop and web compatibility explicit whenever bootstrap, preview,
+7. Keep desktop and web compatibility explicit whenever bootstrap, preview,
    parsing, shared adapters, or runtime behavior change.
 
 ## Wrapper Semantics Matrix


### PR DESCRIPTION
## Summary
- add traceability for the first read-only JP1/AJS3 WebAPI import endpoint
- define the initial OpenAPI 3.0.3 contract for the unit list acquisition API
- update SDD task and plan indexes so the next slice starts at mock/stub generation

## Validation
- corepack pnpm run qlty
- pnpm run lint:md
- YAML parse check for the OpenAPI source

## Notes
- This is a docs-only SDD/OpenAPI source change.
- The first endpoint is scoped to read-only definition import via GET /ajs/api/v1/objects/statuses.