### PR TITLE
[codex] Add WebAPI import DTO contract

### DIFF
--- a/docs/specs/features/import-definition-via-webapi/PLANS.md
+++ b/docs/specs/features/import-definition-via-webapi/PLANS.md
@@ -115,6 +115,27 @@ mock HTTP responses when they need OpenAPI-compatible WebAPI behavior.
 - domain/normalization: receives only product concepts that match existing AJS
   document semantics
 
+## Application DTO Contract
+
+The first application-owned WebAPI import contract lives under
+`src/application/webapi-import/`.
+
+- request DTOs describe the host, connection context, credential reference,
+  manager, scheduler service, and unit location without carrying raw
+  credentials
+- port request DTOs fix the first endpoint to
+  `GET /ajs/api/v1/objects/statuses` with `mode=search` and
+  `searchTarget=DEFINITION`
+- normalized content DTOs expose imported definition units and source metadata
+  without exposing raw WebAPI response objects to downstream presentation
+  features
+- structured error DTOs cover cancellation, unsupported host, authentication,
+  authorization, network, timeout, unexpected status, malformed response, and
+  documented HTTP status mappings
+
+These DTOs intentionally do not import generated OpenAPI artifacts, VS Code
+APIs, Node transport modules, Prism helpers, or webview code.
+
 ## OpenAPI Workflow
 
 1. Trace the selected endpoint to JP1/AJS3 version 13 manual sections.

--- a/docs/specs/features/import-definition-via-webapi/TASKS.md
+++ b/docs/specs/features/import-definition-via-webapi/TASKS.md
@@ -30,11 +30,11 @@
 - [x] Generate a mock server and infrastructure/test stubs from the OpenAPI
       contract
 - [x] Add reproducibility checks for generated OpenAPI artifacts
+- [x] Define request, result, normalized-content, and error DTOs for the first
+      desktop read-only import slice
 
 ## Follow-up
 
-- [ ] Define request, result, normalized-content, and error DTOs for the first
-      desktop read-only import slice
 - [ ] Implement the extension command and desktop infrastructure adapter behind
       the application import port
 - [ ] Add compatibility tests that keep shared domain/application paths free of
@@ -80,3 +80,8 @@
   WebAPI types, Prism test helpers, and a Prism OpenAPI fixture whose examples
   are derived from `sample/`. `pnpm run openapi:check` verifies that the
   checked-in generated artifacts are reproducible.
+- 2026-04-26: application-owned import DTOs and the first import port live in
+  `src/application/webapi-import/`. They define desktop definition-only unit
+  list requests, normalized imported definition content, and recoverable
+  structured errors without depending on generated OpenAPI artifacts,
+  VS Code APIs, Node transport, Prism, or webview code.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -64,14 +64,12 @@ under `docs/requirements/use-cases/`.
 1. Align parameter parsing with JP1/Automatic Job Management System 3 version
    13 reference manuals when a behavior-changing parameter slice needs
    per-key coverage beyond the current audit summary.
-2. Define request, result, normalized-content, and structured-error DTOs for
-   the first desktop read-only JP1/AJS WebAPI import slice.
-3. Implement the beta-labeled extension command and desktop infrastructure
+2. Implement the beta-labeled extension command and desktop infrastructure
    adapter behind the application WebAPI import port.
-4. Record real JP1/AJS3 smoke verification before removing beta labeling.
-5. Extend list-view search on the current presentation path so parameter key
+3. Record real JP1/AJS3 smoke verification before removing beta labeling.
+4. Extend list-view search on the current presentation path so parameter key
    and value queries complement existing rendered-row partial matching.
-6. Keep desktop and web compatibility explicit whenever bootstrap, preview,
+5. Keep desktop and web compatibility explicit whenever bootstrap, preview,
    parsing, shared adapters, or runtime behavior change.
 
 ## Wrapper Semantics Matrix

--- a/src/application/webapi-import/importAjsDefinitionViaWebApi.ts
+++ b/src/application/webapi-import/importAjsDefinitionViaWebApi.ts
@@ -1,0 +1,207 @@
+export type ImportAjsDefinitionHostKind = "desktop" | "web";
+
+export type ImportAjsDefinitionLanguage = "ja" | "en" | "zh";
+
+export type ImportAjsDefinitionErrorCode =
+  | "cancelled"
+  | "unsupported-host"
+  | "authentication-failed"
+  | "authorization-failed"
+  | "network-failed"
+  | "timeout"
+  | "unexpected-status"
+  | "malformed-response"
+  | "resource-not-found"
+  | "web-console-unavailable"
+  | "conflict"
+  | "invalid-request"
+  | "server-error";
+
+export type ImportAjsDefinitionScopeDto = {
+  manager: string;
+  serviceName: string;
+  location: string;
+  searchLowerUnits?: boolean;
+};
+
+export type ImportAjsDefinitionConnectionDto = {
+  baseUrl: string;
+  acceptLanguage?: ImportAjsDefinitionLanguage;
+  timeoutMs?: number;
+};
+
+export type ImportAjsDefinitionRequestDto = {
+  host: ImportAjsDefinitionHostKind;
+  connection: ImportAjsDefinitionConnectionDto;
+  scope: ImportAjsDefinitionScopeDto;
+  credentialRef?: string;
+};
+
+export type ImportAjsDefinitionPortRequestDto = {
+  endpoint: "unit-list";
+  method: "GET";
+  path: "/ajs/api/v1/objects/statuses";
+  connection: ImportAjsDefinitionConnectionDto;
+  credentialRef?: string;
+  query: {
+    mode: "search";
+    manager: string;
+    serviceName: string;
+    location: string;
+    searchLowerUnits: "YES" | "NO";
+    searchTarget: "DEFINITION";
+  };
+};
+
+export type ImportedAjsDefinitionSourceDto = {
+  type: "jp1-ajs3-webapi";
+  endpoint: "unit-list";
+  manualSection: "7.1.1 Unit list acquisition API";
+  apiId: "SC-009";
+  manager: string;
+  serviceName: string;
+  location: string;
+  all: boolean;
+};
+
+export type ImportedAjsUnitDefinitionDto = {
+  unitName: string;
+  simpleUnitName?: string;
+  unitType?: string;
+  unitComment?: string;
+  owner?: string;
+  parameters?: string;
+  rootJobnetName?: string;
+  execAgent?: string;
+  execFileName?: string;
+  customJobType?: string;
+  registerStatus?: string;
+  recoveryUnit?: boolean;
+  wait?: boolean;
+  jobnetReleaseUnit?: boolean;
+  jp1ResourceGroup?: string;
+  unitID?: number;
+};
+
+export type ImportedAjsDefinitionContentDto = {
+  source: ImportedAjsDefinitionSourceDto;
+  units: ImportedAjsUnitDefinitionDto[];
+  warnings: ImportAjsDefinitionWarningDto[];
+};
+
+export type ImportAjsDefinitionWarningDto = {
+  code: "partial-result" | "empty-result" | "definition-missing";
+  message: string;
+  unitName?: string;
+};
+
+export type ImportAjsDefinitionErrorDto = {
+  code: ImportAjsDefinitionErrorCode;
+  message: string;
+  recoverable: true;
+  httpStatus?: number;
+  messageId?: string;
+};
+
+export type ImportAjsDefinitionSuccessDto = {
+  ok: true;
+  content: ImportedAjsDefinitionContentDto;
+};
+
+export type ImportAjsDefinitionFailureDto = {
+  ok: false;
+  error: ImportAjsDefinitionErrorDto;
+};
+
+export type ImportAjsDefinitionResultDto =
+  | ImportAjsDefinitionSuccessDto
+  | ImportAjsDefinitionFailureDto;
+
+export interface ImportAjsDefinitionViaWebApiPort {
+  importDefinition(
+    request: ImportAjsDefinitionPortRequestDto,
+  ): Promise<ImportAjsDefinitionResultDto>;
+}
+
+export const buildDefinitionOnlyUnitListRequest = (
+  request: ImportAjsDefinitionRequestDto,
+): ImportAjsDefinitionPortRequestDto | ImportAjsDefinitionFailureDto => {
+  if (request.host === "web") {
+    return {
+      ok: false,
+      error: createImportAjsDefinitionError(
+        "unsupported-host",
+        "JP1/AJS WebAPI import is not supported in the web extension host yet.",
+      ),
+    };
+  }
+
+  return {
+    endpoint: "unit-list",
+    method: "GET",
+    path: "/ajs/api/v1/objects/statuses",
+    connection: { ...request.connection },
+    credentialRef: request.credentialRef,
+    query: {
+      mode: "search",
+      manager: request.scope.manager,
+      serviceName: request.scope.serviceName,
+      location: request.scope.location,
+      searchLowerUnits: request.scope.searchLowerUnits === false ? "NO" : "YES",
+      searchTarget: "DEFINITION",
+    },
+  };
+};
+
+export const createImportedAjsDefinitionContent = (
+  source: Omit<
+    ImportedAjsDefinitionSourceDto,
+    "type" | "endpoint" | "manualSection" | "apiId"
+  >,
+  units: ImportedAjsUnitDefinitionDto[],
+  warnings: ImportAjsDefinitionWarningDto[] = [],
+): ImportedAjsDefinitionContentDto => ({
+  source: {
+    type: "jp1-ajs3-webapi",
+    endpoint: "unit-list",
+    manualSection: "7.1.1 Unit list acquisition API",
+    apiId: "SC-009",
+    ...source,
+  },
+  units: units.map((unit) => ({ ...unit })),
+  warnings: warnings.map((warning) => ({ ...warning })),
+});
+
+export const createImportAjsDefinitionError = (
+  code: ImportAjsDefinitionErrorCode,
+  message: string,
+  details: Pick<ImportAjsDefinitionErrorDto, "httpStatus" | "messageId"> = {},
+): ImportAjsDefinitionErrorDto => ({
+  code,
+  message,
+  recoverable: true,
+  ...details,
+});
+
+export const mapHttpStatusToImportErrorCode = (
+  httpStatus: number,
+): ImportAjsDefinitionErrorCode => {
+  switch (httpStatus) {
+    case 400:
+      return "invalid-request";
+    case 401:
+      return "authentication-failed";
+    case 403:
+      return "authorization-failed";
+    case 404:
+      return "resource-not-found";
+    case 409:
+      return "conflict";
+    case 412:
+      return "web-console-unavailable";
+    case 500:
+      return "server-error";
+    default:
+      return "unexpected-status";
+  }
+};

--- a/src/test/suite/importAjsDefinitionViaWebApi.test.ts
+++ b/src/test/suite/importAjsDefinitionViaWebApi.test.ts
@@ -1,0 +1,178 @@
+import * as assert from "assert";
+import {
+  buildDefinitionOnlyUnitListRequest,
+  createImportedAjsDefinitionContent,
+  createImportAjsDefinitionError,
+  mapHttpStatusToImportErrorCode,
+  type ImportAjsDefinitionViaWebApiPort,
+} from "../../application/webapi-import/importAjsDefinitionViaWebApi";
+
+suite("Import AJS definition via WebAPI DTOs", () => {
+  test("builds a definition-only desktop port request", () => {
+    const portRequest = buildDefinitionOnlyUnitListRequest({
+      host: "desktop",
+      connection: {
+        baseUrl: "https://web-console.example.com:22252",
+        acceptLanguage: "en",
+        timeoutMs: 10000,
+      },
+      credentialRef: "jp1-webapi:default",
+      scope: {
+        manager: "manager.example.com",
+        serviceName: "AJSROOT1",
+        location: "/JobGroup",
+      },
+    });
+
+    assert.strictEqual("ok" in portRequest, false);
+    assert.deepStrictEqual(portRequest, {
+      endpoint: "unit-list",
+      method: "GET",
+      path: "/ajs/api/v1/objects/statuses",
+      connection: {
+        baseUrl: "https://web-console.example.com:22252",
+        acceptLanguage: "en",
+        timeoutMs: 10000,
+      },
+      credentialRef: "jp1-webapi:default",
+      query: {
+        mode: "search",
+        manager: "manager.example.com",
+        serviceName: "AJSROOT1",
+        location: "/JobGroup",
+        searchLowerUnits: "YES",
+        searchTarget: "DEFINITION",
+      },
+    });
+  });
+
+  test("returns an unsupported-host result for web extension execution", () => {
+    const result = buildDefinitionOnlyUnitListRequest({
+      host: "web",
+      connection: {
+        baseUrl: "https://web-console.example.com:22252",
+      },
+      scope: {
+        manager: "manager.example.com",
+        serviceName: "AJSROOT1",
+        location: "/JobGroup",
+      },
+    });
+
+    assert.strictEqual("ok" in result, true);
+    assert.deepStrictEqual(result, {
+      ok: false,
+      error: {
+        code: "unsupported-host",
+        message:
+          "JP1/AJS WebAPI import is not supported in the web extension host yet.",
+        recoverable: true,
+      },
+    });
+  });
+
+  test("creates normalized import content without exposing transport response objects", () => {
+    const content = createImportedAjsDefinitionContent(
+      {
+        manager: "manager.example.com",
+        serviceName: "AJSROOT1",
+        location: "/JobGroup",
+        all: true,
+      },
+      [
+        {
+          unitName: "/JobGroup/Jobnet",
+          simpleUnitName: "Jobnet",
+          unitType: "ROOTNET",
+          parameters: "sample=sample_ref_minimal_utf8",
+        },
+      ],
+    );
+
+    assert.deepStrictEqual(content.source, {
+      type: "jp1-ajs3-webapi",
+      endpoint: "unit-list",
+      manualSection: "7.1.1 Unit list acquisition API",
+      apiId: "SC-009",
+      manager: "manager.example.com",
+      serviceName: "AJSROOT1",
+      location: "/JobGroup",
+      all: true,
+    });
+    assert.strictEqual(content.units[0].unitName, "/JobGroup/Jobnet");
+    assert.deepStrictEqual(content.warnings, []);
+  });
+
+  test("maps manual HTTP statuses and repository-owned failures to structured errors", () => {
+    assert.strictEqual(
+      mapHttpStatusToImportErrorCode(401),
+      "authentication-failed",
+    );
+    assert.strictEqual(
+      mapHttpStatusToImportErrorCode(403),
+      "authorization-failed",
+    );
+    assert.strictEqual(
+      mapHttpStatusToImportErrorCode(412),
+      "web-console-unavailable",
+    );
+    assert.strictEqual(
+      mapHttpStatusToImportErrorCode(418),
+      "unexpected-status",
+    );
+
+    assert.deepStrictEqual(
+      createImportAjsDefinitionError("timeout", "The request timed out.", {
+        messageId: "timeout",
+      }),
+      {
+        code: "timeout",
+        message: "The request timed out.",
+        recoverable: true,
+        messageId: "timeout",
+      },
+    );
+  });
+
+  test("defines an application import port without infrastructure types", async () => {
+    const port: ImportAjsDefinitionViaWebApiPort = {
+      async importDefinition(request) {
+        return {
+          ok: true,
+          content: createImportedAjsDefinitionContent(
+            {
+              manager: request.query.manager,
+              serviceName: request.query.serviceName,
+              location: request.query.location,
+              all: true,
+            },
+            [{ unitName: request.query.location }],
+          ),
+        };
+      },
+    };
+
+    const request = buildDefinitionOnlyUnitListRequest({
+      host: "desktop",
+      connection: { baseUrl: "https://web-console.example.com:22252" },
+      scope: {
+        manager: "manager.example.com",
+        serviceName: "AJSROOT1",
+        location: "/JobGroup",
+        searchLowerUnits: false,
+      },
+    });
+    assert.strictEqual("ok" in request, false);
+    if ("ok" in request) {
+      throw new Error("Expected a desktop port request.");
+    }
+
+    const result = await port.importDefinition(request);
+
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) {
+      throw new Error("Expected a successful import result.");
+    }
+    assert.strictEqual(result.content.units[0].unitName, "/JobGroup");
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -15,6 +15,7 @@
     "src/application/editor-feedback/**/*.ts",
     "src/application/flow-graph/**/*.ts",
     "src/application/telemetry/**/*.ts",
+    "src/application/webapi-import/**/*.ts",
     "src/application/unit-list/buildUnitList.ts",
     "src/application/unit-list/unitListDocument.ts",
     "src/domain/models/ajs/**/*.ts",


### PR DESCRIPTION
## What changed

- Added application-owned DTOs for the first read-only JP1/AJS WebAPI import slice.
- Added a `ImportAjsDefinitionViaWebApiPort` boundary that infrastructure adapters can implement without leaking transport details into application code.
- Added helpers for definition-only unit-list request construction, normalized imported definition content, structured recoverable errors, and JP1/AJS3 WebAPI HTTP status mapping.
- Added focused tests for desktop request mapping, web-host unsupported behavior, normalized content DTOs, structured errors, and the application port shape.
- Updated SDD task and plan docs to mark the DTO slice complete and make the next priority the command/infrastructure adapter slice.

## Why

The WebAPI import implementation needs a stable application contract before adding VS Code command wiring or desktop HTTP infrastructure. This keeps downstream list, flow, CSV, diagnostics, hover, and unit-definition paths from depending on raw WebAPI transport objects.

## Validation

- `pnpm run qlty`
- `pnpm run lint:md`
- `pnpm run openapi:check`
- `pnpm exec tsc -p tsconfig.test.json --noEmit`
- `pnpm test`
- `pnpm run build` passed with existing webpack bundle-size warnings
- `pnpm run test:web` passed with sandbox-external execution for Playwright Chromium

## Compatibility

- No change to `engines.vscode`.
- Application DTOs do not import `vscode`, Node transport modules, Prism, generated OpenAPI artifacts, or webview code.
- Web extension execution is explicitly represented as an unsupported-host result for this first slice.