### PR TITLE
[codex] Add WebAPI import beta command

### DIFF
--- a/docs/specs/features/import-definition-via-webapi/PLANS.md
+++ b/docs/specs/features/import-definition-via-webapi/PLANS.md
@@ -136,6 +136,28 @@ The first application-owned WebAPI import contract lives under
 These DTOs intentionally do not import generated OpenAPI artifacts, VS Code
 APIs, Node transport modules, Prism helpers, or webview code.
 
+## Desktop Beta Command
+
+The first command implementation contributes
+`ajsbutler.importDefinitionViaWebApiBeta`.
+
+- the command is beta-labeled in the VS Code command palette
+- input collection lives in the extension command boundary, outside webview
+  code
+- credentials are stored through VS Code secret storage and are referenced by
+  an application DTO credential reference rather than passed as DTO fields
+- the desktop infrastructure adapter performs the unit-list WebAPI request,
+  maps documented HTTP statuses and transport failures to structured import
+  errors, and converts success responses to normalized imported definition
+  content
+- browser-hosted execution returns an unsupported-host result until a
+  browser-safe transport and authentication model is explicitly implemented
+  and tested
+
+The initial beta command reports the number of imported units. Opening or
+persisting imported definitions in downstream list, flow, CSV, diagnostics,
+hover, or unit-definition features remains a follow-up integration slice.
+
 ## OpenAPI Workflow
 
 1. Trace the selected endpoint to JP1/AJS3 version 13 manual sections.

--- a/docs/specs/features/import-definition-via-webapi/TASKS.md
+++ b/docs/specs/features/import-definition-via-webapi/TASKS.md
@@ -32,15 +32,15 @@
 - [x] Add reproducibility checks for generated OpenAPI artifacts
 - [x] Define request, result, normalized-content, and error DTOs for the first
       desktop read-only import slice
+- [x] Implement the extension command and desktop infrastructure adapter behind
+      the application import port
+- [x] Add compatibility tests that keep shared domain/application paths free of
+      WebAPI transport, Node-only, and webview dependencies
+- [x] Add beta labeling to the command, release notes, or user-facing docs when
+      the first implementation ships
 
 ## Follow-up
 
-- [ ] Implement the extension command and desktop infrastructure adapter behind
-      the application import port
-- [ ] Add compatibility tests that keep shared domain/application paths free of
-      WebAPI transport, Node-only, and webview dependencies
-- [ ] Add beta labeling to the command, release notes, or user-facing docs when
-      the first implementation ships
 - [ ] Record real JP1/AJS3 environment smoke verification before exiting beta
 
 ## Notes
@@ -85,3 +85,9 @@
   list requests, normalized imported definition content, and recoverable
   structured errors without depending on generated OpenAPI artifacts,
   VS Code APIs, Node transport, Prism, or webview code.
+- 2026-04-26: the beta import command is contributed as
+  `ajsbutler.importDefinitionViaWebApiBeta`. It prompts in the extension host,
+  stores credentials through VS Code secret storage, calls a desktop WebAPI
+  infrastructure adapter behind the application port, and reports the number
+  of imported definition units without handing raw WebAPI responses to webview
+  or downstream presentation code.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -64,12 +64,10 @@ under `docs/requirements/use-cases/`.
 1. Align parameter parsing with JP1/Automatic Job Management System 3 version
    13 reference manuals when a behavior-changing parameter slice needs
    per-key coverage beyond the current audit summary.
-2. Implement the beta-labeled extension command and desktop infrastructure
-   adapter behind the application WebAPI import port.
-3. Record real JP1/AJS3 smoke verification before removing beta labeling.
-4. Extend list-view search on the current presentation path so parameter key
+2. Record real JP1/AJS3 smoke verification before removing beta labeling.
+3. Extend list-view search on the current presentation path so parameter key
    and value queries complement existing rendered-row partial matching.
-5. Keep desktop and web compatibility explicit whenever bootstrap, preview,
+4. Keep desktop and web compatibility explicit whenever bootstrap, preview,
    parsing, shared adapters, or runtime behavior change.
 
 ## Wrapper Semantics Matrix

--- a/package.json
+++ b/package.json
@@ -66,6 +66,13 @@
         "title": "Open JP1/AJS table viewer",
         "shortTitle": "JP1/AJS table viewer",
         "icon": "$(output)"
+      },
+      {
+        "command": "ajsbutler.importDefinitionViaWebApiBeta",
+        "category": "JP1/AJS",
+        "title": "Import JP1/AJS Definition via WebAPI (Beta)",
+        "shortTitle": "Import via WebAPI (Beta)",
+        "icon": "$(cloud-download)"
       }
     ],
     "menus": {
@@ -106,6 +113,7 @@
     ]
   },
   "activationEvents": [
+    "onCommand:ajsbutler.importDefinitionViaWebApiBeta",
     "onWebviewPanel:ajsbutler.tableViewer",
     "onWebviewPanel:ajsbutler.flowViewer"
   ],

--- a/src/extension/bootstrap/extensionSubscriptions.ts
+++ b/src/extension/bootstrap/extensionSubscriptions.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import type { TelemetryPort } from "../../application/telemetry/TelemetryPort";
 import { registerDiagnostics } from "../diagnostics/registerDiagnostics";
 import { registerHoverProvider } from "../languages/registerHoverProvider";
+import { createWebApiImportSubscriptions } from "./webapiImportWiring";
 import { createViewerSubscriptions } from "./viewerWiring";
 
 export const createExtensionSubscriptions = (
@@ -10,5 +11,6 @@ export const createExtensionSubscriptions = (
 ): vscode.Disposable[] => [
   registerDiagnostics(),
   registerHoverProvider(),
+  ...createWebApiImportSubscriptions({ context, telemetry }),
   ...createViewerSubscriptions({ context, telemetry }),
 ];

--- a/src/extension/bootstrap/webapiImportWiring.ts
+++ b/src/extension/bootstrap/webapiImportWiring.ts
@@ -1,0 +1,45 @@
+import * as vscode from "vscode";
+import type { TelemetryPort } from "../../application/telemetry/TelemetryPort";
+import { Jp1Ajs3WebApiImportAdapter } from "../../infrastructure/webapi/Jp1Ajs3WebApiImportAdapter";
+import {
+  IMPORT_AJS_DEFINITION_VIA_WEBAPI_COMMAND,
+  executeImportAjsDefinitionViaWebApiCommand,
+} from "../commands/importAjsDefinitionViaWebApiCommand";
+import { VscodeWebApiCredentialStore } from "../webapi/VscodeWebApiCredentialStore";
+
+export type WebApiImportWiringDeps = {
+  context: vscode.ExtensionContext;
+  telemetry: TelemetryPort;
+};
+
+export const createWebApiImportSubscriptions = ({
+  context,
+  telemetry,
+}: WebApiImportWiringDeps): vscode.Disposable[] => {
+  const credentialStore = new VscodeWebApiCredentialStore(context.secrets);
+  const importPort = new Jp1Ajs3WebApiImportAdapter({
+    credentialProvider: credentialStore,
+  });
+
+  return [
+    vscode.commands.registerCommand(
+      IMPORT_AJS_DEFINITION_VIA_WEBAPI_COMMAND,
+      () =>
+        executeImportAjsDefinitionViaWebApiCommand({
+          getHost: () =>
+            vscode.env.uiKind === vscode.UIKind.Web ? "web" : "desktop",
+          getLanguage: () => vscode.env.language,
+          showInputBox: (options) => vscode.window.showInputBox(options),
+          showInformationMessage: (message) =>
+            vscode.window.showInformationMessage(message),
+          showErrorMessage: (message) =>
+            vscode.window.showErrorMessage(message),
+          storeCredential: (credentialRef, credential) =>
+            credentialStore.storeCredential(credentialRef, credential),
+          importPort,
+          trackEvent: (eventName, properties) =>
+            telemetry.trackEvent(eventName, properties),
+        }),
+    ),
+  ];
+};

--- a/src/extension/commands/importAjsDefinitionViaWebApiCommand.ts
+++ b/src/extension/commands/importAjsDefinitionViaWebApiCommand.ts
@@ -1,0 +1,230 @@
+import {
+  buildDefinitionOnlyUnitListRequest,
+  createImportAjsDefinitionError,
+  type ImportAjsDefinitionConnectionDto,
+  type ImportAjsDefinitionFailureDto,
+  type ImportAjsDefinitionHostKind,
+  type ImportAjsDefinitionResultDto,
+  type ImportAjsDefinitionScopeDto,
+  type ImportAjsDefinitionViaWebApiPort,
+} from "../../application/webapi-import/importAjsDefinitionViaWebApi";
+
+export const IMPORT_AJS_DEFINITION_VIA_WEBAPI_COMMAND =
+  "ajsbutler.importDefinitionViaWebApiBeta";
+
+export type ImportAjsDefinitionInputOptions = {
+  prompt: string;
+  placeHolder?: string;
+  password?: boolean;
+  value?: string;
+};
+
+export type ImportAjsDefinitionCommandDeps = {
+  getHost: () => ImportAjsDefinitionHostKind;
+  getLanguage: () => string | undefined;
+  showInputBox: (
+    options: ImportAjsDefinitionInputOptions,
+  ) => Thenable<string | undefined>;
+  showInformationMessage: (message: string) => Thenable<string | undefined>;
+  showErrorMessage: (message: string) => Thenable<string | undefined>;
+  storeCredential: (
+    credentialRef: string,
+    credential: { username: string; password: string },
+  ) => Promise<void>;
+  importPort: ImportAjsDefinitionViaWebApiPort;
+  trackEvent: (eventName: string, properties?: Record<string, string>) => void;
+};
+
+type ImportInputs = {
+  connection: ImportAjsDefinitionConnectionDto;
+  scope: ImportAjsDefinitionScopeDto;
+  username: string;
+  password: string;
+};
+
+export const executeImportAjsDefinitionViaWebApiCommand = async (
+  deps: ImportAjsDefinitionCommandDeps,
+): Promise<ImportAjsDefinitionResultDto> => {
+  const host = deps.getHost();
+  if (host === "web") {
+    const result: ImportAjsDefinitionResultDto = {
+      ok: false,
+      error: createImportAjsDefinitionError(
+        "unsupported-host",
+        "JP1/AJS WebAPI import beta is available only in the desktop extension host.",
+      ),
+    };
+    await deps.showErrorMessage(result.error.message);
+    deps.trackEvent("webapiImport", {
+      result: "unsupported-host",
+    });
+    return result;
+  }
+
+  const inputs = await collectInputs(deps);
+  if (!inputs) {
+    const result: ImportAjsDefinitionResultDto = {
+      ok: false,
+      error: createImportAjsDefinitionError(
+        "cancelled",
+        "JP1/AJS WebAPI import was cancelled.",
+      ),
+    };
+    deps.trackEvent("webapiImport", {
+      result: "cancelled",
+    });
+    return result;
+  }
+
+  const request = buildDefinitionOnlyUnitListRequest({
+    host,
+    connection: inputs.connection,
+    scope: inputs.scope,
+    credentialRef: buildCredentialRef(inputs.connection, inputs.scope),
+  });
+
+  if ("ok" in request) {
+    await deps.showErrorMessage(request.error.message);
+    deps.trackEvent("webapiImport", {
+      result: request.error.code,
+    });
+    return request;
+  }
+
+  await deps.storeCredential(request.credentialRef ?? "", {
+    username: inputs.username,
+    password: inputs.password,
+  });
+
+  const result = await deps.importPort.importDefinition(request);
+  if (result.ok) {
+    await deps.showInformationMessage(
+      `JP1/AJS WebAPI import beta loaded ${result.content.units.length} unit(s).`,
+    );
+    deps.trackEvent("webapiImport", {
+      result: "success",
+      unitCount: String(result.content.units.length),
+      all: String(result.content.source.all),
+    });
+    return result;
+  }
+
+  if (isFailure(result)) {
+    const error = result.error;
+    await deps.showErrorMessage(error.message);
+    deps.trackEvent("webapiImport", {
+      result: error.code,
+      httpStatus: error.httpStatus ? String(error.httpStatus) : "none",
+    });
+  }
+  return result;
+};
+
+const collectInputs = async (
+  deps: ImportAjsDefinitionCommandDeps,
+): Promise<ImportInputs | undefined> => {
+  const baseUrl = await promptRequired(deps, {
+    prompt: "JP1/AJS Web Console URL",
+    placeHolder: "https://localhost:22252",
+  });
+  if (!baseUrl) {
+    return undefined;
+  }
+
+  const manager = await promptRequired(deps, {
+    prompt: "JP1/AJS manager host",
+    placeHolder: "manager.example.com",
+    value: extractHostName(baseUrl),
+  });
+  if (!manager) {
+    return undefined;
+  }
+
+  const serviceName = await promptRequired(deps, {
+    prompt: "JP1/AJS scheduler service name",
+    placeHolder: "AJSROOT1",
+  });
+  if (!serviceName) {
+    return undefined;
+  }
+
+  const location = await promptRequired(deps, {
+    prompt: "JP1/AJS unit location",
+    placeHolder: "/JobGroup",
+    value: "/",
+  });
+  if (!location) {
+    return undefined;
+  }
+
+  const username = await promptRequired(deps, {
+    prompt: "JP1/AJS user name",
+    placeHolder: "jp1admin",
+  });
+  if (!username) {
+    return undefined;
+  }
+
+  const password = await promptRequired(deps, {
+    prompt: "JP1/AJS password",
+    password: true,
+  });
+  if (!password) {
+    return undefined;
+  }
+
+  return {
+    connection: {
+      baseUrl,
+      acceptLanguage: toWebApiLanguage(deps.getLanguage()),
+    },
+    scope: {
+      manager,
+      serviceName,
+      location,
+      searchLowerUnits: true,
+    },
+    username,
+    password,
+  };
+};
+
+const promptRequired = async (
+  deps: ImportAjsDefinitionCommandDeps,
+  options: ImportAjsDefinitionInputOptions,
+): Promise<string | undefined> => {
+  const value = await deps.showInputBox(options);
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+};
+
+const buildCredentialRef = (
+  connection: ImportAjsDefinitionConnectionDto,
+  scope: ImportAjsDefinitionScopeDto,
+): string =>
+  [
+    "jp1-ajs-webapi",
+    normalizeCredentialRefPart(connection.baseUrl),
+    normalizeCredentialRefPart(scope.manager),
+    normalizeCredentialRefPart(scope.serviceName),
+  ].join(":");
+
+const normalizeCredentialRefPart = (value: string): string =>
+  encodeURIComponent(value.trim().toLowerCase());
+
+const extractHostName = (baseUrl: string): string | undefined => {
+  try {
+    return new URL(baseUrl).hostname;
+  } catch {
+    return undefined;
+  }
+};
+
+const toWebApiLanguage = (language: string | undefined): "ja" | "en" | "zh" => {
+  const normalized = language?.toLowerCase().split("-")[0];
+  return normalized === "ja" || normalized === "zh" ? normalized : "en";
+};
+
+const isFailure = (
+  result: ImportAjsDefinitionResultDto,
+): result is ImportAjsDefinitionFailureDto => !result.ok;

--- a/src/extension/webapi/VscodeWebApiCredentialStore.ts
+++ b/src/extension/webapi/VscodeWebApiCredentialStore.ts
@@ -1,0 +1,54 @@
+import * as vscode from "vscode";
+import type {
+  Jp1Ajs3WebApiCredential,
+  Jp1Ajs3WebApiCredentialProvider,
+} from "../../infrastructure/webapi/Jp1Ajs3WebApiImportAdapter";
+
+export class VscodeWebApiCredentialStore
+  implements Jp1Ajs3WebApiCredentialProvider
+{
+  #secrets: vscode.SecretStorage;
+
+  constructor(secrets: vscode.SecretStorage) {
+    this.#secrets = secrets;
+  }
+
+  async storeCredential(
+    credentialRef: string,
+    credential: Jp1Ajs3WebApiCredential,
+  ): Promise<void> {
+    await this.#secrets.store(credentialRef, JSON.stringify(credential));
+  }
+
+  async resolveCredential(
+    credentialRef: string | undefined,
+  ): Promise<Jp1Ajs3WebApiCredential | undefined> {
+    if (!credentialRef) {
+      return undefined;
+    }
+
+    const serialized = await this.#secrets.get(credentialRef);
+    if (!serialized) {
+      return undefined;
+    }
+
+    try {
+      const credential = JSON.parse(
+        serialized,
+      ) as Partial<Jp1Ajs3WebApiCredential>;
+      if (
+        typeof credential.username === "string" &&
+        typeof credential.password === "string"
+      ) {
+        return {
+          username: credential.username,
+          password: credential.password,
+        };
+      }
+    } catch {
+      return undefined;
+    }
+
+    return undefined;
+  }
+}

--- a/src/infrastructure/webapi/Jp1Ajs3WebApiImportAdapter.ts
+++ b/src/infrastructure/webapi/Jp1Ajs3WebApiImportAdapter.ts
@@ -1,0 +1,294 @@
+import {
+  createImportedAjsDefinitionContent,
+  createImportAjsDefinitionError,
+  mapHttpStatusToImportErrorCode,
+  type ImportAjsDefinitionPortRequestDto,
+  type ImportAjsDefinitionResultDto,
+  type ImportAjsDefinitionViaWebApiPort,
+  type ImportedAjsUnitDefinitionDto,
+} from "../../application/webapi-import/importAjsDefinitionViaWebApi";
+import type {
+  Jp1Ajs3StatusMonitoringResource,
+  Jp1Ajs3UnitDefinitionInformation,
+  Jp1Ajs3UnitListResponse,
+  Jp1Ajs3WebApiError,
+} from "./generated/jp1Ajs3WebApi.generated";
+
+export type Jp1Ajs3WebApiCredential = {
+  username: string;
+  password: string;
+};
+
+export interface Jp1Ajs3WebApiCredentialProvider {
+  resolveCredential(
+    credentialRef: string | undefined,
+  ): Promise<Jp1Ajs3WebApiCredential | undefined>;
+}
+
+export type Jp1Ajs3WebApiFetch = (
+  input: string,
+  init: {
+    method: "GET";
+    headers: Record<string, string>;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
+export type Jp1Ajs3WebApiImportAdapterDeps = {
+  credentialProvider: Jp1Ajs3WebApiCredentialProvider;
+  fetch?: Jp1Ajs3WebApiFetch;
+};
+
+const DEFAULT_TIMEOUT_MS = 30000;
+
+export class Jp1Ajs3WebApiImportAdapter
+  implements ImportAjsDefinitionViaWebApiPort
+{
+  #credentialProvider: Jp1Ajs3WebApiCredentialProvider;
+  #fetch: Jp1Ajs3WebApiFetch;
+
+  constructor(deps: Jp1Ajs3WebApiImportAdapterDeps) {
+    this.#credentialProvider = deps.credentialProvider;
+    this.#fetch = deps.fetch ?? defaultFetch;
+  }
+
+  async importDefinition(
+    request: ImportAjsDefinitionPortRequestDto,
+  ): Promise<ImportAjsDefinitionResultDto> {
+    const credential = await this.#credentialProvider.resolveCredential(
+      request.credentialRef,
+    );
+    if (!credential) {
+      return {
+        ok: false,
+        error: createImportAjsDefinitionError(
+          "authentication-failed",
+          "JP1/AJS WebAPI credentials are not available.",
+        ),
+      };
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      request.connection.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await this.#fetch(buildRequestUrl(request), {
+        method: request.method,
+        headers: buildHeaders(request, credential),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        return await toErrorResult(response);
+      }
+
+      const body = await response.json();
+      if (!isUnitListResponse(body)) {
+        return {
+          ok: false,
+          error: createImportAjsDefinitionError(
+            "malformed-response",
+            "JP1/AJS WebAPI returned an unexpected unit-list response shape.",
+          ),
+        };
+      }
+
+      return toSuccessResult(request, body);
+    } catch (error) {
+      return toTransportError(error);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+const defaultFetch: Jp1Ajs3WebApiFetch = async (input, init) => {
+  const fetchImpl = globalThis.fetch;
+  if (!fetchImpl) {
+    throw new Error("Fetch API is not available in this extension host.");
+  }
+
+  return fetchImpl(input, init);
+};
+
+const buildRequestUrl = (
+  request: ImportAjsDefinitionPortRequestDto,
+): string => {
+  const url = new URL(
+    request.path,
+    ensureTrailingSlash(request.connection.baseUrl),
+  );
+  Object.entries(request.query).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+  return url.toString();
+};
+
+const ensureTrailingSlash = (baseUrl: string): string =>
+  baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+
+const buildHeaders = (
+  request: ImportAjsDefinitionPortRequestDto,
+  credential: Jp1Ajs3WebApiCredential,
+): Record<string, string> => {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Accept-Language": request.connection.acceptLanguage ?? "en",
+    "X-AJS-Authorization": encodeCredential(credential),
+  };
+
+  return headers;
+};
+
+const encodeCredential = (credential: Jp1Ajs3WebApiCredential): string => {
+  const value = `${credential.username}:${credential.password}`;
+  return btoa(unescape(encodeURIComponent(value)));
+};
+
+const toErrorResult = async (response: {
+  status: number;
+  json(): Promise<unknown>;
+}): Promise<ImportAjsDefinitionResultDto> => {
+  const body = await safeJson(response);
+  const apiError = isWebApiError(body) ? body : undefined;
+  return {
+    ok: false,
+    error: createImportAjsDefinitionError(
+      mapHttpStatusToImportErrorCode(response.status),
+      apiError?.message ?? `JP1/AJS WebAPI returned HTTP ${response.status}.`,
+      {
+        httpStatus: response.status,
+        messageId: apiError?.messageID,
+      },
+    ),
+  };
+};
+
+const safeJson = async (response: { json(): Promise<unknown> }) => {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+};
+
+const toSuccessResult = (
+  request: ImportAjsDefinitionPortRequestDto,
+  response: Jp1Ajs3UnitListResponse,
+): ImportAjsDefinitionResultDto => {
+  const units = response.statuses
+    .map((status) => status.definition)
+    .filter(isUnitDefinition)
+    .map(toImportedUnitDefinition);
+  const warnings = [
+    ...(!response.all
+      ? [
+          {
+            code: "partial-result" as const,
+            message:
+              "JP1/AJS WebAPI reported that the unit-list response was truncated.",
+          },
+        ]
+      : []),
+    ...(response.statuses.length === 0
+      ? [
+          {
+            code: "empty-result" as const,
+            message: "JP1/AJS WebAPI returned no units for the selected scope.",
+          },
+        ]
+      : []),
+    ...response.statuses
+      .filter((status) => status.definition === null)
+      .map((status) => ({
+        code: "definition-missing" as const,
+        message:
+          "A status-monitoring resource did not include definition data.",
+        unitName: status.unitStatus?.unitName,
+      })),
+  ];
+
+  return {
+    ok: true,
+    content: createImportedAjsDefinitionContent(
+      {
+        manager: request.query.manager,
+        serviceName: request.query.serviceName,
+        location: request.query.location,
+        all: response.all,
+      },
+      units,
+      warnings,
+    ),
+  };
+};
+
+const toTransportError = (error: unknown): ImportAjsDefinitionResultDto => {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return {
+      ok: false,
+      error: createImportAjsDefinitionError(
+        "timeout",
+        "JP1/AJS WebAPI request timed out.",
+      ),
+    };
+  }
+
+  return {
+    ok: false,
+    error: createImportAjsDefinitionError(
+      "network-failed",
+      "JP1/AJS WebAPI request failed before a response was received.",
+    ),
+  };
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isUnitListResponse = (value: unknown): value is Jp1Ajs3UnitListResponse =>
+  isRecord(value) &&
+  Array.isArray(value.statuses) &&
+  value.statuses.every(isStatusMonitoringResource) &&
+  typeof value.all === "boolean";
+
+const isStatusMonitoringResource = (
+  value: unknown,
+): value is Jp1Ajs3StatusMonitoringResource => isRecord(value);
+
+const isWebApiError = (value: unknown): value is Jp1Ajs3WebApiError =>
+  isRecord(value) &&
+  (typeof value.message === "string" || typeof value.messageID === "string");
+
+const isUnitDefinition = (
+  definition: Jp1Ajs3StatusMonitoringResource["definition"],
+): definition is Jp1Ajs3UnitDefinitionInformation =>
+  isRecord(definition) && typeof definition.unitName === "string";
+
+const toImportedUnitDefinition = (
+  definition: Jp1Ajs3UnitDefinitionInformation,
+): ImportedAjsUnitDefinitionDto => ({
+  unitName: definition.unitName ?? "",
+  simpleUnitName: definition.simpleUnitName,
+  unitType: definition.unitType,
+  unitComment: definition.unitComment,
+  owner: definition.owner,
+  parameters: definition.parameters,
+  rootJobnetName: definition.rootJobnetName,
+  execAgent: definition.execAgent,
+  execFileName: definition.execFileName,
+  customJobType: definition.customJobType,
+  registerStatus: definition.registerStatus,
+  recoveryUnit: definition.recoveryUnit,
+  wait: definition.wait,
+  jobnetReleaseUnit: definition.jobnetReleaseUnit,
+  jp1ResourceGroup: definition.jp1ResourceGroup,
+  unitID: definition.unitID,
+});

--- a/src/test/suite/Jp1Ajs3WebApiImportAdapter.test.ts
+++ b/src/test/suite/Jp1Ajs3WebApiImportAdapter.test.ts
@@ -1,0 +1,200 @@
+import * as assert from "assert";
+import { Jp1Ajs3WebApiImportAdapter } from "../../infrastructure/webapi/Jp1Ajs3WebApiImportAdapter";
+import type { ImportAjsDefinitionPortRequestDto } from "../../application/webapi-import/importAjsDefinitionViaWebApi";
+
+const baseRequest: ImportAjsDefinitionPortRequestDto = {
+  endpoint: "unit-list",
+  method: "GET",
+  path: "/ajs/api/v1/objects/statuses",
+  connection: {
+    baseUrl: "https://web-console.example.com:22252",
+    acceptLanguage: "en",
+    timeoutMs: 1000,
+  },
+  credentialRef: "credential-ref",
+  query: {
+    mode: "search",
+    manager: "manager.example.com",
+    serviceName: "AJSROOT1",
+    location: "/JobGroup",
+    searchLowerUnits: "YES",
+    searchTarget: "DEFINITION",
+  },
+};
+
+suite("JP1/AJS3 WebAPI import adapter", () => {
+  test("maps a successful unit-list response to application content", async () => {
+    const requested: Array<{
+      input: string;
+      headers: Record<string, string>;
+    }> = [];
+    const adapter = new Jp1Ajs3WebApiImportAdapter({
+      credentialProvider: {
+        async resolveCredential() {
+          return {
+            username: "jp1admin",
+            password: "secret",
+          };
+        },
+      },
+      async fetch(input, init) {
+        requested.push({ input, headers: init.headers });
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              statuses: [
+                {
+                  definition: {
+                    unitName: "/JobGroup/Jobnet",
+                    simpleUnitName: "Jobnet",
+                    unitType: "ROOTNET",
+                    parameters: "sample=sample_ref_minimal_utf8",
+                  },
+                  unitStatus: null,
+                  release: null,
+                },
+              ],
+              all: true,
+            };
+          },
+        };
+      },
+    });
+
+    const result = await adapter.importDefinition(baseRequest);
+
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) {
+      throw new Error("Expected successful import.");
+    }
+    assert.strictEqual(result.content.units[0].unitName, "/JobGroup/Jobnet");
+    assert.strictEqual(result.content.source.apiId, "SC-009");
+    assert.strictEqual(requested.length, 1);
+    assert.ok(
+      requested[0].input.includes(
+        "/ajs/api/v1/objects/statuses?mode=search&manager=manager.example.com",
+      ),
+    );
+    assert.strictEqual(requested[0].headers["Accept-Language"], "en");
+    assert.ok(requested[0].headers["X-AJS-Authorization"].length > 0);
+  });
+
+  test("defaults Accept-Language to en for Prism-compatible requests", async () => {
+    let acceptLanguage: string | undefined;
+    const adapter = new Jp1Ajs3WebApiImportAdapter({
+      credentialProvider: {
+        async resolveCredential() {
+          return {
+            username: "jp1admin",
+            password: "secret",
+          };
+        },
+      },
+      async fetch(_input, init) {
+        acceptLanguage = init.headers["Accept-Language"];
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              statuses: [],
+              all: true,
+            };
+          },
+        };
+      },
+    });
+
+    await adapter.importDefinition({
+      ...baseRequest,
+      connection: {
+        baseUrl: baseRequest.connection.baseUrl,
+      },
+    });
+
+    assert.strictEqual(acceptLanguage, "en");
+  });
+
+  test("returns authentication failure when credentials are unavailable", async () => {
+    const adapter = new Jp1Ajs3WebApiImportAdapter({
+      credentialProvider: {
+        async resolveCredential() {
+          return undefined;
+        },
+      },
+      async fetch() {
+        throw new Error("fetch should not be called");
+      },
+    });
+
+    const result = await adapter.importDefinition(baseRequest);
+
+    assert.strictEqual(result.ok, false);
+    if (result.ok) {
+      throw new Error("Expected failed import.");
+    }
+    assert.strictEqual(result.error.code, "authentication-failed");
+  });
+
+  test("maps HTTP errors without leaking credentials", async () => {
+    const adapter = new Jp1Ajs3WebApiImportAdapter({
+      credentialProvider: {
+        async resolveCredential() {
+          return { username: "jp1admin", password: "secret" };
+        },
+      },
+      async fetch() {
+        return {
+          ok: false,
+          status: 403,
+          async json() {
+            return {
+              message: "The operator does not have execution permission.",
+              messageID: "KNAK403",
+            };
+          },
+        };
+      },
+    });
+
+    const result = await adapter.importDefinition(baseRequest);
+
+    assert.strictEqual(result.ok, false);
+    if (result.ok) {
+      throw new Error("Expected failed import.");
+    }
+    assert.strictEqual(result.error.code, "authorization-failed");
+    assert.strictEqual(result.error.httpStatus, 403);
+    assert.strictEqual(result.error.messageId, "KNAK403");
+    assert.ok(!result.error.message.includes("secret"));
+  });
+
+  test("rejects malformed success responses", async () => {
+    const adapter = new Jp1Ajs3WebApiImportAdapter({
+      credentialProvider: {
+        async resolveCredential() {
+          return { username: "jp1admin", password: "secret" };
+        },
+      },
+      async fetch() {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return { statuses: null };
+          },
+        };
+      },
+    });
+
+    const result = await adapter.importDefinition(baseRequest);
+
+    assert.strictEqual(result.ok, false);
+    if (result.ok) {
+      throw new Error("Expected failed import.");
+    }
+    assert.strictEqual(result.error.code, "malformed-response");
+  });
+});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -33,6 +33,7 @@ suite("Extension Test Suite", () => {
 
     assert.ok(commands.includes("open.ajsbutler.tableViewer"));
     assert.ok(commands.includes("open.ajsbutler.flowViewer"));
+    assert.ok(commands.includes("ajsbutler.importDefinitionViaWebApiBeta"));
   });
 
   test("provides diagnostics for invalid jp1ajs documents", async () => {

--- a/src/test/suite/extensionSubscriptions.test.ts
+++ b/src/test/suite/extensionSubscriptions.test.ts
@@ -4,7 +4,7 @@ import type { TelemetryPort } from "../../application/telemetry/TelemetryPort";
 import { createExtensionSubscriptions } from "../../extension/bootstrap/extensionSubscriptions";
 
 suite("Extension subscriptions", () => {
-  test("creates diagnostics, hover, and viewer subscriptions", () => {
+  test("creates diagnostics, hover, import, and viewer subscriptions", () => {
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
     const telemetry: TelemetryPort = {
       trackEvent() {},
@@ -13,7 +13,7 @@ suite("Extension subscriptions", () => {
 
     const subscriptions = createExtensionSubscriptions(context, telemetry);
 
-    assert.strictEqual(subscriptions.length, 6);
+    assert.strictEqual(subscriptions.length, 7);
     subscriptions.forEach((subscription) => {
       assert.strictEqual(typeof subscription.dispose, "function");
       subscription.dispose();

--- a/src/test/suite/importAjsDefinitionViaWebApiCommand.test.ts
+++ b/src/test/suite/importAjsDefinitionViaWebApiCommand.test.ts
@@ -1,0 +1,191 @@
+import * as assert from "assert";
+import {
+  executeImportAjsDefinitionViaWebApiCommand,
+  IMPORT_AJS_DEFINITION_VIA_WEBAPI_COMMAND,
+  type ImportAjsDefinitionCommandDeps,
+} from "../../extension/commands/importAjsDefinitionViaWebApiCommand";
+import {
+  createImportedAjsDefinitionContent,
+  type ImportAjsDefinitionPortRequestDto,
+} from "../../application/webapi-import/importAjsDefinitionViaWebApi";
+
+const createDeps = (
+  answers: string[],
+  overrides: Partial<ImportAjsDefinitionCommandDeps> = {},
+) => {
+  const prompts: Array<{ prompt: string; value?: string }> = [];
+  const credentials: Array<{
+    credentialRef: string;
+    username: string;
+    password: string;
+  }> = [];
+  const imports: ImportAjsDefinitionPortRequestDto[] = [];
+  const informationMessages: string[] = [];
+  const errorMessages: string[] = [];
+  const events: Array<{
+    eventName: string;
+    properties?: Record<string, string>;
+  }> = [];
+
+  const deps: ImportAjsDefinitionCommandDeps = {
+    getHost: () => "desktop",
+    getLanguage: () => "ja",
+    async showInputBox(options) {
+      prompts.push({ prompt: options.prompt, value: options.value });
+      return answers.shift();
+    },
+    async showInformationMessage(message) {
+      informationMessages.push(message);
+      return undefined;
+    },
+    async showErrorMessage(message) {
+      errorMessages.push(message);
+      return undefined;
+    },
+    async storeCredential(credentialRef, credential) {
+      credentials.push({
+        credentialRef,
+        username: credential.username,
+        password: credential.password,
+      });
+    },
+    importPort: {
+      async importDefinition(request) {
+        imports.push(request);
+        return {
+          ok: true,
+          content: createImportedAjsDefinitionContent(
+            {
+              manager: request.query.manager,
+              serviceName: request.query.serviceName,
+              location: request.query.location,
+              all: true,
+            },
+            [{ unitName: "/JobGroup/Jobnet" }],
+          ),
+        };
+      },
+    },
+    trackEvent(eventName, properties) {
+      events.push({ eventName, properties });
+    },
+    ...overrides,
+  };
+
+  return {
+    deps,
+    prompts,
+    credentials,
+    imports,
+    informationMessages,
+    errorMessages,
+    events,
+  };
+};
+
+suite("Import AJS definition via WebAPI command", () => {
+  test("uses the contributed beta command id", () => {
+    assert.strictEqual(
+      IMPORT_AJS_DEFINITION_VIA_WEBAPI_COMMAND,
+      "ajsbutler.importDefinitionViaWebApiBeta",
+    );
+  });
+
+  test("collects desktop inputs and calls the import port", async () => {
+    const state = createDeps([
+      "https://web-console.example.com:22252",
+      "manager.example.com",
+      "AJSROOT1",
+      "/JobGroup",
+      "jp1admin",
+      "secret",
+    ]);
+
+    const result = await executeImportAjsDefinitionViaWebApiCommand(state.deps);
+
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(state.prompts, [
+      { prompt: "JP1/AJS Web Console URL", value: undefined },
+      {
+        prompt: "JP1/AJS manager host",
+        value: "web-console.example.com",
+      },
+      {
+        prompt: "JP1/AJS scheduler service name",
+        value: undefined,
+      },
+      { prompt: "JP1/AJS unit location", value: "/" },
+      { prompt: "JP1/AJS user name", value: undefined },
+      { prompt: "JP1/AJS password", value: undefined },
+    ]);
+    assert.strictEqual(state.imports.length, 1);
+    assert.deepStrictEqual(state.imports[0].query, {
+      mode: "search",
+      manager: "manager.example.com",
+      serviceName: "AJSROOT1",
+      location: "/JobGroup",
+      searchLowerUnits: "YES",
+      searchTarget: "DEFINITION",
+    });
+    assert.strictEqual(state.imports[0].connection.acceptLanguage, "ja");
+    assert.strictEqual(state.credentials.length, 1);
+    assert.strictEqual(state.credentials[0].username, "jp1admin");
+    assert.strictEqual(state.credentials[0].password, "secret");
+    assert.deepStrictEqual(state.informationMessages, [
+      "JP1/AJS WebAPI import beta loaded 1 unit(s).",
+    ]);
+    assert.strictEqual(state.events.at(-1)?.properties?.result, "success");
+  });
+
+  test("returns cancelled without storing credentials when input is cancelled", async () => {
+    const state = createDeps(["https://web-console.example.com:22252"]);
+
+    const result = await executeImportAjsDefinitionViaWebApiCommand(state.deps);
+
+    assert.strictEqual(result.ok, false);
+    if (result.ok) {
+      throw new Error("Expected cancelled result.");
+    }
+    assert.strictEqual(result.error.code, "cancelled");
+    assert.deepStrictEqual(state.credentials, []);
+    assert.deepStrictEqual(state.imports, []);
+  });
+
+  test("falls back to en when VS Code language is not supported by WebAPI", async () => {
+    const state = createDeps(
+      [
+        "https://web-console.example.com:22252",
+        "manager.example.com",
+        "AJSROOT1",
+        "/JobGroup",
+        "jp1admin",
+        "secret",
+      ],
+      {
+        getLanguage: () => "fr",
+      },
+    );
+
+    await executeImportAjsDefinitionViaWebApiCommand(state.deps);
+
+    assert.strictEqual(state.imports[0].connection.acceptLanguage, "en");
+  });
+
+  test("reports unsupported host before prompting in web execution", async () => {
+    const state = createDeps([], {
+      getHost: () => "web",
+    });
+
+    const result = await executeImportAjsDefinitionViaWebApiCommand(state.deps);
+
+    assert.strictEqual(result.ok, false);
+    if (result.ok) {
+      throw new Error("Expected unsupported host result.");
+    }
+    assert.strictEqual(result.error.code, "unsupported-host");
+    assert.deepStrictEqual(state.prompts, []);
+    assert.deepStrictEqual(state.errorMessages, [
+      "JP1/AJS WebAPI import beta is available only in the desktop extension host.",
+    ]);
+  });
+});

--- a/src/test/suite/webapiImportBoundary.test.ts
+++ b/src/test/suite/webapiImportBoundary.test.ts
@@ -1,0 +1,33 @@
+import * as assert from "assert";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+suite("WebAPI import boundaries", () => {
+  test("keeps application WebAPI import free of runtime adapter dependencies", () => {
+    const source = readFileSync(
+      join(
+        __dirname,
+        "../../application/webapi-import/importAjsDefinitionViaWebApi.js",
+      ),
+      "utf8",
+    );
+
+    const forbiddenImports = [
+      "vscode",
+      "node:",
+      "infrastructure/webapi",
+      "generated/jp1Ajs3WebApi",
+      "ui-component",
+      "webview",
+      "react",
+      "Prism",
+    ];
+
+    forbiddenImports.forEach((forbiddenImport) => {
+      assert.ok(
+        !source.includes(forbiddenImport),
+        `application WebAPI import must not include ${forbiddenImport}`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- Added the beta VS Code command `ajsbutler.importDefinitionViaWebApiBeta`.
- Added desktop command wiring that collects Web Console URL, Manager host, scheduler service, unit location, and credentials outside webview code.
- Stores JP1/AJS credentials through VS Code SecretStorage and passes only a credential reference through application DTOs.
- Added a desktop JP1/AJS3 WebAPI infrastructure adapter behind the application import port.
- Maps WebAPI success responses to normalized imported definition content and documented HTTP/transport failures to structured recoverable errors.
- Uses `vscode.env.language` like the existing MyContext resource flow, sending `ja`/`zh` when supported and defaulting to `en` otherwise.
- Added beta command contribution and activation event.
- Updated SDD docs to mark command, adapter, compatibility tests, and beta labeling complete.

## Why

This completes the first beta command/adapter slice for read-only JP1/AJS WebAPI import while keeping transport, authentication, and raw WebAPI responses outside domain/application/presentation consumers.

## Validation

- `pnpm run qlty` passed before the final language fallback adjustment; a later rerun was cancelled locally.
- `pnpm run lint:md`
- `pnpm run openapi:check`
- `pnpm exec tsc -p tsconfig.test.json --noEmit`
- `pnpm test`
- `pnpm run build` passed with existing webpack bundle-size warnings
- `pnpm run test:web` passed with sandbox-external execution for Playwright Chromium
- Manual Prism smoke: `pnpm run openapi:mock` target loaded 1 unit and showed the success notification.

## Compatibility

- No change to `engines.vscode`.
- Web extension execution returns an unsupported-host result for this first slice.
- Application WebAPI import remains free of `vscode`, Node transport, generated OpenAPI, Prism, and webview dependencies.
- The new adapter is wired through extension/infrastructure boundaries and does not pass raw WebAPI response objects to webview or downstream presentation code.