### PR TITLE
[codex] Align schedule-rule ln behavior

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -19,16 +19,19 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 - Added command-builder metadata for the supported commands.
 - Localized command-builder labels, descriptions, and manual links through the
   existing message resources.
+- Prepared the schedule-rule parameter slice in
+  `SCHEDULE_RULE_ALIGNMENT.md`.
+- Added behavior-preserving schedule-rule regression tests for thin evidence
+  before changing helper semantics.
+- Implemented the first behavior-changing schedule-rule alignment fix by
+  ignoring `ln` on root jobnets.
 
 ## Follow-up
 
 - Build a parameter-coverage matrix only when a behavior-changing alignment
   slice needs per-key status beyond the current audit summary.
-- Use the schedule-rule family as the next likely behavior-changing parameter
-  slice: `sd`, `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`, `wc`, and
-  `wt`.
-- Keep this as a focused manual-alignment slice before introducing a broad
-  repository-wide parameter matrix.
+- Choose the next behavior-changing schedule-rule fix from the remaining
+  partial statuses.
 
 ## Validation
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
@@ -1,0 +1,221 @@
+# Schedule Rule Parameter Alignment
+
+## Purpose
+
+Prepare the focused JP1/AJS3 version 13 schedule-rule alignment slice before
+changing parser or helper behavior.
+
+This document keeps the slice narrower than a repository-wide parameter matrix.
+It covers only the jobnet schedule-rule family already called out in
+`AUDIT.md`: `sd`, `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`, `wc`, and
+`wt`.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual section: Command Reference, `5.2.4 Jobnet definition`
+- Source URL:
+  <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0219.HTM>
+
+## Slice Boundary
+
+- Owning domain seams:
+  `src/domain/models/parameters/ruleParameterBuilders.ts`,
+  `src/domain/models/parameters/parameterHelpers.ts`, and
+  `src/domain/models/parameters/ScheduleRule.ts`
+- Primary application consumer:
+  `src/application/unit-list/buildUnitListGroup10View.ts`
+- Regression evidence:
+  `src/test/suite/parameterHelpers.test.ts`,
+  `src/test/suite/parameterFactory.test.ts`,
+  `src/test/suite/buildUnitListGroup10View.test.ts`, and
+  `src/test/suite/buildUnitListView.test.ts`
+- Out of scope for this slice:
+  parser grammar token generation, all-key coverage, UI redesign, and unrelated
+  command-generation work
+
+## Manual-Aligned Expectations
+
+### `sd`
+
+- Manual expectation:
+  jobnet execution dates are repeatable, support rule numbers, allow
+  root-jobnet omission to default to rule `1` / `en`, and allow `sd=0,ud` to
+  make schedules undefined.
+- Current implementation seam:
+  `buildRootDefaultAwareScheduleRuleParameters`, `resolveSdParameters`, and
+  `Sd`.
+- Existing regression evidence:
+  root defaults and explicit multi-rule values are covered in
+  `parameterHelpers.test.ts` and `parameterFactory.test.ts`; unit-list
+  projection is covered in list tests. `parameterFactory.test.ts` also covers
+  explicit `sd=0,ud` preservation.
+- Status:
+  partial. Default, sorting, and `sd=0,ud` preservation evidence exists; any
+  collapse or reinterpretation of `sd=0,ud` still needs a product decision.
+
+### `ln`
+
+- Manual expectation:
+  rule numbers map a nested jobnet schedule rule to an upper-level jobnet
+  schedule rule; root-jobnet use is ignored by JP1/AJS3.
+- Current implementation seam:
+  `buildSortedScheduleRuleParameters` and `Ln`.
+- Existing regression evidence:
+  sorting by rule is covered in helper and facade tests; list projection is
+  covered. Root-jobnet ignored behavior is covered in
+  `parameterFactory.test.ts`, `buildUnitListGroup10View.test.ts`, and
+  `buildUnitListView.test.ts`.
+- Status:
+  aligned for the current slice. `ln` values on the root jobnet are ignored by
+  the domain facade and unit-list projection, while nested jobnet values remain
+  visible and sorted by rule.
+
+### `st`
+
+- Manual expectation:
+  execution start time is per `sd` rule; omitted values default to relative
+  `+00:00`.
+- Current implementation seam:
+  `buildSdAlignedDefaultScheduleRuleParameters` and `St`.
+- Existing regression evidence:
+  default alignment is covered in `parameterFactory.test.ts`.
+- Status:
+  partial. Default alignment exists; behavior-changing time validation is not
+  enforced.
+
+### `cy`
+
+- Manual expectation:
+  processing cycle is per `sd` rule and is omitted when no processing cycle is
+  set.
+- Current implementation seam:
+  `buildSdAlignedEmptyScheduleRuleParameters` and `Cy`.
+- Existing regression evidence:
+  empty `sd`-aligned placeholder behavior is covered generically; list
+  projection is covered.
+- Status:
+  partial. Generic alignment exists; cycle range and open/closed day
+  restrictions are not enforced.
+
+### `sh`
+
+- Manual expectation:
+  closed-day substitution is per `sd` rule and supports `be`, `af`, `ca`, and
+  `no`.
+- Current implementation seam:
+  `buildSdAlignedEmptyScheduleRuleParameters` and `Sh`.
+- Existing regression evidence:
+  list projection covers explicit values.
+- Status:
+  partial. Value parsing exists; focused default/omission evidence is thin.
+
+### `shd`
+
+- Manual expectation:
+  maximum shift days are per `sd` rule and default to `2`.
+- Current implementation seam:
+  `buildSdAlignedDefaultScheduleRuleParameters` and `Shd`.
+- Existing regression evidence:
+  default builder behavior is covered generically and through
+  `parameterFactory.test.ts`.
+- Status:
+  partial. Default value is encoded; range validation is not enforced.
+
+### `cftd`
+
+- Manual expectation:
+  schedule-by-days-from-start is per `sd` rule; omitted values default to
+  `no`; start days default to `1`; maximum shift days default to `10` except
+  when invalid for the selected mode.
+- Current implementation seam:
+  `buildSdAlignedDefaultScheduleRuleParameters` and `Cftd`.
+- Existing regression evidence:
+  list projection covers explicit parsed display fields. Default expansion is
+  covered in `parameterFactory.test.ts`.
+- Status:
+  partial. Value parsing and defaults exist; mode-specific invalid fields need
+  explicit evidence.
+
+### `sy`
+
+- Manual expectation:
+  delayed start time is per `sd` rule and supports absolute or relative-minute
+  formats.
+- Current implementation seam:
+  `buildSdAlignedEmptyScheduleRuleParameters` and `Sy`.
+- Existing regression evidence:
+  list projection covers explicit values. Relative-minute preservation is
+  covered in `parameterFactory.test.ts`.
+- Status:
+  partial. Aligned omission and relative-minute preservation exist; range
+  validation is not enforced.
+
+### `ey`
+
+- Manual expectation:
+  delayed end time is per `sd` rule and supports absolute or relative-minute
+  formats.
+- Current implementation seam:
+  `buildSdAlignedEmptyScheduleRuleParameters` and `Ey`.
+- Existing regression evidence:
+  generic empty alignment evidence exists; list projection covers explicit
+  values. Relative-minute preservation is covered in `parameterFactory.test.ts`.
+- Status:
+  partial. Aligned omission and relative-minute preservation exist; range
+  validation is not enforced.
+
+### `wc`
+
+- Manual expectation:
+  start-condition execution count is per `sd` rule, defaults to `no`, and is
+  paired with `wt`.
+- Current implementation seam:
+  `buildSdAlignedDefaultScheduleRuleParameters` and `Wc`.
+- Existing regression evidence:
+  explicit and fallback values are covered in helper and facade tests. Default
+  expansion for all effective `sd` rules is covered in
+  `parameterFactory.test.ts`.
+- Status:
+  partial. Default alignment exists; paired `wt` invalidation is not modeled.
+
+### `wt`
+
+- Manual expectation:
+  start-condition monitoring end time is per `sd` rule, defaults to `no`, and
+  is paired with `wc`.
+- Current implementation seam:
+  `buildSdAlignedDefaultScheduleRuleParameters` and `Wt`.
+- Existing regression evidence:
+  default alignment is covered in facade tests. Default expansion for all
+  effective `sd` rules is covered in `parameterFactory.test.ts`.
+- Status:
+  partial. Default alignment exists; paired `wc` invalidation is not modeled.
+
+## Next Implementation Acceptance Criteria
+
+- Preserve current DTO output for existing unit-list schedule columns.
+- Add focused regression tests for at least one currently thin behavior before
+  changing helper semantics.
+- Keep schedule-rule interpretation in domain/application seams; UI components
+  must continue consuming view-model fields.
+- If a manual mismatch is intentionally left open, record it here with the
+  affected key, code seam, and missing evidence.
+
+## Behavior-Preserving Evidence
+
+Behavior-preserving tests now cover default expansion and known manual edge
+cases:
+
+1. `sd=0,ud` remains visible as an undefined-schedule rule until a product
+   decision says to collapse all schedule items.
+2. `st`, `shd`, `cftd`, `wc`, and `wt` synthesize documented defaults for each
+   effective `sd` rule.
+3. `sy` and `ey` preserve relative-minute values without viewer-specific
+   parsing.
+
+## Delivered Behavior-Changing Alignment
+
+- `ln`: root-jobnet values are ignored, matching the manual note that root
+  jobnet specification is ignored. Nested jobnet `ln` values continue to be
+  sorted and projected into the unit-list parent-rule column.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -30,15 +30,23 @@
       existing default command text
 - [x] Localize command-builder labels, descriptions, and command reference
       links through the existing `lang` context
+- [x] Prepare the next behavior-changing alignment slice around schedule-rule
+      parameters (`sd`, `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`,
+      `wc`, and `wt`) with manual references, code seams, and regression
+      evidence status
+- [x] Add behavior-preserving regression tests for thin schedule-rule evidence
+      before changing helper semantics
+- [x] Implement the first behavior-changing schedule-rule alignment fix:
+      ignore `ln` on root jobnets while preserving nested jobnet `ln`
+      behavior
 
 ## Follow-up
 
 - [ ] Turn the audit notes into an explicit parameter-coverage matrix only when
       a behavior-changing alignment slice needs per-key status beyond the
       current audit summary
-- [ ] Prepare the next behavior-changing alignment slice around schedule-rule
-      parameters (`sd`, `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`,
-      `wc`, and `wt`) before attempting a broad all-key coverage matrix
+- [ ] Choose the next schedule-rule manual-alignment fix from the remaining
+      partial statuses
 
 ## Notes
 
@@ -64,3 +72,12 @@
   family because these keys already share helper seams, affect unit-list
   behavior, and can be covered as a focused manual-alignment slice without
   creating a full parameter matrix first.
+- 2026-04-27: schedule-rule alignment preparation is recorded in
+  `SCHEDULE_RULE_ALIGNMENT.md`, keeping the matrix limited to the focused
+  schedule-rule family instead of expanding to all parameters.
+- 2026-04-27: behavior-preserving regression tests now cover explicit
+  `sd=0,ud` preservation, default expansion for `st`, `shd`, `cftd`, `wc`, and
+  `wt`, and relative-minute preservation for `sy` and `ey`.
+- 2026-04-27: `ln` now follows the JP1/AJS3 v13 root-jobnet rule: root-jobnet
+  `ln` values are ignored, while nested jobnet `ln` values remain sorted and
+  visible to the unit-list parent-rule projection.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -22,9 +22,8 @@ under `docs/requirements/use-cases/`.
 
 ## Next Priority Tasks
 
-1. Prepare the schedule-rule parameter alignment slice with manual references,
-   per-key expected behavior, and regression evidence before changing parsing
-   or helper semantics.
+1. Choose the next behavior-changing schedule-rule manual-alignment fix from
+   the remaining partial statuses.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -18,8 +18,10 @@
    - Add traceability from JP1/AJS v13 manual sections to supported parameter
      keys, parser behavior, normalized model fields, use cases, and regression
      tests.
-   - The next likely focused slice is the schedule-rule parameter family:
-     `sd`, `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`.
+   - The active focused slice is the schedule-rule parameter family: `sd`,
+     `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`; the
+     first behavior-changing fix ignores root-jobnet `ln` values, and the next
+     fix should come from the remaining partial statuses.
    - Keep behavior-preserving slices separate from behavior-changing manual
      alignment slices.
 

--- a/src/application/unit-list/buildUnitListGroup10View.ts
+++ b/src/application/unit-list/buildUnitListGroup10View.ts
@@ -22,7 +22,9 @@ export const buildUnitListGroup10View = (
   executionDate: findAjsUnitParameterValue(unit, "ed"),
   jobGroupPath: findAjsUnitParameterValue(unit, "jc"),
   exclusiveJobnetName: findAjsUnitParameterValue(unit, "ejn"),
-  parentRules: findAjsUnitParameterValues(unit, "ln").map(parseLnParentRule),
+  parentRules: unit.isRootJobnet
+    ? []
+    : findAjsUnitParameterValues(unit, "ln").map(parseLnParentRule),
   scheduleDateTypes: findAjsUnitParameterValues(unit, "sd").map(
     (value) => parseSd(value).type,
   ),

--- a/src/domain/models/parameters/ruleParameterBuilders.ts
+++ b/src/domain/models/parameters/ruleParameterBuilders.ts
@@ -66,6 +66,27 @@ const createSortedScheduleRuleBuilder = <
     );
 };
 
+const createRootJobnetIgnoredScheduleRuleBuilder = <
+  T extends ScheduleRule,
+  P extends ParamInternal["parameter"],
+>(
+  parameter: P,
+  mapParam: (param: ParamInternal) => T,
+) => {
+  return (unit: UnitEntity): Array<T> | undefined => {
+    if (unit instanceof N && unit.isRootJobnet) {
+      return undefined;
+    }
+    return buildSortedScheduleRuleParameters(
+      resolveParameterArray({
+        unit: unit,
+        parameter: parameter,
+      }),
+      mapParam,
+    );
+  };
+};
+
 const createRootDefaultAwareScheduleRuleBuilder = <
   T extends ScheduleRule,
   P extends ParamInternal["parameter"],
@@ -96,7 +117,10 @@ export const ruleParameterBuilders = {
   ),
   cy: createScheduleRuleEmptyBuilder("cy", (param) => new Cy(param)),
   ey: createScheduleRuleEmptyBuilder("ey", (param) => new Ey(param)),
-  ln: createSortedScheduleRuleBuilder("ln", (param) => new Ln(param)),
+  ln: createRootJobnetIgnoredScheduleRuleBuilder(
+    "ln",
+    (param) => new Ln(param),
+  ),
   sd: createRootDefaultAwareScheduleRuleBuilder(
     "sd",
     "sd",

--- a/src/test/suite/buildUnitListGroup10View.test.ts
+++ b/src/test/suite/buildUnitListGroup10View.test.ts
@@ -32,6 +32,25 @@ unit=root,,jp1admin,;
 }
 `;
 
+const rootJobnetLnDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    ln=2;
+    el=subnet,n,+160+0;
+    unit=subnet,,jp1admin,;
+    {
+      ty=n;
+      ln=2;
+    }
+  }
+}
+`;
+
 suite("Build Unit List Group 10 View", () => {
   test("projects schedule-related group10 fields from unit parameters", () => {
     const result = parseAjs(definition);
@@ -85,5 +104,19 @@ suite("Build Unit List Group 10 View", () => {
     assert.deepStrictEqual(view.endRangeTimes, []);
     assert.deepStrictEqual(view.waitCounts, []);
     assert.deepStrictEqual(view.waitTimes, []);
+  });
+
+  test("ignores parent rules on the root jobnet only", () => {
+    const result = parseAjs(rootJobnetLnDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const jobnet = document.rootUnits[0]?.children[0];
+    const subnet = jobnet?.children[0];
+
+    assert.ok(jobnet);
+    assert.ok(subnet);
+
+    assert.deepStrictEqual(buildUnitListGroup10View(jobnet).parentRules, []);
+    assert.deepStrictEqual(buildUnitListGroup10View(subnet).parentRules, ["2"]);
   });
 });

--- a/src/test/suite/buildUnitListView.test.ts
+++ b/src/test/suite/buildUnitListView.test.ts
@@ -274,7 +274,7 @@ suite("Build Unit List View", () => {
     assert.strictEqual(jobnet?.group10.executionDate, "2024/12/31");
     assert.strictEqual(jobnet?.group10.jobGroupPath, "/root");
     assert.strictEqual(jobnet?.group10.exclusiveJobnetName, "exclusive-a");
-    assert.deepStrictEqual(jobnet?.group10.parentRules, ["2"]);
+    assert.deepStrictEqual(jobnet?.group10.parentRules, []);
     assert.deepStrictEqual(jobnet?.group10.scheduleDateTypes, ["+", "en"]);
     assert.deepStrictEqual(jobnet?.group10.scheduleDateYearMonths, [
       "2024/12",

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -73,6 +73,69 @@ unit=root,,jp1admin,;
 }
 `;
 
+const scheduleDefaultDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    sd=2026/04/27;
+    sd=2,en;
+  }
+}
+`;
+
+const undefinedScheduleDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    sd=0,ud;
+  }
+}
+`;
+
+const scheduleRelativeTimeDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    sd=2026/04/27;
+    sd=2,en;
+    sy=M120;
+    ey=2,U60;
+  }
+}
+`;
+
+const nestedScheduleDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    ln=2;
+    el=subnet,n,+160+0;
+    unit=subnet,,jp1admin,;
+    {
+      ty=n;
+      ln=2;
+      ln=1;
+    }
+  }
+}
+`;
+
 const rootDefaultDefinition = `
 unit=root,,jp1admin,;
 {
@@ -136,6 +199,36 @@ const parseScheduleJobnet = (): N => {
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as N;
+};
+
+const parseScheduleDefaultJobnet = (): N => {
+  const result = parseAjs(scheduleDefaultDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as N;
+};
+
+const parseUndefinedScheduleJobnet = (): N => {
+  const result = parseAjs(undefinedScheduleDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as N;
+};
+
+const parseScheduleRelativeTimeJobnet = (): N => {
+  const result = parseAjs(scheduleRelativeTimeDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as N;
+};
+
+const parseNestedScheduleJobnets = (): { jobnet: N; subnet: N } => {
+  const result = parseAjs(nestedScheduleDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  const jobnet = root.children[0] as N;
+  const subnet = jobnet.children[0] as N;
+  return { jobnet, subnet };
 };
 
 const parseRootDefaultJobnet = (): N => {
@@ -268,9 +361,9 @@ suite("ParameterFactory", () => {
   });
 
   test("returns schedule-rule-bearing parameters sorted by rule", () => {
-    const jobnet = parseScheduleJobnet();
+    const { subnet } = parseNestedScheduleJobnets();
 
-    const ln = ParamFactory.ln(jobnet);
+    const ln = ParamFactory.ln(subnet);
 
     assert.deepStrictEqual(
       ln?.map((parameter) => ({
@@ -282,6 +375,12 @@ suite("ParameterFactory", () => {
         { rule: 2, value: "2" },
       ],
     );
+  });
+
+  test("ignores ln on the root jobnet", () => {
+    const { jobnet } = parseNestedScheduleJobnets();
+
+    assert.strictEqual(ParamFactory.ln(jobnet), undefined);
   });
 
   test("returns explicit root-aware scalar and root-default-aware schedule-rule parameters through the facade", () => {
@@ -307,6 +406,74 @@ suite("ParameterFactory", () => {
     assert.deepStrictEqual(
       sd?.map((parameter) => parameter.value()),
       [DEFAULTS.Sd],
+    );
+  });
+
+  test("preserves an explicit undefined schedule rule through the facade", () => {
+    const jobnet = parseUndefinedScheduleJobnet();
+
+    const sd = ParamFactory.sd(jobnet);
+
+    assert.deepStrictEqual(
+      sd?.map((parameter) => ({
+        rule: parameter.rule,
+        type: parameter.type,
+        value: parameter.value(),
+      })),
+      [{ rule: 0, type: "ud", value: "0,ud" }],
+    );
+  });
+
+  test("returns schedule-rule defaults aligned to every sd rule", () => {
+    const jobnet = parseScheduleDefaultJobnet();
+
+    const st = ParamFactory.st(jobnet);
+    const shd = ParamFactory.shd(jobnet);
+    const cftd = ParamFactory.cftd(jobnet);
+    const wc = ParamFactory.wc(jobnet);
+    const wt = ParamFactory.wt(jobnet);
+
+    assert.deepStrictEqual(
+      st?.map((parameter) => parameter?.time),
+      [DEFAULTS.St, DEFAULTS.St],
+    );
+    assert.deepStrictEqual(
+      shd?.map((parameter) => parameter?.shiftDays),
+      [DEFAULTS.Shd, DEFAULTS.Shd],
+    );
+    assert.deepStrictEqual(
+      cftd?.map((parameter) => ({
+        scheduleByDaysFromStart: parameter?.scheduleByDaysFromStart,
+        maxShiftableDays: parameter?.maxShiftableDays,
+      })),
+      [
+        { scheduleByDaysFromStart: DEFAULTS.Cftd, maxShiftableDays: undefined },
+        { scheduleByDaysFromStart: DEFAULTS.Cftd, maxShiftableDays: undefined },
+      ],
+    );
+    assert.deepStrictEqual(
+      wc?.map((parameter) => parameter?.numberOfTimes),
+      [DEFAULTS.Wc, DEFAULTS.Wc],
+    );
+    assert.deepStrictEqual(
+      wt?.map((parameter) => parameter?.time),
+      [DEFAULTS.Wt, DEFAULTS.Wt],
+    );
+  });
+
+  test("preserves relative-minute start and end delay values", () => {
+    const jobnet = parseScheduleRelativeTimeJobnet();
+
+    const sy = ParamFactory.sy(jobnet);
+    const ey = ParamFactory.ey(jobnet);
+
+    assert.deepStrictEqual(
+      sy?.map((parameter) => parameter?.time),
+      ["M120", undefined],
+    );
+    assert.deepStrictEqual(
+      ey?.map((parameter) => parameter?.time),
+      [undefined, "U60"],
     );
   });
 


### PR DESCRIPTION
## Summary

- Add focused SDD coverage for JP1/AJS3 v13 schedule-rule parameter alignment.
- Add behavior-preserving regression tests for thin schedule-rule evidence before semantic changes.
- Align `ln` handling with the JP1/AJS3 v13 jobnet definition rule by ignoring `ln` on root jobnets while preserving nested jobnet behavior.

## Impact

Root jobnet `ln` values are no longer surfaced through the domain facade or unit-list parent-rule projection. Nested jobnet `ln` values remain sorted and visible.

## Validation

- `pnpm test`
- `pnpm run lint:md`
- `pnpm run qlty`
- `pnpm run build`
- `pnpm run test:web`

`pnpm run build` still reports existing bundle-size warnings only.