### PR TITLE
[codex] Align schedule-rule parameter parsing

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -25,13 +25,15 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   before changing helper semantics.
 - Implemented the first behavior-changing schedule-rule alignment fix by
   ignoring `ln` on root jobnets.
+- Started category-level value parsing alignment with the schedule-rule
+  parameter family, using shared domain helpers as the boundary pattern.
 
 ## Follow-up
 
-- Build a parameter-coverage matrix only when a behavior-changing alignment
-  slice needs per-key status beyond the current audit summary.
-- Choose the next behavior-changing schedule-rule fix from the remaining
-  partial statuses.
+- Apply the same value parsing audit/refactor workflow to other parameter
+  categories before marking them official-reference aligned.
+- Build a parameter-coverage matrix when category-level status needs tracking
+  beyond the current audit summary.
 
 ## Validation
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
@@ -2,11 +2,12 @@
 
 ## Purpose
 
-Prepare the focused JP1/AJS3 version 13 schedule-rule alignment slice before
-changing parser or helper behavior.
+Record the JP1/AJS3 version 13 alignment slice for jobnet schedule-rule
+parameters. This is the first category-level value-parsing alignment pattern;
+later parameter categories should follow the same audit, helper-boundary, and
+regression-test workflow instead of moving one key at a time.
 
-This document keeps the slice narrower than a repository-wide parameter matrix.
-It covers only the jobnet schedule-rule family already called out in
+This document covers only the jobnet schedule-rule family already called out in
 `AUDIT.md`: `sd`, `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`, `wc`, and
 `wt`.
 
@@ -19,203 +20,71 @@ It covers only the jobnet schedule-rule family already called out in
 
 ## Slice Boundary
 
-- Owning domain seams:
+- Domain seams:
+  `src/domain/models/parameters/scheduleRuleHelpers.ts`,
   `src/domain/models/parameters/ruleParameterBuilders.ts`,
-  `src/domain/models/parameters/parameterHelpers.ts`, and
+  `src/domain/models/parameters/parameterHelpers.ts`,
+  `src/domain/models/parameters/Day.ts`,
+  `src/domain/models/parameters/Time.ts`, and
   `src/domain/models/parameters/ScheduleRule.ts`
-- Primary application consumer:
-  `src/application/unit-list/buildUnitListGroup10View.ts`
+- Application consumer:
+  `src/application/unit-list/buildUnitListGroup10View.ts` through
+  `src/application/unit-list/unitListViewHelpers.ts`
 - Regression evidence:
-  `src/test/suite/parameterHelpers.test.ts`,
+  `src/test/suite/scheduleRuleHelpers.test.ts`,
   `src/test/suite/parameterFactory.test.ts`,
+  `src/test/suite/parameterHelpers.test.ts`,
   `src/test/suite/buildUnitListGroup10View.test.ts`, and
   `src/test/suite/buildUnitListView.test.ts`
-- Out of scope for this slice:
-  parser grammar token generation, all-key coverage, UI redesign, and unrelated
-  command-generation work
+- Out of scope:
+  parser grammar token generation, all-key coverage, UI redesign, unrelated
+  command generation, numeric range diagnostics, and cross-parameter
+  invalidation diagnostics
 
-## Manual-Aligned Expectations
+## Shared Expectations
 
-### `sd`
+- Omitted schedule-rule number `N` resolves to rule `1`, unless a
+  parameter-specific note says otherwise.
+- Schedule-rule value-shape parsing lives in
+  `scheduleRuleHelpers.ts`; domain wrapper classes and unit-list projection
+  reuse the same helpers.
+- `ln` on root jobnets is ignored, matching the manual note that root-jobnet
+  specification is ignored.
+- `cftd` defaults are interpreted by mode: start days default to `1`; maximum
+  shift days default to `10` for `be` / `af`; maximum shift days are ignored for
+  `no`, `db`, and `da`.
 
-- Manual expectation:
-  jobnet execution dates are repeatable, support rule numbers, allow
-  root-jobnet omission to default to rule `1` / `en`, and allow `sd=0,ud` to
-  make schedules undefined.
-- Current implementation seam:
-  `buildRootDefaultAwareScheduleRuleParameters`, `resolveSdParameters`, and
-  `Sd`.
-- Existing regression evidence:
-  root defaults and explicit multi-rule values are covered in
-  `parameterHelpers.test.ts` and `parameterFactory.test.ts`; unit-list
-  projection is covered in list tests. `parameterFactory.test.ts` also covers
-  explicit `sd=0,ud` preservation.
-- Status:
-  partial. Default, sorting, and `sd=0,ud` preservation evidence exists; any
-  collapse or reinterpretation of `sd=0,ud` still needs a product decision.
+## Parameter Status
 
-### `ln`
+| Key    | Manual expectation covered in this slice                                                 | Owning parser/helper seam                                         | Remaining gap                                                        |
+| ------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `sd`   | Repeatable schedule dates, rule numbers, root default `1,en`, and `sd=0,ud` preservation | `parseScheduleDateValue`, `Sd`, `resolveSdParameters`             | Date and rule value ranges; product decision on collapsing `sd=0,ud` |
+| `ln`   | Nested jobnet parent-rule mapping; root-jobnet values ignored                            | `parseParentScheduleRuleValue`, `Ln`, root-jobnet ignored builder | Rule value ranges                                                    |
+| `st`   | Per-`sd` start time; omitted value default `+00:00`                                      | `parseStartTimeValue`, `St`                                       | Time range validation                                                |
+| `cy`   | Per-`sd` cycle value shape                                                               | `parseCycleValue`, `Cy`                                           | Cycle ranges and open/closed-day restrictions                        |
+| `sh`   | Per-`sd` substitution values `be`, `af`, `ca`, `no`                                      | `parseClosedDaySubstitutionValue`, `Sh`                           | None for value-shape parsing                                         |
+| `shd`  | Per-`sd` max shift days; omitted value default `2`                                       | `parseShiftDaysValue`, `Shd`                                      | Range validation                                                     |
+| `cftd` | Per-`sd` mode, start-day default, and mode-specific max-shift default/ignore behavior    | `parseScheduleByDaysFromStartValue`, `Cftd`                       | Range validation                                                     |
+| `sy`   | Per-`sd` delayed start time; absolute or relative-minute shape                           | `parseDelayTimeValue`, `Sy`                                       | Range validation                                                     |
+| `ey`   | Per-`sd` delayed end time; absolute or relative-minute shape                             | `parseDelayTimeValue`, `Ey`                                       | Range validation                                                     |
+| `wc`   | Per-`sd` start-condition count; omitted value default `no`                               | `parseWaitCountValue`, `Wc`                                       | Range validation and paired `wt` invalidation                        |
+| `wt`   | Per-`sd` monitoring end time; omitted value default `no`                                 | `parseWaitTimeValue`, `Wt`                                        | Range validation and paired `wc` invalidation                        |
 
-- Manual expectation:
-  rule numbers map a nested jobnet schedule rule to an upper-level jobnet
-  schedule rule; root-jobnet use is ignored by JP1/AJS3.
-- Current implementation seam:
-  `buildSortedScheduleRuleParameters` and `Ln`.
-- Existing regression evidence:
-  sorting by rule is covered in helper and facade tests; list projection is
-  covered. Root-jobnet ignored behavior is covered in
-  `parameterFactory.test.ts`, `buildUnitListGroup10View.test.ts`, and
-  `buildUnitListView.test.ts`.
-- Status:
-  aligned for the current slice. `ln` values on the root jobnet are ignored by
-  the domain facade and unit-list projection, while nested jobnet values remain
-  visible and sorted by rule.
+## Delivered Alignment
 
-### `st`
+- `ln`: root-jobnet values are ignored while nested jobnet values remain sorted
+  and visible to the unit-list parent-rule projection.
+- Shared rule-number behavior: omitted `N` values now resolve to rule `1`
+  across the schedule-rule domain boundary.
+- Shared value-shape parsing: schedule-rule parameter values parse through
+  `scheduleRuleHelpers.ts`, and unit-list projection no longer maintains a
+  separate set of schedule-rule regular expressions.
 
-- Manual expectation:
-  execution start time is per `sd` rule; omitted values default to relative
-  `+00:00`.
-- Current implementation seam:
-  `buildSdAlignedDefaultScheduleRuleParameters` and `St`.
-- Existing regression evidence:
-  default alignment is covered in `parameterFactory.test.ts`.
-- Status:
-  partial. Default alignment exists; behavior-changing time validation is not
-  enforced.
+## Follow-up
 
-### `cy`
-
-- Manual expectation:
-  processing cycle is per `sd` rule and is omitted when no processing cycle is
-  set.
-- Current implementation seam:
-  `buildSdAlignedEmptyScheduleRuleParameters` and `Cy`.
-- Existing regression evidence:
-  empty `sd`-aligned placeholder behavior is covered generically; list
-  projection is covered.
-- Status:
-  partial. Generic alignment exists; cycle range and open/closed day
-  restrictions are not enforced.
-
-### `sh`
-
-- Manual expectation:
-  closed-day substitution is per `sd` rule and supports `be`, `af`, `ca`, and
-  `no`.
-- Current implementation seam:
-  `buildSdAlignedEmptyScheduleRuleParameters` and `Sh`.
-- Existing regression evidence:
-  list projection covers explicit values.
-- Status:
-  partial. Value parsing exists; focused default/omission evidence is thin.
-
-### `shd`
-
-- Manual expectation:
-  maximum shift days are per `sd` rule and default to `2`.
-- Current implementation seam:
-  `buildSdAlignedDefaultScheduleRuleParameters` and `Shd`.
-- Existing regression evidence:
-  default builder behavior is covered generically and through
-  `parameterFactory.test.ts`.
-- Status:
-  partial. Default value is encoded; range validation is not enforced.
-
-### `cftd`
-
-- Manual expectation:
-  schedule-by-days-from-start is per `sd` rule; omitted values default to
-  `no`; start days default to `1`; maximum shift days default to `10` except
-  when invalid for the selected mode.
-- Current implementation seam:
-  `buildSdAlignedDefaultScheduleRuleParameters` and `Cftd`.
-- Existing regression evidence:
-  list projection covers explicit parsed display fields. Default expansion is
-  covered in `parameterFactory.test.ts`.
-- Status:
-  partial. Value parsing and defaults exist; mode-specific invalid fields need
-  explicit evidence.
-
-### `sy`
-
-- Manual expectation:
-  delayed start time is per `sd` rule and supports absolute or relative-minute
-  formats.
-- Current implementation seam:
-  `buildSdAlignedEmptyScheduleRuleParameters` and `Sy`.
-- Existing regression evidence:
-  list projection covers explicit values. Relative-minute preservation is
-  covered in `parameterFactory.test.ts`.
-- Status:
-  partial. Aligned omission and relative-minute preservation exist; range
-  validation is not enforced.
-
-### `ey`
-
-- Manual expectation:
-  delayed end time is per `sd` rule and supports absolute or relative-minute
-  formats.
-- Current implementation seam:
-  `buildSdAlignedEmptyScheduleRuleParameters` and `Ey`.
-- Existing regression evidence:
-  generic empty alignment evidence exists; list projection covers explicit
-  values. Relative-minute preservation is covered in `parameterFactory.test.ts`.
-- Status:
-  partial. Aligned omission and relative-minute preservation exist; range
-  validation is not enforced.
-
-### `wc`
-
-- Manual expectation:
-  start-condition execution count is per `sd` rule, defaults to `no`, and is
-  paired with `wt`.
-- Current implementation seam:
-  `buildSdAlignedDefaultScheduleRuleParameters` and `Wc`.
-- Existing regression evidence:
-  explicit and fallback values are covered in helper and facade tests. Default
-  expansion for all effective `sd` rules is covered in
-  `parameterFactory.test.ts`.
-- Status:
-  partial. Default alignment exists; paired `wt` invalidation is not modeled.
-
-### `wt`
-
-- Manual expectation:
-  start-condition monitoring end time is per `sd` rule, defaults to `no`, and
-  is paired with `wc`.
-- Current implementation seam:
-  `buildSdAlignedDefaultScheduleRuleParameters` and `Wt`.
-- Existing regression evidence:
-  default alignment is covered in facade tests. Default expansion for all
-  effective `sd` rules is covered in `parameterFactory.test.ts`.
-- Status:
-  partial. Default alignment exists; paired `wc` invalidation is not modeled.
-
-## Next Implementation Acceptance Criteria
-
-- Preserve current DTO output for existing unit-list schedule columns.
-- Add focused regression tests for at least one currently thin behavior before
-  changing helper semantics.
-- Keep schedule-rule interpretation in domain/application seams; UI components
-  must continue consuming view-model fields.
-- If a manual mismatch is intentionally left open, record it here with the
-  affected key, code seam, and missing evidence.
-
-## Behavior-Preserving Evidence
-
-Behavior-preserving tests now cover default expansion and known manual edge
-cases:
-
-1. `sd=0,ud` remains visible as an undefined-schedule rule until a product
-   decision says to collapse all schedule items.
-2. `st`, `shd`, `cftd`, `wc`, and `wt` synthesize documented defaults for each
-   effective `sd` rule.
-3. `sy` and `ey` preserve relative-minute values without viewer-specific
-   parsing.
-
-## Delivered Behavior-Changing Alignment
-
-- `ln`: root-jobnet values are ignored, matching the manual note that root
-  jobnet specification is ignored. Nested jobnet `ln` values continue to be
-  sorted and projected into the unit-list parent-rule column.
+- Add range validation only after deciding whether invalid JP1/AJS parameter
+  values should become diagnostics, warnings, or preserved raw values.
+- Model `wc` / `wt` paired invalidation once the behavior contract is explicit
+  enough to test across domain and unit-list projection.
+- Apply this category-level parser alignment workflow to the next non-schedule
+  parameter family before marking that category official-reference aligned.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
@@ -56,19 +56,54 @@ This document covers only the jobnet schedule-rule family already called out in
 
 ## Parameter Status
 
-| Key    | Manual expectation covered in this slice                                                 | Owning parser/helper seam                                         | Remaining gap                                                        |
-| ------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `sd`   | Repeatable schedule dates, rule numbers, root default `1,en`, and `sd=0,ud` preservation | `parseScheduleDateValue`, `Sd`, `resolveSdParameters`             | Date and rule value ranges; product decision on collapsing `sd=0,ud` |
-| `ln`   | Nested jobnet parent-rule mapping; root-jobnet values ignored                            | `parseParentScheduleRuleValue`, `Ln`, root-jobnet ignored builder | Rule value ranges                                                    |
-| `st`   | Per-`sd` start time; omitted value default `+00:00`                                      | `parseStartTimeValue`, `St`                                       | Time range validation                                                |
-| `cy`   | Per-`sd` cycle value shape                                                               | `parseCycleValue`, `Cy`                                           | Cycle ranges and open/closed-day restrictions                        |
-| `sh`   | Per-`sd` substitution values `be`, `af`, `ca`, `no`                                      | `parseClosedDaySubstitutionValue`, `Sh`                           | None for value-shape parsing                                         |
-| `shd`  | Per-`sd` max shift days; omitted value default `2`                                       | `parseShiftDaysValue`, `Shd`                                      | Range validation                                                     |
-| `cftd` | Per-`sd` mode, start-day default, and mode-specific max-shift default/ignore behavior    | `parseScheduleByDaysFromStartValue`, `Cftd`                       | Range validation                                                     |
-| `sy`   | Per-`sd` delayed start time; absolute or relative-minute shape                           | `parseDelayTimeValue`, `Sy`                                       | Range validation                                                     |
-| `ey`   | Per-`sd` delayed end time; absolute or relative-minute shape                             | `parseDelayTimeValue`, `Ey`                                       | Range validation                                                     |
-| `wc`   | Per-`sd` start-condition count; omitted value default `no`                               | `parseWaitCountValue`, `Wc`                                       | Range validation and paired `wt` invalidation                        |
-| `wt`   | Per-`sd` monitoring end time; omitted value default `no`                                 | `parseWaitTimeValue`, `Wt`                                        | Range validation and paired `wc` invalidation                        |
+- `sd`
+  - Covered: repeatable schedule dates, rule numbers, root default `1,en`, and
+    `sd=0,ud` preservation.
+  - Seam: `parseScheduleDateValue`, `Sd`, and `resolveSdParameters`.
+  - Remaining gap: date and rule value ranges; product decision on collapsing
+    `sd=0,ud`.
+- `ln`
+  - Covered: nested jobnet parent-rule mapping; root-jobnet values ignored.
+  - Seam: `parseParentScheduleRuleValue`, `Ln`, and the root-jobnet ignored
+    builder.
+  - Remaining gap: rule value ranges.
+- `st`
+  - Covered: per-`sd` start time; omitted value default `+00:00`.
+  - Seam: `parseStartTimeValue` and `St`.
+  - Remaining gap: time range validation.
+- `cy`
+  - Covered: per-`sd` cycle value shape.
+  - Seam: `parseCycleValue` and `Cy`.
+  - Remaining gap: cycle ranges and open/closed-day restrictions.
+- `sh`
+  - Covered: per-`sd` substitution values `be`, `af`, `ca`, and `no`.
+  - Seam: `parseClosedDaySubstitutionValue` and `Sh`.
+  - Remaining gap: none for value-shape parsing.
+- `shd`
+  - Covered: per-`sd` max shift days; omitted value default `2`.
+  - Seam: `parseShiftDaysValue` and `Shd`.
+  - Remaining gap: range validation.
+- `cftd`
+  - Covered: per-`sd` mode, start-day default, and mode-specific max-shift
+    default/ignore behavior.
+  - Seam: `parseScheduleByDaysFromStartValue` and `Cftd`.
+  - Remaining gap: range validation.
+- `sy`
+  - Covered: per-`sd` delayed start time; absolute or relative-minute shape.
+  - Seam: `parseDelayTimeValue` and `Sy`.
+  - Remaining gap: range validation.
+- `ey`
+  - Covered: per-`sd` delayed end time; absolute or relative-minute shape.
+  - Seam: `parseDelayTimeValue` and `Ey`.
+  - Remaining gap: range validation.
+- `wc`
+  - Covered: per-`sd` start-condition count; omitted value default `no`.
+  - Seam: `parseWaitCountValue` and `Wc`.
+  - Remaining gap: range validation and paired `wt` invalidation.
+- `wt`
+  - Covered: per-`sd` monitoring end time; omitted value default `no`.
+  - Seam: `parseWaitTimeValue` and `Wt`.
+  - Remaining gap: range validation and paired `wc` invalidation.
 
 ## Delivered Alignment
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -39,14 +39,22 @@
 - [x] Implement the first behavior-changing schedule-rule alignment fix:
       ignore `ln` on root jobnets while preserving nested jobnet `ln`
       behavior
+- [x] Align omitted schedule-rule numbers to rule `1` across the schedule-rule
+      helper boundary for `sd`, `st`, `sy`, `ey`, `ln`, `cy`, `sh`, `shd`,
+      `cftd`, `wc`, and `wt`
+- [x] Centralize schedule-rule value parsing behind domain helpers and verify
+      the official format shape for the schedule-rule family before treating
+      the category as aligned
 
 ## Follow-up
 
-- [ ] Turn the audit notes into an explicit parameter-coverage matrix only when
-      a behavior-changing alignment slice needs per-key status beyond the
-      current audit summary
-- [ ] Choose the next schedule-rule manual-alignment fix from the remaining
-      partial statuses
+- [ ] Apply the same category-level value parsing audit/refactor workflow to
+      non-schedule parameter families before marking those categories aligned
+- [ ] Turn the audit notes into an explicit parameter-coverage matrix when
+      category-level status needs tracking beyond the current audit summary
+- [ ] Continue schedule-rule helper-boundary alignment with the remaining
+      grouped semantics, such as `wc` / `wt` pairing or range validation, when
+      the behavior contract is explicit enough to test across the family
 
 ## Notes
 
@@ -81,3 +89,11 @@
 - 2026-04-27: `ln` now follows the JP1/AJS3 v13 root-jobnet rule: root-jobnet
   `ln` values are ignored, while nested jobnet `ln` values remain sorted and
   visible to the unit-list parent-rule projection.
+- 2026-04-27: schedule-rule number omission is now handled as a shared
+  schedule-rule boundary concern. The domain parameter classes resolve omitted
+  rule numbers to manual default rule `1`, and regression coverage verifies the
+  schedule family together instead of one parameter at a time.
+- 2026-04-27: schedule-rule value parsing is now centralized in domain helpers
+  and reused by unit-list projection. This is the first category-level parser
+  alignment pattern; later parameter categories should follow the same audit,
+  helper-boundary, and regression-test workflow.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -11,9 +11,10 @@ under `docs/requirements/use-cases/`.
 - List search stays presentation-local until another non-table consumer needs
   the same matching semantics.
 - Parameter-reference alignment should proceed in small JP1/AJS v13 slices
-  with explicit manual coverage. The next likely behavior-changing slice is the
-  schedule-rule parameter family: `sd`, `ln`, `st`, `cy`, `sh`, `shd`,
-  `cftd`, `sy`, `ey`, `wc`, and `wt`.
+  with explicit manual coverage. For each parameter category, verify value
+  parsing against the official format before claiming the category aligned.
+  The active category is the schedule-rule parameter family: `sd`, `ln`, `st`,
+  `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`.
 - Read-only JP1/AJS WebAPI import stays beta until real JP1/AJS3 environment
   smoke verification and enough user feedback are recorded. Beta exit is
   feedback-gated and is not the next active implementation priority.
@@ -22,8 +23,10 @@ under `docs/requirements/use-cases/`.
 
 ## Next Priority Tasks
 
-1. Choose the next behavior-changing schedule-rule manual-alignment fix from
-   the remaining partial statuses.
+1. Continue category-level parameter parsing alignment. Use the schedule-rule
+   helper boundary as the first pattern, then apply the same audit/refactor
+   workflow to other parameter categories instead of checking isolated keys one
+   by one.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -18,10 +18,13 @@
    - Add traceability from JP1/AJS v13 manual sections to supported parameter
      keys, parser behavior, normalized model fields, use cases, and regression
      tests.
+   - Parameter value parsing must be verified by category against the official
+     format before a category is marked aligned; avoid one-key-at-a-time slices
+     when a shared helper boundary can cover the category.
    - The active focused slice is the schedule-rule parameter family: `sd`,
-     `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`; the
-     first behavior-changing fix ignores root-jobnet `ln` values, and the next
-     fix should come from the remaining partial statuses.
+     `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`; use it
+     as the first category-level parser alignment pattern before applying the
+     same workflow to other parameter families.
    - Keep behavior-preserving slices separate from behavior-changing manual
      alignment slices.
 

--- a/src/application/unit-list/unitListViewHelpers.ts
+++ b/src/application/unit-list/unitListViewHelpers.ts
@@ -5,6 +5,16 @@ import {
   findAjsUnitParameter,
   findParentAjsUnit,
 } from "../../domain/models/ajs/AjsDocument";
+import {
+  parseAnyScheduleTimeValue,
+  parseClosedDaySubstitutionValue,
+  parseCycleValue,
+  parseParentScheduleRuleValue,
+  parseScheduleByDaysFromStartValue,
+  parseScheduleDateValue,
+  parseShiftDaysValue,
+  parseWaitCountValue,
+} from "../../domain/models/parameters/scheduleRuleHelpers";
 import { WeekSymbol, isWeekSymbol } from "../../domain/values/AjsType";
 
 const weekSymbols: WeekSymbol[] = ["su", "mo", "tu", "we", "th", "fr", "sa"];
@@ -106,23 +116,15 @@ export const getPriorityForUnitTypes = (
   return 1;
 };
 
-const parseRulePrefix = (value: string): { rule?: string; body: string } => {
-  const matched = /^(\d{1,3}),(.*)$/.exec(value);
-  return matched ? { rule: matched[1], body: matched[2] } : { body: value };
-};
-
 export const parseLnParentRule = (value: string): string =>
-  parseRulePrefix(value).body;
+  parseParentScheduleRuleValue(value)?.value ?? "";
 
 export const parseSd = (
   value: string,
 ): { type: string; yearMonth: string; day: string } => {
-  const matched =
-    /^((\d{1,3}),)?((\d{4}\/)?\d{2}\/)?(([+*@])?\d{2}|([+*@])?b(-\d{2})?|\+?(su|mo|tu|we|th|fr|sa)(:(\d|b))?|en|ud)/.exec(
-      value,
-    );
-  const yearMonth = matched?.[3]?.slice(0, -1) ?? "";
-  const dayValue = matched?.[5] ?? "";
+  const parsed = parseScheduleDateValue(value);
+  const yearMonth = parsed?.yearMonth?.slice(0, -1) ?? "";
+  const dayValue = parsed?.day ?? "";
   const type =
     dayValue === "en" || dayValue === "ud"
       ? dayValue
@@ -141,31 +143,33 @@ export const parseSd = (
 };
 
 export const parseTimeValue = (value: string, fallback = ""): string =>
-  /^((\d{1,3}),)?(no|([+]?)\d{2}:\d{2}|([MCU])?\d{1,4}|un)?/.exec(value)?.[3] ??
-  fallback;
+  parseAnyScheduleTimeValue(value)?.value ?? fallback;
 
 export const parseCy = (value: string): string =>
-  /^((\d{1,3}),)?\(((\d{1,3}),([ymwd]))\)/.exec(value)?.[3] ?? "";
+  parseCycleValue(value)?.value.slice(1, -1) ?? "";
 
 export const parseSh = (value: string): string =>
-  /^((\d{1,3}),)?(be|af|ca|no)/.exec(value)?.[3] ?? "";
+  parseClosedDaySubstitutionValue(value)?.value ?? "";
 
 export const parseShd = (value: string): string =>
-  /^((\d{1,3}),)?(\d{1,3})/.exec(value)?.[3] ?? "2";
+  parseShiftDaysValue(value)?.value ?? "2";
 
 export const parseCftd = (
   value: string,
 ): { scheduleByDaysFromStart: string; maxShiftableDays: string } => {
-  const matched =
-    /^((\d{1,3}),)?(no|be|af|db|da)((,(\d{1,2}))(,(\d{1,2}))?)?/.exec(value);
-  const type = matched?.[3] ?? "no";
+  const parsed = parseScheduleByDaysFromStartValue(value);
+  const type = parsed?.type ?? "no";
   return {
     scheduleByDaysFromStart:
-      type === "no" ? "no" : `${type},${matched?.[6] ?? "1"}`,
+      type === "no"
+        ? "no"
+        : `${type},${parsed?.scheduleByDaysFromStart ?? "1"}`,
     maxShiftableDays:
-      type && ["no", "db", "da"].includes(type) ? "" : (matched?.[8] ?? "10"),
+      type && ["no", "db", "da"].includes(type)
+        ? ""
+        : (parsed?.maxShiftableDays ?? "10"),
   };
 };
 
 export const parseWc = (value: string): string =>
-  /^((\d{1,3}),)?(.+)/.exec(value)?.[3] ?? "1";
+  parseWaitCountValue(value)?.value ?? "1";

--- a/src/domain/models/parameters/Day.ts
+++ b/src/domain/models/parameters/Day.ts
@@ -1,5 +1,6 @@
 import Parameter from "./Parameter";
 import { ParamInternal } from "./parameter.types";
+import { parseScheduleDateValue } from "./scheduleRuleHelpers";
 
 class Day extends Parameter {
   /**
@@ -15,21 +16,17 @@ class Day extends Parameter {
    *   }|en|ud                                 )
    * }
    */
-  #pattern =
-    /^((\d{1,3}),)?((\d{4}\/)?\d{2}\/)?(([+|*|@])?\d{2}|([+|*|@])?b(-\d{2})?|[+]?(su|mo|tu|we|th|fr|sa)(:(\d|b))?|en|ud)/;
-  _re;
-  _rule = -1;
+  _rule = 1;
   _yearMonth;
   _day;
 
   constructor(arg: ParamInternal) {
     super(arg);
-    this._re = this.#pattern.exec(this.value() ?? "");
-    const re = this._re;
-    if (re) {
-      this._rule = Number(re[2]);
-      this._yearMonth = re[3];
-      this._day = re[5];
+    const parsed = parseScheduleDateValue(this.value());
+    if (parsed) {
+      this._rule = parsed.rule;
+      this._yearMonth = parsed.yearMonth;
+      this._day = parsed.day;
     }
   }
 }

--- a/src/domain/models/parameters/ScheduleRule.ts
+++ b/src/domain/models/parameters/ScheduleRule.ts
@@ -1,6 +1,14 @@
 import Day from "./Day";
 import Parameter from "./Parameter";
 import { ParamInternal } from "./parameter.types";
+import {
+  parseClosedDaySubstitutionValue,
+  parseCycleValue,
+  parseParentScheduleRuleValue,
+  parseScheduleByDaysFromStartValue,
+  parseShiftDaysValue,
+  parseWaitCountValue,
+} from "./scheduleRuleHelpers";
 
 interface ScheduleRule {
   get rule(): number;
@@ -8,25 +16,19 @@ interface ScheduleRule {
 export default ScheduleRule;
 
 export class Cftd extends Parameter implements ScheduleRule {
-  /**
-   * [N,]{no|be|af|db|da}[,n[,N]]    ((\d{1,3}),)?(no|be|af|db|da)((,(\d{1,2}))(,(\d{1,2}))?)?
-   */
-  #pattern = /^((\d{1,3}),)?(no|be|af|db|da)((,(\d{1,2}))(,(\d{1,2}))?)?/;
-  #_re;
-  #_rule = -1;
-  #_type;
+  #_rule = 1;
+  #_type = "no";
   #_scheduleByDaysFromStart;
   #_maxShiftableDays;
 
   constructor(arg: ParamInternal) {
     super(arg);
-    this.#_re = this.#pattern.exec(this.value() ?? "");
-    const re = this.#_re;
-    if (re) {
-      this.#_rule = Number(re[2]);
-      this.#_type = re[3] ?? "no";
-      this.#_scheduleByDaysFromStart = re[6];
-      this.#_maxShiftableDays = re[8];
+    const parsed = parseScheduleByDaysFromStartValue(this.value());
+    if (parsed) {
+      this.#_rule = parsed.rule;
+      this.#_type = parsed.type;
+      this.#_scheduleByDaysFromStart = parsed.scheduleByDaysFromStart;
+      this.#_maxShiftableDays = parsed.maxShiftableDays;
     }
   }
 
@@ -49,21 +51,15 @@ export class Cftd extends Parameter implements ScheduleRule {
 }
 
 export class Cy extends Parameter implements ScheduleRule {
-  /**
-   * [N,](n,{y|m|w|d})    ((\d{1,3}),)?\(((\d{1,3}),([ymwd]))\)
-   */
-  #pattern = /^((\d{1,3}),)?\(((\d{1,3}),([ymwd]))\)/;
-  _re;
   _rule;
   _cycle;
 
   constructor(arg: ParamInternal) {
     super(arg);
-    this._re = this.#pattern.exec(this.value() ?? "");
-    const re = this._re;
-    if (re) {
-      this._rule = Number(re[2]);
-      this._cycle = re[3];
+    const parsed = parseCycleValue(this.value());
+    if (parsed) {
+      this._rule = parsed.rule;
+      this._cycle = parsed.value.slice(1, -1);
     }
   }
 
@@ -77,21 +73,15 @@ export class Cy extends Parameter implements ScheduleRule {
 }
 
 export class Ln extends Parameter implements ScheduleRule {
-  /**
-   * [N,] n       ((\d{1,3}),)?(\d{1,3})
-   */
-  #pattern = /^((\d{1,3}),)?(\d{1,3})/;
-  _re;
   _rule;
   _parentRule;
 
   constructor(arg: ParamInternal) {
     super(arg);
-    this._re = this.#pattern.exec(this.value() ?? "");
-    const re = this._re;
-    if (re) {
-      this._rule = Number(re[2]);
-      this._parentRule = re[3];
+    const parsed = parseParentScheduleRuleValue(this.value());
+    if (parsed) {
+      this._rule = parsed.rule;
+      this._parentRule = parsed.value;
     }
   }
 
@@ -143,21 +133,15 @@ export class Sd extends Day implements ScheduleRule {
   }
 }
 export class Sh extends Parameter implements ScheduleRule {
-  /**
-   * [N,]{be|af|ca|no}      ((\d{1,3}),)?(be|af|ca|no)
-   */
-  #pattern = /^((\d{1,3}),)?(be|af|ca|no)/;
-  _re;
   _rule;
   _substitute;
 
   constructor(arg: ParamInternal) {
     super(arg);
-    this._re = this.#pattern.exec(this.value() ?? "");
-    const re = this._re;
-    if (re) {
-      this._rule = Number(re[2]);
-      this._substitute = re[3];
+    const parsed = parseClosedDaySubstitutionValue(this.value());
+    if (parsed) {
+      this._rule = parsed.rule;
+      this._substitute = parsed.value;
     }
   }
 
@@ -171,21 +155,15 @@ export class Sh extends Parameter implements ScheduleRule {
 }
 
 export class Shd extends Parameter implements ScheduleRule {
-  /**
-   * [N,] n       ((\d{1,3}),)?(\d{1,3})
-   */
-  #pattern = /^((\d{1,3}),)?(\d{1,3})/;
-  _re;
   _rule;
   _shiftDays;
 
   constructor(arg: ParamInternal) {
     super(arg);
-    this._re = this.#pattern.exec(this.value() ?? "");
-    const re = this._re;
-    if (re) {
-      this._rule = Number(re[2]);
-      this._shiftDays = re[3];
+    const parsed = parseShiftDaysValue(this.value());
+    if (parsed) {
+      this._rule = parsed.rule;
+      this._shiftDays = parsed.value;
     }
   }
 
@@ -199,21 +177,15 @@ export class Shd extends Parameter implements ScheduleRule {
 }
 
 export class Wc extends Parameter implements ScheduleRule {
-  /**
-   * [N,] {no|N|un}       ((\d{1,3}),)?(.+)
-   */
-  #pattern = /^((\d{1,3}),)?(.+)/;
-  _re;
   _rule;
   _numberOfTimes;
 
   constructor(arg: ParamInternal) {
     super(arg);
-    this._re = this.#pattern.exec(this.value() ?? "");
-    const re = this._re;
-    if (re) {
-      this._rule = Number(re[2]);
-      this._numberOfTimes = re[3];
+    const parsed = parseWaitCountValue(this.value());
+    if (parsed) {
+      this._rule = parsed.rule;
+      this._numberOfTimes = parsed.value;
     }
   }
 

--- a/src/domain/models/parameters/Time.ts
+++ b/src/domain/models/parameters/Time.ts
@@ -1,24 +1,29 @@
 import { ParamInternal } from "./parameter.types";
 import Parameter from "./Parameter";
 import ScheduleRule from "./ScheduleRule";
+import {
+  parseDelayTimeValue,
+  parseStartTimeValue,
+  parseWaitTimeValue,
+} from "./scheduleRuleHelpers";
+
+type ParseTimeValue = (rawValue: string | undefined) =>
+  | {
+      rule: number;
+      value: string;
+    }
+  | undefined;
 
 abstract class Time extends Parameter implements ScheduleRule {
-  /**
-   * [N,]                   ((\d{1,3}),)?
-   * {no|hh:mm|mmmm|un}     (no|([+]?)\d{2}:\d{2}|([MCU])?\d{1,4}|un)
-   */
-  #pattern = /^((\d{1,3}),)?(no|([+]?)\d{2}:\d{2}|([MCU])?\d{1,4}|un)?/;
-  #_re;
-  #_rule = -1;
+  #_rule = 1;
   #_time;
 
-  constructor(arg: ParamInternal) {
+  constructor(arg: ParamInternal, parseTimeValue: ParseTimeValue) {
     super(arg);
-    this.#_re = this.#pattern.exec(this.value() ?? "");
-    const re = this.#_re;
-    if (re) {
-      this.#_rule = Number(re[2]);
-      this.#_time = re[3];
+    const parsed = parseTimeValue(this.value());
+    if (parsed) {
+      this.#_rule = parsed.rule;
+      this.#_time = parsed.value;
     }
   }
 
@@ -32,21 +37,37 @@ abstract class Time extends Parameter implements ScheduleRule {
 }
 
 export class Ey extends Time {
+  constructor(arg: ParamInternal) {
+    super(arg, parseDelayTimeValue);
+  }
+
   get time() {
     return super.time;
   }
 }
 
 export class St extends Time {
+  constructor(arg: ParamInternal) {
+    super(arg, parseStartTimeValue);
+  }
+
   get time() {
     return super.time ?? "+00:00";
   }
 }
 
 export class Sy extends Time {
+  constructor(arg: ParamInternal) {
+    super(arg, parseDelayTimeValue);
+  }
+
   get time() {
     return super.time;
   }
 }
 
-export class Wt extends Time {}
+export class Wt extends Time {
+  constructor(arg: ParamInternal) {
+    super(arg, parseWaitTimeValue);
+  }
+}

--- a/src/domain/models/parameters/ruleParameterBuilders.ts
+++ b/src/domain/models/parameters/ruleParameterBuilders.ts
@@ -49,23 +49,6 @@ const createScheduleRuleEmptyBuilder = <
     );
 };
 
-const createSortedScheduleRuleBuilder = <
-  T extends ScheduleRule,
-  P extends ParamInternal["parameter"],
->(
-  parameter: P,
-  mapParam: (param: ParamInternal) => T,
-) => {
-  return (unit: UnitEntity): Array<T> | undefined =>
-    buildSortedScheduleRuleParameters(
-      resolveParameterArray({
-        unit: unit,
-        parameter: parameter,
-      }),
-      mapParam,
-    );
-};
-
 const createRootJobnetIgnoredScheduleRuleBuilder = <
   T extends ScheduleRule,
   P extends ParamInternal["parameter"],

--- a/src/domain/models/parameters/scheduleRuleHelpers.ts
+++ b/src/domain/models/parameters/scheduleRuleHelpers.ts
@@ -1,0 +1,117 @@
+export const resolveScheduleRuleNumber = (
+  rawRuleNumber: string | undefined,
+): number => (rawRuleNumber === undefined ? 1 : Number(rawRuleNumber));
+
+type ParsedRuleValue = {
+  rule: number;
+  value: string;
+};
+
+const parseRuleValue = (
+  rawValue: string | undefined,
+  valuePattern: RegExp,
+): ParsedRuleValue | undefined => {
+  const matched = /^((\d{1,3}),)?(.+)$/.exec(rawValue ?? "");
+  if (!matched) {
+    return undefined;
+  }
+  const value = matched[3];
+  return valuePattern.test(value)
+    ? {
+        rule: resolveScheduleRuleNumber(matched[2]),
+        value,
+      }
+    : undefined;
+};
+
+export type ParsedScheduleDateValue = {
+  rule: number;
+  yearMonth?: string;
+  day?: string;
+};
+
+export const parseScheduleDateValue = (
+  rawValue: string | undefined,
+): ParsedScheduleDateValue | undefined => {
+  const matched =
+    /^((\d{1,3}),)?((\d{4}\/)?\d{2}\/)?(([+*@])?\d{2}|([+*@])?b(-\d{2})?|\+?(su|mo|tu|we|th|fr|sa)(:(\d|b))?|en|ud)$/.exec(
+      rawValue ?? "",
+    );
+  return matched
+    ? {
+        rule: resolveScheduleRuleNumber(matched[2]),
+        yearMonth: matched[3],
+        day: matched[5],
+      }
+    : undefined;
+};
+
+export const parseParentScheduleRuleValue = (
+  rawValue: string | undefined,
+): ParsedRuleValue | undefined => parseRuleValue(rawValue, /^\d{1,3}$/);
+
+export const parseCycleValue = (
+  rawValue: string | undefined,
+): ParsedRuleValue | undefined =>
+  parseRuleValue(rawValue, /^\((\d{1,3},[ymwd])\)$/);
+
+export const parseClosedDaySubstitutionValue = (
+  rawValue: string | undefined,
+): ParsedRuleValue | undefined => parseRuleValue(rawValue, /^(be|af|ca|no)$/);
+
+export const parseShiftDaysValue = (
+  rawValue: string | undefined,
+): ParsedRuleValue | undefined => parseRuleValue(rawValue, /^\d{1,3}$/);
+
+export const parseStartTimeValue = (
+  rawValue: string | undefined,
+): ParsedRuleValue | undefined => parseRuleValue(rawValue, /^\+?\d{2}:\d{2}$/);
+
+export const parseDelayTimeValue = (
+  rawValue: string | undefined,
+): ParsedRuleValue | undefined =>
+  parseRuleValue(rawValue, /^(\d{2}:\d{2}|[MCU]\d{1,4})$/);
+
+export const parseWaitTimeValue = (
+  rawValue: string | undefined,
+): ParsedRuleValue | undefined =>
+  parseRuleValue(rawValue, /^(no|\d{2}:\d{2}|\d{1,4}|un)$/);
+
+export const parseAnyScheduleTimeValue = (
+  rawValue: string | undefined,
+): ParsedRuleValue | undefined =>
+  parseStartTimeValue(rawValue) ??
+  parseDelayTimeValue(rawValue) ??
+  parseWaitTimeValue(rawValue);
+
+export const parseWaitCountValue = (
+  rawValue: string | undefined,
+): ParsedRuleValue | undefined => parseRuleValue(rawValue, /^(no|\d{1,3}|un)$/);
+
+export type ParsedScheduleByDaysFromStartValue = {
+  rule: number;
+  type: "no" | "be" | "af" | "db" | "da";
+  scheduleByDaysFromStart?: string;
+  maxShiftableDays?: string;
+};
+
+export const parseScheduleByDaysFromStartValue = (
+  rawValue: string | undefined,
+): ParsedScheduleByDaysFromStartValue | undefined => {
+  const matched =
+    /^((\d{1,3}),)?(no|be|af|db|da)(,(\d{1,2})(,(\d{1,2}))?)?$/.exec(
+      rawValue ?? "",
+    );
+  if (!matched) {
+    return undefined;
+  }
+
+  const type = matched[3] as ParsedScheduleByDaysFromStartValue["type"];
+  return {
+    rule: resolveScheduleRuleNumber(matched[2]),
+    type,
+    scheduleByDaysFromStart: type === "no" ? undefined : (matched[5] ?? "1"),
+    maxShiftableDays:
+      type === "be" || type === "af" ? (matched[7] ?? "10") : undefined,
+  };
+};

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -87,6 +87,40 @@ unit=root,,jp1admin,;
 }
 `;
 
+const explicitRuleOneScheduleDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    sd=1,en;
+    sd=2,en;
+    st=08:00;
+    st=2,09:00;
+    sy=M120;
+    sy=2,U60;
+    ey=C180;
+    ey=2,18:00;
+    ln=3;
+    ln=2,4;
+    cy=(3,d);
+    cy=2,(4,w);
+    sh=be;
+    sh=2,af;
+    shd=5;
+    shd=2,6;
+    cftd=be,3,9;
+    cftd=2,af,4,8;
+    wc=4;
+    wc=2,5;
+    wt=00:30;
+    wt=2,01:00;
+  }
+}
+`;
+
 const undefinedScheduleDefinition = `
 unit=root,,jp1admin,;
 {
@@ -203,6 +237,13 @@ const parseScheduleJobnet = (): N => {
 
 const parseScheduleDefaultJobnet = (): N => {
   const result = parseAjs(scheduleDefaultDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as N;
+};
+
+const parseExplicitRuleOneScheduleJobnet = (): N => {
+  const result = parseAjs(explicitRuleOneScheduleDefinition);
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as N;
@@ -357,6 +398,68 @@ suite("ParameterFactory", () => {
     assert.deepStrictEqual(
       wt?.map((parameter) => parameter?.value()),
       ["no", "2,no"],
+    );
+  });
+
+  test("aligns omitted schedule-rule numbers to explicit rule one", () => {
+    const jobnet = parseExplicitRuleOneScheduleJobnet();
+
+    const st = ParamFactory.st(jobnet);
+    const sy = ParamFactory.sy(jobnet);
+    const ey = ParamFactory.ey(jobnet);
+    const ln = ParamFactory.ln(jobnet);
+    const cy = ParamFactory.cy(jobnet);
+    const sh = ParamFactory.sh(jobnet);
+    const shd = ParamFactory.shd(jobnet);
+    const cftd = ParamFactory.cftd(jobnet);
+    const wc = ParamFactory.wc(jobnet);
+    const wt = ParamFactory.wt(jobnet);
+
+    assert.deepStrictEqual(
+      st?.map((parameter) => parameter?.time),
+      ["08:00", "09:00"],
+    );
+    assert.deepStrictEqual(
+      sy?.map((parameter) => parameter?.time),
+      ["M120", "U60"],
+    );
+    assert.deepStrictEqual(
+      ey?.map((parameter) => parameter?.time),
+      ["C180", "18:00"],
+    );
+    assert.deepStrictEqual(
+      ln?.map((parameter) => parameter?.parentRule),
+      ["3", "4"],
+    );
+    assert.deepStrictEqual(
+      cy?.map((parameter) => parameter?.cycle),
+      ["3,d", "4,w"],
+    );
+    assert.deepStrictEqual(
+      sh?.map((parameter) => parameter?.substitute),
+      ["be", "af"],
+    );
+    assert.deepStrictEqual(
+      shd?.map((parameter) => parameter?.shiftDays),
+      ["5", "6"],
+    );
+    assert.deepStrictEqual(
+      cftd?.map((parameter) => ({
+        scheduleByDaysFromStart: parameter?.scheduleByDaysFromStart,
+        maxShiftableDays: parameter?.maxShiftableDays,
+      })),
+      [
+        { scheduleByDaysFromStart: "be,3", maxShiftableDays: "9" },
+        { scheduleByDaysFromStart: "af,4", maxShiftableDays: "8" },
+      ],
+    );
+    assert.deepStrictEqual(
+      wc?.map((parameter) => parameter?.numberOfTimes),
+      ["4", "5"],
+    );
+    assert.deepStrictEqual(
+      wt?.map((parameter) => parameter?.time),
+      ["00:30", "01:00"],
     );
   });
 

--- a/src/test/suite/scheduleRuleHelpers.test.ts
+++ b/src/test/suite/scheduleRuleHelpers.test.ts
@@ -1,0 +1,96 @@
+import * as assert from "assert";
+import {
+  parseClosedDaySubstitutionValue,
+  parseCycleValue,
+  parseDelayTimeValue,
+  parseParentScheduleRuleValue,
+  parseScheduleByDaysFromStartValue,
+  parseScheduleDateValue,
+  parseShiftDaysValue,
+  parseStartTimeValue,
+  parseWaitCountValue,
+  parseWaitTimeValue,
+} from "../../domain/models/parameters/scheduleRuleHelpers";
+
+suite("Schedule rule helpers", () => {
+  test("parses supported schedule-rule values with omitted rule defaults", () => {
+    assert.deepStrictEqual(parseScheduleDateValue("en"), {
+      rule: 1,
+      yearMonth: undefined,
+      day: "en",
+    });
+    assert.deepStrictEqual(parseScheduleDateValue("2,2026/04/27"), {
+      rule: 2,
+      yearMonth: "2026/04/",
+      day: "27",
+    });
+    assert.deepStrictEqual(parseStartTimeValue("+09:00"), {
+      rule: 1,
+      value: "+09:00",
+    });
+    assert.deepStrictEqual(parseDelayTimeValue("2,U60"), {
+      rule: 2,
+      value: "U60",
+    });
+    assert.deepStrictEqual(parseWaitTimeValue("un"), {
+      rule: 1,
+      value: "un",
+    });
+    assert.deepStrictEqual(parseParentScheduleRuleValue("3"), {
+      rule: 1,
+      value: "3",
+    });
+    assert.deepStrictEqual(parseCycleValue("(3,d)"), {
+      rule: 1,
+      value: "(3,d)",
+    });
+    assert.deepStrictEqual(parseClosedDaySubstitutionValue("ca"), {
+      rule: 1,
+      value: "ca",
+    });
+    assert.deepStrictEqual(parseShiftDaysValue("5"), {
+      rule: 1,
+      value: "5",
+    });
+    assert.deepStrictEqual(parseWaitCountValue("un"), {
+      rule: 1,
+      value: "un",
+    });
+  });
+
+  test("parses cftd defaults and mode-specific max-shift fields", () => {
+    assert.deepStrictEqual(parseScheduleByDaysFromStartValue("be"), {
+      rule: 1,
+      type: "be",
+      scheduleByDaysFromStart: "1",
+      maxShiftableDays: "10",
+    });
+    assert.deepStrictEqual(parseScheduleByDaysFromStartValue("2,af,4,8"), {
+      rule: 2,
+      type: "af",
+      scheduleByDaysFromStart: "4",
+      maxShiftableDays: "8",
+    });
+    assert.deepStrictEqual(parseScheduleByDaysFromStartValue("db,4,8"), {
+      rule: 1,
+      type: "db",
+      scheduleByDaysFromStart: "4",
+      maxShiftableDays: undefined,
+    });
+    assert.deepStrictEqual(parseScheduleByDaysFromStartValue("no"), {
+      rule: 1,
+      type: "no",
+      scheduleByDaysFromStart: undefined,
+      maxShiftableDays: undefined,
+    });
+  });
+
+  test("does not partially parse unsupported value shapes", () => {
+    assert.strictEqual(parseStartTimeValue("09:00x"), undefined);
+    assert.strictEqual(parseDelayTimeValue("+09:00"), undefined);
+    assert.strictEqual(parseWaitTimeValue("M120"), undefined);
+    assert.strictEqual(parseCycleValue("(3,q)"), undefined);
+    assert.strictEqual(parseClosedDaySubstitutionValue("before"), undefined);
+    assert.strictEqual(parseScheduleByDaysFromStartValue("be,3,9x"), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- Centralize schedule-rule value parsing in `scheduleRuleHelpers.ts` and reuse it from domain parameter classes and unit-list projection.
- Align omitted schedule-rule numbers to rule `1` across the schedule-rule family.
- Update SDD docs so category-level value parsing audits apply beyond schedule-related parameters.

## Why

The previous schedule-rule parsing logic was spread across domain wrappers and unit-list helper regular expressions. That made it hard to tell whether the value parsing matched the JP1/AJS3 v13 reference, and it encouraged one-parameter-at-a-time slices that were too small to review clearly.

## Validation

- `npm run qlty`
- `npm test`
- `npm run test:web`
- `npm run build`

`npm run build` still reports the existing webpack bundle-size warnings.