### PR TITLE
[codex] Strengthen SDD behavior scenarios

### DIFF
--- a/.codex/skills/sdd-change/SKILL.md
+++ b/.codex/skills/sdd-change/SKILL.md
@@ -9,10 +9,25 @@ Prepare or update SDD artifacts before implementing a non-trivial repository cha
 1. read `AGENTS.md`
 2. read `package.json`
 3. read the relevant files in `docs/specs/`
-4. update or create the matching use-case spec in
+4. investigate impact before implementation changes:
+   - search affected functions, classes, components, and commands
+   - list affected files, features, tests, docs, and breaking-change risk
+   - when behavior scenarios exist, list changed, added, or removed scenarios
+     and affected tests
+5. record findings by responsibility:
+   - `docs/specs/plans.md` for branch scope, assumptions, candidates, and risk
+   - feature `SPECS.md` for durable impact analysis, alternatives, and boundary
+     decisions
+   - feature `TASKS.md` for investigation, approval, fixes, tests, and
+     follow-up tasks
+6. update or create the matching use-case spec in
    `docs/requirements/use-cases/`
-5. update `PLANS.md` with assumptions, scope, and acceptance criteria
-6. summarize compatibility and layering risks before editing runtime code
+   when the behavior contract changes
+7. stop after the investigation and ask for explicit human approval before
+   editing runtime code, tests, generated artifacts, or configuration
+8. after approval, enumerate all affected references and task the complete fix
+9. implement in small meaningful blocks, checking compile/tests as you go
+10. run required validation before finishing
 
 ## Rules
 
@@ -20,5 +35,8 @@ Prepare or update SDD artifacts before implementing a non-trivial repository cha
 - preserve desktop and web extension behavior
 - prefer small vertical slices over broad rewrites
 - document assumptions instead of hiding them
+- keep KISS and YAGNI ahead of abstraction; avoid over-DRY process or code
 - use a `docs/...` branch name only when the slice stays within the docs-only
   file set used by `.github/workflows/verify.yml`
+- for docs-only changes, `pnpm run qlty` is required; add
+  `pnpm run lint:md` when useful

--- a/docs/requirements/use-cases/README.md
+++ b/docs/requirements/use-cases/README.md
@@ -26,9 +26,12 @@ That belongs in `docs/specs/`.
    acceptance notes.
 4. Keep UI framework details, VS Code adapter details, and file-level refactor
    steps out of the use case unless they are part of the behavior contract.
-5. When implementation changes but the behavior contract does not, update
+5. Use Gherkin scenarios only when they clarify behavior contracts. Keep
+   `Rules` for invariant constraints and remove `Acceptance Notes` that merely
+   repeat the same scenario.
+6. When implementation changes but the behavior contract does not, update
    `docs/specs/` and leave the use-case file stable.
-6. When the actual behavior contract changes, update the use-case file first,
+7. When the actual behavior contract changes, update the use-case file first,
    then align specs, plans, tasks, tests, and code.
 
 ## Relationship To `docs/specs/`

--- a/docs/requirements/use-cases/_template.md
+++ b/docs/requirements/use-cases/_template.md
@@ -18,12 +18,40 @@
 
 ## Rules
 
+<!--
+Invariant constraints, boundaries, must-not statements, compatibility
+requirements, and policy decisions that apply across scenarios.
+-->
+
 -
 
+## Behavioral Scenarios (Gherkin)
+
+Use scenarios only for behavior contracts that benefit from Given / When /
+Then clarity. Keep one behavior per scenario, use domain language, and avoid
+implementation details or long UI operation scripts.
+
+```gherkin
+Feature: Flow graph rendering
+
+Scenario: Hidden jobs are excluded by filter
+  Given a definition containing hidden jobs
+  When a hidden-job filter is applied
+  Then hidden jobs are not displayed
+```
+
 ## Acceptance Notes
+
+<!--
+Supplemental acceptance or validation notes that are not already expressed by
+Behavioral Scenarios, such as fixture strategy, migration caveats, or
+cross-host checks.
+-->
 
 -
 
 ## Risks Or Edge Cases
+
+<!-- Unresolved hazards, rare inputs, or focused future verification needs. -->
 
 -

--- a/docs/requirements/use-cases/uc-build-flow-graph.md
+++ b/docs/requirements/use-cases/uc-build-flow-graph.md
@@ -27,9 +27,29 @@ The user opens or refreshes a flow-oriented view for a selected unit scope.
   when practical
 - parser internals must not be exposed in the graph DTO
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Build flow graph
+
+Scenario: Selected scope produces deterministic graph content
+  Given normalized unit relationships for a selected unit scope
+  When the flow graph DTO is built for that scope
+  Then the graph contains deterministic nodes and edges for the same input
+
+Scenario: Parser internals are hidden from graph output
+  Given normalized unit relationships for visible units
+  When the flow graph DTO is built
+  Then the graph output does not expose parser-internal structures
+
+Scenario: Malformed relationships stay outside presentation workarounds
+  Given normalized unit relationships that include malformed links
+  When the flow graph DTO is built
+  Then the use case reports graph content without requiring UI-library types
+```
+
 ## Acceptance Notes
 
-- the same selected unit scope produces deterministic graph DTO content
 - desktop and web presentation layers can convert the DTO into their own graph
   structures without requiring `UnitEntity` reconstruction
 - flow rendering behavior remains unchanged after DTO to XyFlow mapping
@@ -38,8 +58,6 @@ The user opens or refreshes a flow-oriented view for a selected unit scope.
 
 ## Risks Or Edge Cases
 
-- cyclic or malformed relationships must not force
-  UI-library-specific workarounds into the use case
 - selected scope changes must preserve current-node and ancestor rendering semantics
 - large sample definitions should continue to build graph DTOs without
   presentation-layer shortcuts

--- a/docs/requirements/use-cases/uc-build-unit-list-view.md
+++ b/docs/requirements/use-cases/uc-build-unit-list-view.md
@@ -33,13 +33,31 @@ wrappers.
 - migration should be incremental, starting with the smallest set of columns
   that can move behind a stable row/view adapter
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Build unit list view
+
+Scenario: Same document produces the same visible rows
+  Given a normalized JP1/AJS document
+  When table row view models are built
+  Then the visible rows and unit ordering match current behavior
+
+Scenario: Row view models support definition actions
+  Given table row view models for a normalized JP1/AJS document
+  When a viewer requests dialog-opening metadata for a row
+  Then the row provides stable unit metadata for that action
+
+Scenario: Desktop and web viewers share the row shape
+  Given a normalized JP1/AJS document
+  When table row view models are built
+  Then desktop and web viewers can consume the same row shape
+```
+
 ## Acceptance Notes
 
-- table view still renders the same visible rows and unit-ordering for the same
-  input document
 - dialog opening, jump behavior, filtering, and CSV export continue to work
   from the application row/view adapter path
-- desktop and web viewers consume the same row/view model shape
 
 ## Risks Or Edge Cases
 

--- a/docs/requirements/use-cases/uc-build-unit-list.md
+++ b/docs/requirements/use-cases/uc-build-unit-list.md
@@ -27,12 +27,29 @@ presentation without exposing parser-adjacent structures to the UI.
 - normalized AJS semantics should be reused when practical so list and flow
   slices share the same business interpretation
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Build unit list
+
+Scenario: Valid JP1/AJS input produces deterministic unit-list data
+  Given valid JP1/AJS document text
+  When the unit-list document DTO is built
+  Then root units and nested children are returned in deterministic order
+
+Scenario: Invalid JP1/AJS input reports parser errors
+  Given invalid JP1/AJS document text
+  When the unit-list document DTO is built
+  Then parser errors are returned without constructing a partial UI document
+
+Scenario: Encoded sample definitions remain supported
+  Given a representative UTF-8 or Shift_JIS JP1/AJS sample definition
+  When the unit-list document DTO is built
+  Then the output preserves the expected unit-list content
+```
+
 ## Acceptance Notes
 
-- valid JP1/AJS input produces deterministic root-unit ordering and nested unit
-  content
-- invalid JP1/AJS input reports parser errors without constructing a partial UI
-  document
 - desktop and web table viewers can consume the same DTO shape
 - representative fixtures in `sample/` should be reusable for regression tests,
   especially UTF-8, Shift_JIS, and large-definition coverage
@@ -43,5 +60,3 @@ presentation without exposing parser-adjacent structures to the UI.
   parameters are mapped inconsistently
 - large definitions must continue to build list DTOs without introducing
   presentation-specific filtering behavior into the use case
-- encoding-sensitive input should keep working for both UTF-8 and Shift_JIS
-  samples

--- a/docs/requirements/use-cases/uc-export-unit-list-csv.md
+++ b/docs/requirements/use-cases/uc-export-unit-list-csv.md
@@ -27,17 +27,33 @@ React table internals or webview event handling.
   APIs
 - CSV escaping and column ordering must preserve current user-visible behavior
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Export unit list CSV
+
+Scenario: Copy and save produce the same CSV payload
+  Given the same visible unit-list rows and visible columns
+  When CSV text is requested for copy and save operations
+  Then both operations receive the same CSV payload
+
+Scenario: Hidden columns are excluded
+  Given visible unit-list rows with hidden columns
+  When CSV text is generated
+  Then hidden columns are not included in the CSV output
+
+Scenario: Escaped values preserve current CSV behavior
+  Given visible unit-list rows containing quotes or multi-line values
+  When CSV text is generated
+  Then embedded quotes and line breaks are escaped as users expect
+```
+
 ## Acceptance Notes
 
-- copying and saving produce the same CSV payload for the same visible table
-  state
-- hidden columns are not exported
 - desktop and web viewers can request the same CSV payload shape before their
   platform-specific save/copy steps
 
 ## Risks Or Edge Cases
 
-- multi-line parameter values and embedded quotes must remain escaped exactly as
-  current users expect
 - the current implementation depends on React Table structures, so extracting a
   stable export input DTO must avoid accidental column-order regressions

--- a/docs/requirements/use-cases/uc-generate-ajs-commands.md
+++ b/docs/requirements/use-cases/uc-generate-ajs-commands.md
@@ -38,6 +38,28 @@ inside one presentation-specific builder.
 - command reference links should follow the active UI language when a
   language-specific JP1/AJS manual URL is known
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Generate AJS commands
+
+Scenario: Selected scope produces command text
+  Given a selected JP1/AJS unit or scope
+  And application-facing definition data for that context
+  When command text is generated
+  Then generated JP1/AJS command text is returned for the selected scope
+
+Scenario: Default command text is preserved
+  Given a selected scope supported by existing ajsshow and ajsprint behavior
+  When command text is generated
+  Then the default ajsshow and ajsprint command text remains unchanged
+
+Scenario: Presentation surfaces receive structured builder definitions
+  Given supported command options for a selected scope
+  When command builder definitions are requested
+  Then presentation surfaces receive structured command option definitions
+```
+
 ## Acceptance Notes
 
 - command-generation behavior can be tested without opening a viewer dialog
@@ -45,8 +67,6 @@ inside one presentation-specific builder.
   same dedicated contract
 - command support can expand incrementally across documented JP1/AJS commands
   without rewriting the consumer surface each time
-- the initial builder surface preserves the existing default command text for
-  `ajsshow` and `ajsprint`
 
 ## Risks Or Edge Cases
 

--- a/docs/requirements/use-cases/uc-import-ajs-definition-via-webapi.md
+++ b/docs/requirements/use-cases/uc-import-ajs-definition-via-webapi.md
@@ -48,16 +48,34 @@ the extension is not limited to local definition files.
 - server responses must not be exposed directly to list, flow, CSV,
   diagnostics, hover, or unit-definition presentation code
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Import AJS definition via WebAPI
+
+Scenario: Read-only import returns consumable definition data
+  Given a supported JP1/AJS WebAPI connection context
+  And request parameters for a definition scope
+  When read-only import is requested
+  Then definition data is returned through application-facing structures
+
+Scenario: Unsupported browser host reports a stable error
+  Given browser-hosted execution without a browser-safe WebAPI adapter
+  When read-only import is requested
+  Then the import result reports unsupported host
+
+Scenario: Authentication or transport failure is structured
+  Given a JP1/AJS WebAPI request that fails authentication or transport
+  When read-only import is requested
+  Then a structured import error is returned without leaking secrets
+```
+
 ## Acceptance Notes
 
 - a user can request server-side definition loading without relying on a local
   exported file as the primary source
-- downstream features can consume imported data through explicit application
-  contracts instead of direct WebAPI response objects
 - desktop and web compatibility implications are documented explicitly for the
   chosen transport approach
-- authentication and error-reporting behavior is explicit before implementation
-  starts
 - generated mocks or stubs can exercise supported success and failure paths
   without requiring a live JP1/AJS3 server for every test run
 - beta labeling makes limited real-environment validation and limited field

--- a/docs/requirements/use-cases/uc-interpret-jp1-parameters.md
+++ b/docs/requirements/use-cases/uc-interpret-jp1-parameters.md
@@ -33,11 +33,30 @@ target product reference so multiple features can rely on the same semantics.
 - manual-aligned semantics should not be duplicated independently in multiple
   viewers or adapters
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Interpret JP1 parameters
+
+Scenario: Parameter interpretation follows the named product version
+  Given parsed or normalized JP1/AJS parameter data
+  And JP1/AJS3 version 13 parameter rules
+  When parameter interpretation is requested
+  Then results are described against JP1/AJS3 version 13 semantics
+
+Scenario: Shared consumers reuse interpretation results
+  Given parameter interpretation results for a JP1/AJS unit
+  When hover, unit definition, flow, or list presentation needs the same rule
+  Then consumers reuse the shared interpretation instead of re-deriving it
+
+Scenario: Context-sensitive rules remain explicit
+  Given a parameter rule that depends on unit type, inheritance, or schedule
+  When the parameter is interpreted
+  Then the context that affects the result is visible in the interpretation
+```
+
 ## Acceptance Notes
 
-- parameter parsing behavior is described against one named product version
-- shared consumers can reuse the same parameter interpretation results instead
-  of re-deriving semantics ad hoc
 - existing behavior can be preserved incrementally while mismatches against the
   chosen manual are made explicit and corrected in focused slices
 

--- a/docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md
+++ b/docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md
@@ -31,18 +31,38 @@ other viewer when that counterpart view is available.
 - desktop and web hosts should be able to use the same application-facing
   navigation contract
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Navigate between unit list and flow graph
+
+Scenario: Jump from unit list to matching flow scope
+  Given a selected unit in the unit-list viewer
+  And a flow graph can be built for the same document context
+  When the user invokes jump to flow graph
+  Then the flow graph opens or focuses the matching unit scope
+
+Scenario: Jump from flow graph to matching unit row
+  Given a selected unit in the flow-graph viewer
+  And a unit-list view can be built for the same document context
+  When the user invokes jump to unit list
+  Then the unit-list viewer opens or focuses the matching unit row
+
+Scenario: Counterpart viewer is unavailable
+  Given a selected unit in one viewer
+  And the counterpart viewer cannot be opened for that context
+  When the user invokes cross-view navigation
+  Then the current viewer state remains stable
+  And the action fails predictably
+```
+
 ## Acceptance Notes
 
-- a jump from unit-list to flow-graph lands on the matching unit scope when a
-  flow view can be built
-- a jump from flow-graph to unit-list lands on the matching unit row when a
-  list view can be built
 - the action does not require `UnitEntity` reconstruction in the presentation
   layer if stable normalized or DTO identity is sufficient
 
 ## Risks Or Edge Cases
 
-- target viewers might not already be open
 - some units might not have a meaningful flow scope or list row under the same
   presentation rules
 - navigation semantics can drift if unit identity differs between list and flow

--- a/docs/requirements/use-cases/uc-normalize-ajs-document.md
+++ b/docs/requirements/use-cases/uc-normalize-ajs-document.md
@@ -33,16 +33,31 @@ independent from parser tree mechanics, VS Code APIs, and UI-library types.
 - normalized output must be deterministic and suitable for unit list, flow
   graph, CSV, and future reuse
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Normalize AJS document
+
+Scenario: Parsed units become deterministic normalized units
+  Given a parsed raw Unit root tree
+  When the AJS document is normalized
+  Then normalized units are produced with deterministic identity and structure
+
+Scenario: Common navigation semantics are reusable
+  Given a normalized AJS document with nested units
+  When parent, ancestor, or root jobnet lookup is requested
+  Then the normalized model provides reusable navigation semantics
+
+Scenario: Shared parameter lookup stays consistent
+  Given a normalized AJS document with inherited parameter values
+  When direct, repeated, or first-ancestor parameter lookup is requested
+  Then consumers receive consistent parameter semantics
+```
+
 ## Acceptance Notes
 
 - `BuildUnitList` can derive its DTOs from the normalized model
 - `BuildFlowGraph` can derive its graph inputs from the normalized model
-- common navigation semantics such as parent lookup, ancestor lookup, and root
-  jobnet lookup should be reusable from the normalized model when multiple
-  application or presentation paths need them
-- common parameter semantics such as direct lookup, repeated-value lookup, and
-  first-ancestor inherited lookup should be reusable from the normalized model
-  when multiple consumers need the same interpretation
 - remaining wrapper-derived semantics should move into the normalized model
   only when the same rule is still duplicated across multiple normalized or
   application consumers

--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -28,10 +28,29 @@ embedding VS Code object construction inside parser-adjacent business logic.
 - VS Code adapters map DTOs into editor-specific objects
 - existing diagnostic messages and hover syntax content must remain unchanged
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Provide editor feedback
+
+Scenario: Invalid JP1/AJS text produces diagnostics
+  Given a JP1/AJS document containing invalid syntax
+  When editor feedback is requested
+  Then application-level diagnostic DTOs are returned
+
+Scenario: Parameter hover returns syntax information
+  Given a JP1/AJS document with a recognized parameter token
+  When hover information is requested for that token
+  Then application-level hover DTOs include the same syntax information
+
+Scenario: VS Code objects stay outside application output
+  Given JP1/AJS editor feedback output
+  When diagnostics and hover data are produced
+  Then the application output does not construct VS Code API objects
+```
+
 ## Acceptance Notes
 
-- invalid JP1/AJS text still produces diagnostics in the editor
-- parameter hover still shows the same syntax information as before
 - desktop and web extension entry points continue to share the same
   application logic for diagnostics and hover decisions
 

--- a/docs/requirements/use-cases/uc-record-telemetry.md
+++ b/docs/requirements/use-cases/uc-record-telemetry.md
@@ -27,10 +27,29 @@ exposing telemetry SDK types outside the outer adapter layer.
 - event names and basic payload behavior stay unchanged in this refactor
 - telemetry scope must remain minimal and privacy-conscious
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Record telemetry
+
+Scenario: Activation and deactivation events are submitted
+  Given the extension activates or deactivates
+  When telemetry is recorded through the application-facing contract
+  Then the existing lifecycle event is submitted through the adapter
+
+Scenario: Preview and webview operation events are submitted
+  Given a preview command or webview-originated operation occurs
+  When telemetry is recorded through the application-facing contract
+  Then the existing event name and basic payload behavior are preserved
+
+Scenario: Telemetry payload remains privacy-conscious
+  Given telemetry event payload properties
+  When an event is submitted
+  Then file content, file paths, and personal identifiers are not added
+```
+
 ## Acceptance Notes
 
-- activation and deactivation events still fire
-- existing preview and webview operation telemetry still fires
 - desktop and web entry points share the same telemetry contract
 
 ## Risks Or Edge Cases

--- a/docs/requirements/use-cases/uc-show-unit-definition.md
+++ b/docs/requirements/use-cases/uc-show-unit-definition.md
@@ -29,12 +29,31 @@ objects.
   the same selected unit
 - platform-specific dialog rendering stays in presentation code
 
+## Behavioral Scenarios (Gherkin)
+
+```gherkin
+Feature: Show unit definition
+
+Scenario: Table and flow views show the same unit definition
+  Given the same selected JP1/AJS unit in table and flow contexts
+  When unit-definition details are requested
+  Then both viewers receive the same raw parameter text
+
+Scenario: Command text uses the selected unit path
+  Given a selected JP1/AJS unit with an absolute path
+  When unit-definition details are requested
+  Then command text is derived from that selected unit path
+
+Scenario: Opening definition details preserves flow navigation
+  Given a selected unit in the flow view
+  When unit-definition details are opened
+  Then current flow-navigation behavior is unchanged
+```
+
 ## Acceptance Notes
 
-- the same selected unit shows the same raw parameter text in table and flow
-  views
-- command text remains based on the selected unit absolute path
-- opening the dialog does not change current flow-navigation behavior
+- unit-definition dialog content can be extracted without forcing a broader
+  table or flow rewrite
 
 ## Risks Or Edge Cases
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,24 +27,26 @@ For non-trivial changes:
 
 1. create a dedicated git branch before implementation work starts
    and use `docs/...` only for docs-only slices
-2. update or create the relevant use-case spec in
+2. prefer quality assurance, KISS, DRY/YAGNI, then SOLID in that order;
+   do not add abstractions unless they reduce real complexity
+3. update or create the relevant use-case spec in
    `docs/requirements/use-cases/` when the behavior contract changes
-3. update or create concise feature docs under
+4. update or create concise feature docs under
    `docs/specs/features/<feature>/` when implementation requirements,
    boundary decisions, or active tasks need tracking
-4. track execution tasks in `docs/specs/features/<feature>/TASKS.md`
+5. track execution tasks in `docs/specs/features/<feature>/TASKS.md`
    and update that file in the same commit whenever a task is completed,
    reframed, or dropped
-5. document assumptions explicitly
-6. implement in small vertical slices
-7. refresh `docs/specs/plans.md` in the same commit if the active slice or
+6. document assumptions explicitly
+7. implement in small vertical slices
+8. refresh `docs/specs/plans.md` in the same commit if the active slice or
    branch priorities change materially
-8. refresh `docs/specs/roadmap.md` in the same commit if a completed slice
+9. refresh `docs/specs/roadmap.md` in the same commit if a completed slice
    changes repository-level ordering, remaining debt, or deferred work
-9. before `git push`, run local validation serially in this order for code
-   changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`, `pnpm run build`
-10. run any additional task-specific checks before finishing
-11. avoid anemic domain models: extract only cross-unit or cross-layer
+10. before `git push`, run local validation serially in this order for code
+    changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`, `pnpm run build`
+11. run any additional task-specific checks before finishing
+12. avoid anemic domain models: extract only cross-unit or cross-layer
     semantics into helpers/interfaces, and keep entity identity plus
     unit-local behavior in the entity when that behavior is part of the
     JP1/AJS concept itself
@@ -52,8 +54,100 @@ For non-trivial changes:
 For docs-only changes:
 
 - `pnpm run build` is not required
-- run markdown-focused validation such as `pnpm run lint:md`
+- `pnpm run qlty` is required
+- run `pnpm run lint:md` when the changed markdown scope benefits from
+  markdown-specific validation
 - repository `Verify` workflow should not be relied on as a required gate
+
+## Implementation Change Gate
+
+Before editing runtime code, tests, generated artifacts, or configuration:
+
+1. perform an impact investigation
+2. record the findings in the right SDD artifacts
+3. report the planned change, affected files, affected features, affected
+   tests, breaking-change risk, and alternatives
+4. stop until a human explicitly approves implementation
+
+After approval, expand the investigation into a complete reference impact
+check, list every required fix, and task the work before implementation.
+Do not finish with only a subset of affected references updated.
+
+Implementation should then proceed in small meaningful blocks:
+
+1. implement one coherent block
+2. compile or run the closest fast check
+3. repair affected references in order
+4. run relevant unit tests
+5. after all fixes, run non-unit validation required by the change
+
+Do not leave failing checks unexplained or deferred without an explicit
+follow-up decision.
+
+## Impact Investigation Records
+
+Use the SDD artifacts by responsibility instead of storing all investigation
+notes in `TASKS.md`.
+
+- `docs/specs/plans.md`:
+  branch-level plan, scope boundary, changed-area summary, likely fix
+  candidates, risk summary, and assumptions
+- `docs/specs/features/<feature>/SPECS.md`:
+  durable impact analysis, reference propagation decisions, breaking-change
+  analysis, alternatives, and boundary decisions
+- `docs/specs/features/<feature>/TASKS.md`:
+  execution tasks for investigation, approval, implementation, tests, and
+  follow-up tracking
+
+`TASKS.md` may point to investigation results, but it is not the primary
+record for design decisions or impact analysis.
+
+When behavior scenarios exist, include the scenario impact in the same
+investigation: changed scenarios, added scenarios, removed scenarios, and
+tests affected by those scenarios.
+
+## Gherkin Usage
+
+Use Gherkin selectively for behavior contracts where Given / When / Then makes
+the expected behavior clearer.
+
+Keep use-case sections separated by responsibility:
+
+- `Rules`:
+  invariant constraints, boundaries, must-not statements, compatibility
+  requirements, and policy decisions that apply across scenarios
+- `Behavioral Scenarios`:
+  concrete observable examples of behavior, one behavior per scenario
+- `Acceptance Notes`:
+  supplemental acceptance or validation notes that are not already expressed by
+  scenarios, such as fixture strategy, migration caveats, or cross-host checks
+- `Risks Or Edge Cases`:
+  unresolved hazards, rare inputs, and conditions that need focused future
+  verification
+
+When adding scenarios, remove or shorten `Acceptance Notes` that repeat the
+same Given / When / Then behavior. Keep `Rules` unless they are only restating
+one scenario and are not a general constraint.
+
+Good fit:
+
+- use-case scenarios
+- regression-prone behavior
+- domain rules
+- bug recurrence prevention
+- breaking-change examples
+
+Poor fit:
+
+- architecture design
+- layering decisions
+- refactor plans
+- dependency design
+- internal algorithm details
+
+Prefer clarity over ceremony. Do not force every specification into Gherkin,
+and do not add Cucumber or other executable-spec tooling unless a future slice
+explicitly justifies it.
 
 ## Branch Naming
 

--- a/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
+++ b/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
@@ -16,20 +16,40 @@ Read these documents first:
 
 Implementation rules:
 
-1. Follow TASKS.md in small safe steps.
-2. Do not rewrite unrelated code.
-3. Preserve existing behavior unless SPECS.md explicitly changes it.
-4. Respect DDD and Clean Architecture boundaries.
-5. Keep UI, application, domain, and infrastructure responsibilities separate.
-6. Preserve VS Code 1.75 compatibility.
-7. Add or update tests for every behavior change.
-8. Update documentation if implementation decisions differ from the spec.
+1. Start with impact investigation.
+2. Stop for explicit human approval before implementation.
+3. After approval, enumerate all affected references and track the complete fix.
+4. Follow TASKS.md in small safe steps.
+5. Do not rewrite unrelated code.
+6. Preserve existing behavior unless SPECS.md explicitly changes it.
+7. Respect DDD and Clean Architecture boundaries.
+8. Keep UI, application, domain, and infrastructure responsibilities separate.
+9. Preserve VS Code compatibility declared in `package.json`.
+10. Add or update tests for every behavior change.
+11. Update documentation if implementation decisions differ from the spec.
 
 Before editing:
 
+- Search affected functions, classes, components, commands, and DTOs.
+- List changed areas, affected features, affected tests, related docs, and
+  breaking-change risk.
+- When behavior scenarios exist, list changed, added, or removed scenarios and
+  affected tests.
+- Record branch scope and risks in PLANS.md.
+- Record durable impact, propagation, alternatives, and boundary decisions in
+  SPECS.md.
+- Record investigation, approval, implementation, test, and follow-up tasks in
+  TASKS.md.
+- Report the plan, affected files, tests, risks, and alternatives to the human
+  reviewer, then wait for approval.
+
+After approval:
+
 - Inspect existing files and naming conventions.
-- Identify relevant tests and fixtures.
-- Confirm expected behavior.
+- Confirm every affected reference is either fixed or explicitly left
+  unchanged in SPECS.md.
+- Implement one coherent block at a time.
+- Compile or run the closest fast check after meaningful changes.
 
 After editing:
 

--- a/docs/specs/features/_templates/CODEX_SDD_PROMPT.template.md
+++ b/docs/specs/features/_templates/CODEX_SDD_PROMPT.template.md
@@ -34,8 +34,10 @@ Instructions:
    - TRACEABILITY.md if requirements mapping is useful
 5. Keep documents concise, repository-specific, and implementation-ready.
 6. Align with DDD and Clean Architecture.
-7. Preserve VS Code 1.75 compatibility when relevant.
+7. Preserve VS Code compatibility declared in `package.json` when relevant.
 8. Prefer evolutionary design over rewrite-oriented plans.
+9. Use Gherkin scenarios only when they clarify behavior contracts,
+   regression-prone behavior, domain rules, or bug recurrence prevention.
 
 Output:
 

--- a/docs/specs/features/_templates/PLANS.template.md
+++ b/docs/specs/features/_templates/PLANS.template.md
@@ -12,6 +12,14 @@
 
 - {{out of scope}}
 
+## Impact Summary
+
+- Change targets: {{files, modules, or boundaries}}
+- Affected features: {{features or "none"}}
+- Affected tests: {{tests or "none"}}
+- Related docs: {{docs or "none"}}
+- Breaking-change risk: {{none/low/medium/high and reason}}
+
 ## Milestones
 
 1. {{milestone}}
@@ -25,4 +33,4 @@
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/_templates/SPECS.template.md
+++ b/docs/specs/features/_templates/SPECS.template.md
@@ -13,12 +13,49 @@
 
 - {{requirement}}
 
+## Behavioral Scenarios (optional)
+
+Use Gherkin only for behavior contracts, regression-prone behavior, domain
+rules, or bug recurrence prevention. Do not convert architecture, layering,
+dependency design, refactor plans, or internal algorithms into scenarios.
+When scenarios cover an acceptance note, keep the scenario and remove the
+duplicate note.
+
+```gherkin
+Feature: {{behavior area}}
+
+Scenario: {{one observable behavior}}
+  Given {{domain precondition}}
+  When {{domain event or request}}
+  Then {{observable outcome}}
+```
+
 ## Architecture
 
 - Domain: {{responsibility or "none"}}
 - Application: {{responsibility or "none"}}
 - Presentation: {{responsibility or "none"}}
 - Infrastructure: {{responsibility or "none"}}
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected callers, components, commands, adapters, tests, and docs:
+  {{impact summary}}
+- Propagation decision: {{what must change together and what is intentionally
+  unchanged}}
+
+### Breaking Change Analysis
+
+- User-visible behavior: {{none or impact}}
+- API/DTO/schema compatibility: {{none or impact}}
+- VS Code/web extension compatibility: {{none or impact}}
+- Changed scenarios: {{scenario IDs added, changed, removed, or "none"}}
+
+### Alternative Considerations
+
+- {{alternative}}: {{reason accepted or rejected}}
 
 ## Compatibility
 

--- a/docs/specs/features/_templates/TASKS.template.md
+++ b/docs/specs/features/_templates/TASKS.template.md
@@ -9,7 +9,11 @@
 
 ## Tasks
 
-- [ ] {{task}}
+- [ ] Impact investigation completed and recorded in PLANS/SPECS/TASKS by
+      responsibility
+- [ ] Human approval gate passed before implementation
+- [ ] Fix targets tracked to completion
+- [ ] {{implementation task}}
 
 ## Validation
 
@@ -19,4 +23,6 @@
 
 ## Notes
 
-- {{durable note}}
+- Keep investigation details in PLANS.md or SPECS.md when they describe scope,
+  risk, alternatives, or boundary decisions.
+- Use this file for executable tasks and follow-up tracking only.

--- a/docs/specs/features/_templates/TRACEABILITY.template.md
+++ b/docs/specs/features/_templates/TRACEABILITY.template.md
@@ -2,14 +2,19 @@
 
 ## Purpose
 
-Map the use case, feature requirements, tasks, and tests when that mapping is
-not obvious from SPECS.md and TASKS.md alone.
+Map the use case, behavioral scenarios, feature requirements, implementation,
+tasks, and tests when that mapping is not obvious from SPECS.md and TASKS.md
+alone.
 
-## Matrix
+## Mapping
 
-| Use Case  | Requirement | Spec        | Task     | Test     |
-| --------- | ----------- | ----------- | -------- | -------- |
-| UC-{{ID}} | FR-{{ID}}   | {{section}} | {{task}} | {{test}} |
+- UC: UC-{{ID}}
+- Scenario: SCN-{{ID}}-1
+- Requirement: FR-{{ID}}
+- Spec: {{section}}
+- Implementation: {{path}}
+- Task: {{task}}
+- Test: TEST-{{ID}}
 
 ## Coverage
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -39,4 +39,4 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/build-flow-graph/PLANS.md
+++ b/docs/specs/features/build-flow-graph/PLANS.md
@@ -21,4 +21,4 @@ boundary.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/build-unit-list-view/PLANS.md
+++ b/docs/specs/features/build-unit-list-view/PLANS.md
@@ -20,4 +20,4 @@ Maintain the delivered table-view projection boundary.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/build-unit-list/PLANS.md
+++ b/docs/specs/features/build-unit-list/PLANS.md
@@ -30,4 +30,4 @@ list-search behavior.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/enhance-flow-graph-experience/PLANS.md
+++ b/docs/specs/features/enhance-flow-graph-experience/PLANS.md
@@ -49,4 +49,4 @@ Deliver a clearer and more navigable flow-graph experience in focused slices.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/export-unit-list-csv/PLANS.md
+++ b/docs/specs/features/export-unit-list-csv/PLANS.md
@@ -20,4 +20,4 @@ Maintain delivered CSV export behavior.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/import-definition-via-webapi/PLANS.md
+++ b/docs/specs/features/import-definition-via-webapi/PLANS.md
@@ -195,4 +195,4 @@ hover, or unit-definition features remains a follow-up integration slice.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/modernize-runtime-boundaries/PLANS.md
+++ b/docs/specs/features/modernize-runtime-boundaries/PLANS.md
@@ -30,4 +30,4 @@ startup-time, or payload requirement appears.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/normalize-ajs-document/PLANS.md
+++ b/docs/specs/features/normalize-ajs-document/PLANS.md
@@ -21,4 +21,4 @@ semantics split.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/provide-editor-feedback/PLANS.md
+++ b/docs/specs/features/provide-editor-feedback/PLANS.md
@@ -21,4 +21,4 @@ Maintain delivered diagnostics and hover behavior.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/record-telemetry/PLANS.md
+++ b/docs/specs/features/record-telemetry/PLANS.md
@@ -20,4 +20,4 @@ Maintain delivered telemetry-port behavior.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/features/show-unit-definition/PLANS.md
+++ b/docs/specs/features/show-unit-definition/PLANS.md
@@ -21,4 +21,4 @@ Maintain delivered unit-definition dialog behavior.
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
-- docs-only changes: `pnpm run lint:md`
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -6,6 +6,9 @@ This is the branch-level SDD planning index. Feature-local details live under
 `docs/specs/features/<feature>/`; repository-level behavior contracts live
 under `docs/requirements/use-cases/`.
 
+Clear branch-specific notes when starting a new branch. Keep stable workflow
+rules in `docs/specs/README.md`, not in this file.
+
 ## Current Decisions
 
 - List search stays presentation-local until another non-table consumer needs
@@ -32,6 +35,26 @@ under `docs/requirements/use-cases/`.
 3. Keep compatibility risk visible for every shared or extension-runtime
    change.
 
+## Current Branch Plan
+
+- Branch: `docs/sdd-safety-gates`
+- Objective: tighten SDD safety gates and add selective Gherkin guidance for
+  behavior-oriented specifications without adding new document families.
+- Scope: update the SDD README, Codex SDD skill, branch plan guidance, and
+  feature/use-case templates for SPECS, TASKS, TRACEABILITY, implementation
+  prompts, plan validation, and behavior scenarios. Add selective Gherkin
+  scenarios to existing use cases where the behavior contract is already clear.
+- Out of scope: runtime code changes, generated artifacts, and new feature
+  directories.
+- Impact summary: SDD workflow documentation and templates only. Gherkin is
+  documentation guidance for behavior contracts, not a test-tool dependency;
+  no product behavior, VS Code compatibility, parser behavior, web extension
+  runtime, or tests are changed. Existing use-case behavior is clarified, not
+  expanded.
+- Risks and assumptions: keep the rules concise so feature docs remain useful
+  working documents rather than process logs; require `pnpm run qlty` for this
+  docs-only slice.
+
 ## Wrapper Semantics Matrix
 
 - Capability interface + helper:
@@ -49,17 +72,8 @@ under `docs/requirements/use-cases/`.
   JP1 getters; avoid debug helpers, dead compatibility APIs, or
   wrapper-specific business rules.
 
-## Default Workflow
+## Branch Validation
 
-1. Use a dedicated branch. Reserve `docs/...` branches for docs-only changes.
-2. Read the relevant documents in `docs/specs/`.
-3. Update `docs/requirements/use-cases/` only when the durable behavior
-   contract changes.
-4. Update or create feature docs under `docs/specs/features/<feature>/` only
-   when implementation requirements, boundary decisions, or active tasks need
-   tracking.
-5. Update feature `TASKS.md`, this file, and `roadmap.md` in the same commit
-   when task completion changes priorities or repository sequencing.
-6. For code changes, run `pnpm run qlty`, `pnpm test`,
-   `pnpm run test:web`, and `pnpm run build`.
-7. For docs-only changes, run `pnpm run lint:md`.
+- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when markdown
+  structure or links need focused validation
+- code changes: follow `docs/specs/README.md`


### PR DESCRIPTION
## Summary

- Add selective Gherkin guidance to SDD templates and use-case documentation.
- Add behavior-oriented scenarios to use cases where the behavior contract is already clear.
- Remove or shorten acceptance notes that duplicated the new scenarios while keeping rules as invariant constraints.
- Require docs-only quality validation through `pnpm run qlty` and keep markdown lint guidance explicit.

## Scope

Docs-only. No runtime code, tests, generated artifacts, VS Code API usage, or web extension behavior changed.

## Validation

- `pnpm run lint:md`
- `pnpm run qlty`