### PR TITLE
[codex] Align transfer operation parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,13 +64,16 @@ Good first slices:
 
 For non-trivial changes, follow this order:
 
-1. Read relevant docs in `docs/specs/`.
-2. Update or create the relevant use-case spec.
-3. Write or update a short implementation plan in `PLANS.md`.
-4. Confirm acceptance criteria.
-5. Implement.
-6. Run quality checks.
-7. Summarize impact and remaining risks.
+1. Read `docs/specs/README.md` first, especially the
+   Implementation Change Gate.
+2. Read relevant feature and roadmap docs in `docs/specs/`.
+3. Update or create the relevant use-case spec.
+4. Write or update a short implementation plan in `PLANS.md`.
+5. Confirm acceptance criteria and required approval gates before editing
+   runtime code, tests, generated artifacts, or configuration.
+6. Implement.
+7. Run quality checks.
+8. Summarize impact and remaining risks.
 
 If the requested change is ambiguous, prefer documenting assumptions explicitly in `PLANS.md` instead of making hidden assumptions.
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -27,6 +27,28 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   ignoring `ln` on root jobnets.
 - Started category-level value parsing alignment with the schedule-rule
   parameter family, using shared domain helpers as the boundary pattern.
+- Prepared the next category-level helper-boundary slice for transfer
+  operation parameters in `TRANSFER_OPERATION_ALIGNMENT.md`.
+- Extracted `top1` to `top4` default resolution into
+  `transferOperationHelpers.ts` while preserving explicit and derived values.
+
+## Impact Investigation
+
+- Planned change: move `top1` to `top4` default resolution out of the generic
+  `parameterHelpers.ts` module and into a transfer-operation helper seam.
+- Affected files:
+  `src/domain/models/parameters/parameterHelpers.ts`,
+  `src/domain/models/parameters/transferOperationHelpers.ts`,
+  `src/domain/models/parameters/transferOperationParameterBuilders.ts`,
+  `src/test/suite/parameterHelpers.test.ts`, and this feature's SDD docs.
+- Affected features: JP1/AJS parameter interpretation for UNIX/PC job and
+  UNIX/PC custom job transfer operation defaults.
+- Tests affected: parameter helper and parameter factory regression tests.
+- Breaking-change risk: low. The intended behavior preserves current explicit
+  and derived `topN` values while narrowing the owning helper boundary.
+- Alternatives considered: leave `topN` logic in `parameterHelpers.ts`; this
+  was rejected because the schedule-rule slice established category-specific
+  helper seams and `topN` has transfer-specific paired-parameter semantics.
 
 ## Follow-up
 
@@ -34,6 +56,8 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   categories before marking them official-reference aligned.
 - Build a parameter-coverage matrix when category-level status needs tracking
   beyond the current audit summary.
+- Revisit QUEUE job transfer-file coverage separately because the manual
+  defines `tsN` and `tdN` but not `topN`.
 
 ## Validation
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -45,11 +45,17 @@
 - [x] Centralize schedule-rule value parsing behind domain helpers and verify
       the official format shape for the schedule-rule family before treating
       the category as aligned
+- [x] Record transfer-operation alignment scope, manual references, affected
+      seams, and expected `top1` to `top4` default behavior before completing
+      the helper-boundary extraction
 
 ## Follow-up
 
+- [x] Extract `top1` to `top4` default resolution into a transfer-operation
+      helper seam while preserving explicit and derived values
 - [ ] Apply the same category-level value parsing audit/refactor workflow to
-      non-schedule parameter families before marking those categories aligned
+      another non-schedule parameter family before marking those categories
+      aligned
 - [ ] Turn the audit notes into an explicit parameter-coverage matrix when
       category-level status needs tracking beyond the current audit summary
 - [ ] Continue schedule-rule helper-boundary alignment with the remaining
@@ -97,3 +103,9 @@
   and reused by unit-list projection. This is the first category-level parser
   alignment pattern; later parameter categories should follow the same audit,
   helper-boundary, and regression-test workflow.
+- 2026-04-27: transfer-operation alignment is the next helper-boundary slice.
+  It keeps the existing `topN` behavior but moves the paired `tsN` / `tdN`
+  default rule out of generic parameter helper code.
+- 2026-04-27: `topN` default resolution now lives in
+  `transferOperationHelpers.ts`; regression evidence covers explicit `topN`,
+  derived `sav`, derived `del`, and the no-default case.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TRANSFER_OPERATION_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TRANSFER_OPERATION_ALIGNMENT.md
@@ -1,0 +1,57 @@
+# Transfer Operation Parameter Alignment
+
+## Purpose
+
+Record the JP1/AJS3 version 13 alignment slice for transfer operation
+parameters used by UNIX/PC jobs and UNIX/PC custom jobs. This is the next
+category-level helper-boundary slice after schedule-rule parsing.
+
+This document covers only `top1`, `top2`, `top3`, and `top4`, plus their
+paired transfer source and destination presence checks through `ts1` to `ts4`
+and `td1` to `td4`.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual sections:
+  - Command Reference, `5.2.6 UNIX/PC job definition`
+  - Command Reference, `5.2.24 UNIX/PC custom job definition`
+- Source URLs:
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0221.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0239.HTM>
+
+## Slice Boundary
+
+- Domain seams:
+  `src/domain/models/parameters/transferOperationHelpers.ts` and
+  `src/domain/models/parameters/transferOperationParameterBuilders.ts`
+- Existing consumers:
+  `src/domain/models/units/J.ts`, `src/domain/models/units/Cj.ts`, and
+  `ParamFactory.top1` to `ParamFactory.top4`
+- Regression evidence:
+  `src/test/suite/parameterHelpers.test.ts` and
+  `src/test/suite/parameterFactory.test.ts`
+- Out of scope:
+  quoted filename parsing, byte-length validation, macro-variable validation,
+  custom PC job invalidation, and QUEUE job transfer-file handling because
+  QUEUE job definitions do not define `top1` to `top4`
+
+## Shared Expectations
+
+- Explicit `topN` values are preserved.
+- If `topN` is omitted and both `tsN` and `tdN` exist, `topN` resolves to
+  `sav`.
+- If `topN` is omitted and `tsN` exists without `tdN`, `topN` resolves to
+  `del`.
+- If `topN`, `tsN`, and `tdN` are all omitted, no default `topN` parameter is
+  synthesized.
+- The transfer operation default rule is isolated from the generic parameter
+  helper so future transfer-specific checks do not broaden
+  `parameterHelpers.ts`.
+
+## Follow-up
+
+- Add validation only after deciding whether invalid JP1/AJS parameter values
+  should become diagnostics, warnings, or preserved raw values.
+- Revisit QUEUE job transfer-file coverage separately because its manual
+  contract includes `tsN` and `tdN` but not `topN`.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -37,23 +37,22 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `docs/sdd-safety-gates`
-- Objective: tighten SDD safety gates and add selective Gherkin guidance for
-  behavior-oriented specifications without adding new document families.
-- Scope: update the SDD README, Codex SDD skill, branch plan guidance, and
-  feature/use-case templates for SPECS, TASKS, TRACEABILITY, implementation
-  prompts, plan validation, and behavior scenarios. Add selective Gherkin
-  scenarios to existing use cases where the behavior contract is already clear.
-- Out of scope: runtime code changes, generated artifacts, and new feature
-  directories.
-- Impact summary: SDD workflow documentation and templates only. Gherkin is
-  documentation guidance for behavior contracts, not a test-tool dependency;
-  no product behavior, VS Code compatibility, parser behavior, web extension
-  runtime, or tests are changed. Existing use-case behavior is clarified, not
-  expanded.
-- Risks and assumptions: keep the rules concise so feature docs remain useful
-  working documents rather than process logs; require `pnpm run qlty` for this
-  docs-only slice.
+- Branch: `codex/align-transfer-operation-parameters`
+- Objective: continue JP1/AJS3 version 13 parameter alignment by extracting the
+  transfer-operation `top1` to `top4` default rule into a category-specific
+  domain helper seam.
+- Scope: update the SDD plan for the transfer-operation category, preserve
+  current explicit and derived `topN` values, and add focused regression
+  evidence for source/destination-driven defaults.
+- Out of scope: parser grammar changes, byte-length validation, macro-variable
+  validation, custom PC job invalidation, QUEUE job transfer-file behavior, and
+  UI changes.
+- Impact summary: domain parameter helper ownership changes only. User-visible
+  parser, list, flow, CSV, diagnostics, hover, telemetry, desktop extension,
+  and web extension behavior should remain unchanged.
+- Risks and assumptions: treat the JP1/AJS3 v13 UNIX/PC job and UNIX/PC custom
+  job references as the normative source for `topN` defaults; keep invalid
+  value handling deferred until a diagnostics/warnings policy is chosen.
 
 ## Wrapper Semantics Matrix
 

--- a/src/domain/models/parameters/parameterHelpers.ts
+++ b/src/domain/models/parameters/parameterHelpers.ts
@@ -8,14 +8,6 @@ export type ParamLookupArg = ParamBase & {
   defaultRawValue?: string | string[];
 };
 
-type TopParameterIndex = 1 | 2 | 3 | 4;
-
-type TopParameterSource = {
-  [key in `ts${TopParameterIndex}`]?: unknown;
-} & {
-  [key in `td${TopParameterIndex}`]?: unknown;
-};
-
 type DefaultApplicationMode = "always" | "root-jobnet-only";
 type RootJobnetDefaultParameter = "rg" | "sd" | "ncl" | "ncs" | "ncex";
 type ConnectorControlDefaultParameter = "ncl" | "ncs" | "ncex";
@@ -70,37 +62,6 @@ export const resolveConnectorControlDefaultRawValue = (
     mode,
     isRootJobnet,
   );
-};
-
-export const resolveTopDefaultRawValue = (
-  unit: TopParameterSource,
-  index: TopParameterIndex,
-): string => {
-  const hasTransferSource = Boolean(unit[`ts${index}`]);
-  const hasTransferDestination = Boolean(unit[`td${index}`]);
-
-  if (hasTransferSource && hasTransferDestination) {
-    return "sav";
-  }
-  if (hasTransferSource) {
-    return "del";
-  }
-  return "";
-};
-
-export const buildTopParameter = <T>(
-  arg: Omit<ParamLookupArg, "defaultRawValue"> & {
-    unit: TopParameterSource & ParamLookupArg["unit"];
-    index: TopParameterIndex;
-  },
-  mapParam: (param: ParamInternal) => T,
-): T | undefined => {
-  const parameter = resolveParameter({
-    unit: arg.unit,
-    parameter: arg.parameter,
-    defaultRawValue: resolveTopDefaultRawValue(arg.unit, arg.index),
-  });
-  return parameter ? mapParam(parameter) : undefined;
 };
 
 export const buildOptionalParameter = <T>(

--- a/src/domain/models/parameters/transferOperationHelpers.ts
+++ b/src/domain/models/parameters/transferOperationHelpers.ts
@@ -1,0 +1,41 @@
+import { resolveParameter, type ParamLookupArg } from "./parameterHelpers";
+import type { ParamInternal } from "./parameter.types";
+
+type TopParameterIndex = 1 | 2 | 3 | 4;
+
+type TopParameterSource = {
+  [key in `ts${TopParameterIndex}`]?: unknown;
+} & {
+  [key in `td${TopParameterIndex}`]?: unknown;
+};
+
+export const resolveTopDefaultRawValue = (
+  unit: TopParameterSource,
+  index: TopParameterIndex,
+): string | undefined => {
+  const hasTransferSource = Boolean(unit[`ts${index}`]);
+  const hasTransferDestination = Boolean(unit[`td${index}`]);
+
+  if (hasTransferSource && hasTransferDestination) {
+    return "sav";
+  }
+  if (hasTransferSource) {
+    return "del";
+  }
+  return undefined;
+};
+
+export const buildTopParameter = <T>(
+  arg: Omit<ParamLookupArg, "defaultRawValue"> & {
+    unit: TopParameterSource & ParamLookupArg["unit"];
+    index: TopParameterIndex;
+  },
+  mapParam: (param: ParamInternal) => T,
+): T | undefined => {
+  const parameter = resolveParameter({
+    unit: arg.unit,
+    parameter: arg.parameter,
+    defaultRawValue: resolveTopDefaultRawValue(arg.unit, arg.index),
+  });
+  return parameter ? mapParam(parameter) : undefined;
+};

--- a/src/domain/models/parameters/transferOperationParameterBuilders.ts
+++ b/src/domain/models/parameters/transferOperationParameterBuilders.ts
@@ -1,7 +1,7 @@
 import { Top1, Top2, Top3, Top4 } from "../parameters";
 import { Cj } from "../units/Cj";
 import { J } from "../units/J";
-import { buildTopParameter } from "./parameterHelpers";
+import { buildTopParameter } from "./transferOperationHelpers";
 
 export const transferOperationParameterBuilders = {
   top1(unit: J | Cj) {

--- a/src/test/suite/parameterHelpers.test.ts
+++ b/src/test/suite/parameterHelpers.test.ts
@@ -19,14 +19,16 @@ import {
   buildSdAlignedEmptyScheduleRuleParameters,
   buildSdAlignedScheduleParameters,
   buildSortedScheduleRuleParameters,
-  buildTopParameter,
   resolveSdParameters,
   resolveConnectorControlDefaultRawValue,
   resolveParameter,
   resolveParameterArray,
   resolveRootJobnetDefaultRawValue,
-  resolveTopDefaultRawValue,
 } from "../../domain/models/parameters/parameterHelpers";
+import {
+  buildTopParameter,
+  resolveTopDefaultRawValue,
+} from "../../domain/models/parameters/transferOperationHelpers";
 
 const validDefinition = `
 unit=root,,jp1admin,;
@@ -663,7 +665,7 @@ unit=root,,jp1admin,;
     assert.strictEqual(resolveTopDefaultRawValue(job, 1), "sav");
     assert.strictEqual(resolveTopDefaultRawValue(job, 2), "del");
     assert.strictEqual(resolveTopDefaultRawValue(job, 3), "del");
-    assert.strictEqual(resolveTopDefaultRawValue(job, 4), "");
+    assert.strictEqual(resolveTopDefaultRawValue(job, 4), undefined);
 
     assert.strictEqual(job.top1?.value(), "sav");
     assert.strictEqual(job.top2?.value(), "del");


### PR DESCRIPTION
## Summary

- Document the transfer-operation parameter alignment slice for JP1/AJS3 v13.
- Move `top1` to `top4` default resolution into a dedicated transfer-operation helper seam.
- Preserve existing explicit and derived `topN` behavior with regression coverage.
- Tighten `AGENTS.md` so SDD work reads `docs/specs/README.md` and its Implementation Change Gate first.

## Validation

- `pnpm run qlty`
- `pnpm test`
- `pnpm run test:web` (passed after rerun outside the sandbox because Chromium launch hit a macOS Mach port permission error inside the sandbox)
- `pnpm run build` (passed with existing bundle size warnings)
- `pnpm run lint:md`

## Compatibility

No VS Code API, parser grammar, UI, telemetry, or web-extension runtime behavior changes are intended. The change is scoped to domain parameter helper ownership and SDD documentation.