### PR TITLE
[codex] Align job end judgment defaults and SDD approval gate

### DIFF
--- a/.codex/skills/sdd-change/SKILL.md
+++ b/.codex/skills/sdd-change/SKILL.md
@@ -9,7 +9,7 @@ Prepare or update SDD artifacts before implementing a non-trivial repository cha
 1. read `AGENTS.md`
 2. read `package.json`
 3. read the relevant files in `docs/specs/`
-4. investigate impact before implementation changes:
+4. run the investigation-only phase before implementation changes:
    - search affected functions, classes, components, and commands
    - list affected files, features, tests, docs, and breaking-change risk
    - when behavior scenarios exist, list changed, added, or removed scenarios
@@ -23,14 +23,27 @@ Prepare or update SDD artifacts before implementing a non-trivial repository cha
 6. update or create the matching use-case spec in
    `docs/requirements/use-cases/`
    when the behavior contract changes
-7. stop after the investigation and ask for explicit human approval before
+7. record `TASKS.md` human approval evidence with `Status: Pending`
+8. stop after the investigation and ask for clear human approval before
    editing runtime code, tests, generated artifacts, or configuration
-8. after approval, enumerate all affected references and task the complete fix
-9. implement in small meaningful blocks, checking compile/tests as you go
-10. run required validation before finishing
+9. after approval, record the approval text and approved scope in `TASKS.md`
+10. enumerate all affected references and task the complete fix
+11. implement in small meaningful blocks, checking compile/tests as you go
+12. stop again for additional approval if required changes exceed the approved
+    scope
+13. run required validation before finishing
 
 ## Rules
 
+- investigation-only phase permits investigation, SDD document updates, impact
+  records, alternatives, and approval requests only
+- approval-required phase must not edit runtime code, tests, generated
+  artifacts, configuration, implementation branches, implementation commits,
+  implementation refactors, or incidental fixes
+- approval definition, approval evidence, and re-approval rules are centralized
+  in `docs/specs/README.md` `Implementation Change Gate`
+- implementation phase starts only when `TASKS.md` records `Status: Approved`
+  and the approval text
 - keep `engines.vscode` unchanged unless explicitly approved
 - preserve desktop and web extension behavior
 - prefer small vertical slices over broad rewrites

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -65,9 +65,79 @@ Before editing runtime code, tests, generated artifacts, or configuration:
 
 1. perform an impact investigation
 2. record the findings in the right SDD artifacts
-3. report the planned change, affected files, affected features, affected
-   tests, breaking-change risk, and alternatives
-4. stop until a human explicitly approves implementation
+3. record the approval evidence section in the feature `TASKS.md`
+4. report the planned change, affected files, affected functions/classes or
+   components, affected features, affected tests, related docs,
+   breaking-change risk, and alternatives
+5. stop until a human gives clear approval for implementation
+
+Clear approval means the human response unambiguously permits implementation
+for the reported scope. The following are not approval:
+
+- answers to investigation questions
+- additional information
+- design discussion
+- ambiguous agreement
+- Codex's own judgment
+
+While approval is pending, Codex must not:
+
+- edit runtime code
+- edit tests
+- edit generated artifacts
+- edit configuration
+- create an implementation branch
+- create an implementation commit
+- refactor for implementation purposes
+- make incidental or "while here" fixes
+
+While approval is pending, Codex may only:
+
+- investigate
+- update SDD documents
+- record impact scope
+- organize alternatives
+- present the approval request
+
+Each feature `TASKS.md` must include the approval evidence:
+
+```md
+## Human Approval
+
+- Status: Pending | Approved
+- Approved by:
+- Approved at:
+- Approval text:
+- Approved scope:
+```
+
+Implementation may start only when `Status: Approved` and `Approval text`
+records the human approval. If implementation reveals required changes
+outside the approved scope, stop again, update the impact record, and obtain
+additional clear approval before editing those areas.
+
+Before approval, Codex must report only this implementation-gate output and
+must not claim that implementation has started or completed:
+
+```md
+## Impact Investigation Summary
+
+- Planned change:
+- Affected files:
+- Affected functions/classes/components:
+- Affected features:
+- Affected tests:
+- Related docs:
+- Breaking-change risk:
+- Alternatives:
+
+## Approval Request
+
+Please approve implementation before I edit runtime code, tests,
+generated artifacts, or configuration.
+
+Implementation will not proceed until approval is given.
+```
 
 After approval, expand the investigation into a complete reference impact
 check, list every required fix, and task the work before implementation.

--- a/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
+++ b/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
@@ -17,16 +17,24 @@ Read these documents first:
 Implementation rules:
 
 1. Start with impact investigation.
-2. Stop for explicit human approval before implementation.
-3. After approval, enumerate all affected references and track the complete fix.
-4. Follow TASKS.md in small safe steps.
-5. Do not rewrite unrelated code.
-6. Preserve existing behavior unless SPECS.md explicitly changes it.
-7. Respect DDD and Clean Architecture boundaries.
-8. Keep UI, application, domain, and infrastructure responsibilities separate.
-9. Preserve VS Code compatibility declared in `package.json`.
-10. Add or update tests for every behavior change.
-11. Update documentation if implementation decisions differ from the spec.
+2. Before approval, only investigate and update SDD documents.
+3. Before approval, do not edit runtime code, tests, generated artifacts, or
+   configuration.
+4. Before approval, do not create implementation branches, implementation
+   commits, implementation refactors, or incidental fixes.
+5. Stop for clear human approval before implementation.
+6. After approval, enumerate all affected references and track the complete fix.
+7. Follow TASKS.md in small safe steps.
+8. Do not rewrite unrelated code.
+9. Preserve existing behavior unless SPECS.md explicitly changes it.
+10. Respect DDD and Clean Architecture boundaries.
+11. Keep UI, application, domain, and infrastructure responsibilities separate.
+12. Preserve VS Code compatibility declared in `package.json`.
+13. Add or update tests for every behavior change.
+14. Update documentation if implementation decisions differ from the spec.
+
+Approval definition, approval evidence, and re-approval rules are centralized
+in `docs/specs/README.md` `Implementation Change Gate`.
 
 Before editing:
 
@@ -38,18 +46,43 @@ Before editing:
 - Record branch scope and risks in PLANS.md.
 - Record durable impact, propagation, alternatives, and boundary decisions in
   SPECS.md.
-- Record investigation, approval, implementation, test, and follow-up tasks in
-  TASKS.md.
-- Report the plan, affected files, tests, risks, and alternatives to the human
-  reviewer, then wait for approval.
+- Record investigation, implementation, test, and follow-up tasks in TASKS.md.
+- Record the TASKS.md `Human Approval` section with `Status: Pending`.
+- Report only this approval request, then wait for approval:
+
+```md
+## Impact Investigation Summary
+
+- Planned change:
+- Affected files:
+- Affected functions/classes/components:
+- Affected features:
+- Affected tests:
+- Related docs:
+- Breaking-change risk:
+- Alternatives:
+
+## Approval Request
+
+Please approve implementation before I edit runtime code, tests,
+generated artifacts, or configuration.
+
+Implementation will not proceed until approval is given.
+```
 
 After approval:
 
+- Record `Status: Approved`, the human approver, approval time, exact approval
+  text, and approved scope in TASKS.md before implementation.
+- Do not implement if TASKS.md does not contain `Status: Approved` and
+  `Approval text`.
 - Inspect existing files and naming conventions.
 - Confirm every affected reference is either fixed or explicitly left
   unchanged in SPECS.md.
 - Implement one coherent block at a time.
 - Compile or run the closest fast check after meaningful changes.
+- If required changes exceed the approved scope, stop, update the impact
+  record, and request additional clear approval before editing those areas.
 
 After editing:
 

--- a/docs/specs/features/_templates/PLANS.template.md
+++ b/docs/specs/features/_templates/PLANS.template.md
@@ -20,6 +20,13 @@
 - Related docs: {{docs or "none"}}
 - Breaking-change risk: {{none/low/medium/high and reason}}
 
+## Approval Scope Summary
+
+- Approval status: see TASKS.md `Human Approval`
+- Approved scope: {{implementation scope once approved}}
+- Scope guard: stop and request additional approval before changing anything
+  outside the approved scope
+
 ## Milestones
 
 1. {{milestone}}

--- a/docs/specs/features/_templates/SPECS.template.md
+++ b/docs/specs/features/_templates/SPECS.template.md
@@ -57,6 +57,12 @@ Scenario: {{one observable behavior}}
 
 - {{alternative}}: {{reason accepted or rejected}}
 
+### Approval Impact Decisions
+
+- Approval evidence owner: TASKS.md `Human Approval`
+- Scope changes requiring re-approval: {{changes that exceed the approved
+  scope}}
+
 ## Compatibility
 
 - VS Code compatibility follows `package.json` `engines.vscode`.

--- a/docs/specs/features/_templates/TASKS.template.md
+++ b/docs/specs/features/_templates/TASKS.template.md
@@ -7,11 +7,23 @@
 - Update `docs/specs/plans.md` or `docs/specs/roadmap.md` in the same commit
   when branch priorities or repository sequencing change.
 
+## Human Approval
+
+- Status: Pending
+- Approved by:
+- Approved at:
+- Approval text:
+- Approved scope:
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
+
 ## Tasks
 
 - [ ] Impact investigation completed and recorded in PLANS/SPECS/TASKS by
       responsibility
-- [ ] Human approval gate passed before implementation
+- [ ] Human approval recorded
+- [ ] Implementation scope matches approved scope
 - [ ] Fix targets tracked to completion
 - [ ] {{implementation task}}
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
@@ -1,0 +1,57 @@
+# Job End Judgment Parameter Alignment
+
+## Purpose
+
+Record the JP1/AJS3 version 13 alignment slice for job end-judgment
+parameters used by UNIX/PC jobs and UNIX/PC custom jobs. This is the next
+non-schedule parameter-family slice after the transfer-operation helper
+boundary.
+
+This document covers the currently modeled end-judgment defaults for `jd`,
+`wth`, `tho`, `jdf`, and `abr`.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual sections:
+  - Command Reference, `5.2.6 UNIX/PC job definition`
+  - Command Reference, `5.2.24 UNIX/PC custom job definition`
+  - Command Reference, `ajsprint`, default values table
+- Source URLs:
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0221.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0239.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0121.HTM>
+
+## Slice Boundary
+
+- Domain seams:
+  `src/domain/models/parameters/jobEndJudgmentHelpers.ts`,
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`, and
+  `src/domain/models/parameters/Defaults.ts`
+- Existing consumers:
+  `src/domain/models/units/J.ts`, `src/domain/models/units/Cj.ts`, and
+  `ParamFactory.jd`
+- Regression evidence:
+  `src/test/suite/parameterFactory.test.ts` and
+  `src/test/suite/jobEndJudgmentHelpers.test.ts`
+- Out of scope:
+  parser grammar changes, byte-length validation, numeric range validation,
+  invalid `jd` / `abr` pairing diagnostics, retry range diagnostics, and
+  command-generation changes
+
+## Shared Expectations
+
+- Explicit `jd` values are preserved.
+- Omitted `jd` resolves to `cod` for UNIX/PC jobs and UNIX/PC custom jobs.
+- Omitted `tho` remains `0`.
+- Omitted `abr` remains `n`.
+- `wth` and `jdf` are not synthesized when omitted.
+- Invalid combinations, such as `jd` values other than `cod` with `abr=y`,
+  remain preserved raw values until the diagnostics policy is explicit.
+
+## Follow-up
+
+- Add range validation only after deciding whether invalid JP1/AJS parameter
+  values should become diagnostics, warnings, or preserved raw values.
+- Model `jd` / `abr` invalid combinations once the behavior contract is
+  explicit enough to test across domain and editor-feedback paths.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -31,24 +31,35 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   operation parameters in `TRANSFER_OPERATION_ALIGNMENT.md`.
 - Extracted `top1` to `top4` default resolution into
   `transferOperationHelpers.ts` while preserving explicit and derived values.
+- Prepared the next non-schedule category slice for job end-judgment
+  parameters in `JOB_END_JUDGMENT_ALIGNMENT.md`.
+- Aligned omitted UNIX/PC job and UNIX/PC custom job `jd` values to the
+  JP1/AJS3 v13 default `cod` behind `jobEndJudgmentHelpers.ts`.
 
 ## Impact Investigation
 
-- Planned change: move `top1` to `top4` default resolution out of the generic
-  `parameterHelpers.ts` module and into a transfer-operation helper seam.
+- Planned change: align the omitted `jd` default for UNIX/PC jobs and
+  UNIX/PC custom jobs with JP1/AJS3 version 13 by changing the default from
+  `cond` to `cod` and moving the category-specific default into a
+  job-end-judgment helper seam.
 - Affected files:
-  `src/domain/models/parameters/parameterHelpers.ts`,
-  `src/domain/models/parameters/transferOperationHelpers.ts`,
-  `src/domain/models/parameters/transferOperationParameterBuilders.ts`,
-  `src/test/suite/parameterHelpers.test.ts`, and this feature's SDD docs.
+  `src/domain/models/parameters/Defaults.ts`,
+  `src/domain/models/parameters/jobEndJudgmentHelpers.ts`,
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`,
+  `src/test/suite/jobEndJudgmentHelpers.test.ts`,
+  `src/test/suite/parameterFactory.test.ts`, and this feature's SDD docs.
 - Affected features: JP1/AJS parameter interpretation for UNIX/PC job and
-  UNIX/PC custom job transfer operation defaults.
+  UNIX/PC custom job end-judgment defaults.
 - Tests affected: parameter helper and parameter factory regression tests.
-- Breaking-change risk: low. The intended behavior preserves current explicit
-  and derived `topN` values while narrowing the owning helper boundary.
-- Alternatives considered: leave `topN` logic in `parameterHelpers.ts`; this
-  was rejected because the schedule-rule slice established category-specific
-  helper seams and `topN` has transfer-specific paired-parameter semantics.
+- Breaking-change risk: medium. Omitted `jd` values will now surface as
+  `cod`, matching the v13 manual and `ajsprint -a` default table, but any
+  existing consumer that expected the previous `cond` fallback will observe a
+  changed default value.
+- Alternatives considered: leave `DEFAULTS.Jd` as-is and document the mismatch;
+  this was rejected because the roadmap prioritizes manual-backed parameter
+  alignment and the affected behavior has a focused regression boundary.
+- Approval: human approval to proceed was given on 2026-04-27 after branch
+  creation for `codex/align-job-end-judgment-parameters`.
 
 ## Follow-up
 
@@ -58,9 +69,18 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   beyond the current audit summary.
 - Revisit QUEUE job transfer-file coverage separately because the manual
   defines `tsN` and `tdN` but not `topN`.
+- Revisit invalid `jd` / `abr` combinations when diagnostics behavior is
+  explicit.
 
 ## Validation
 
 - code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
   `pnpm run build`
 - docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful
+
+Current branch validation:
+
+- 2026-04-27: `npm test`
+- 2026-04-27: `npm run qlty`
+- 2026-04-27: `npm run test:web`
+- 2026-04-27: `npm run build`

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -48,11 +48,15 @@
 - [x] Record transfer-operation alignment scope, manual references, affected
       seams, and expected `top1` to `top4` default behavior before completing
       the helper-boundary extraction
+- [x] Record job end-judgment alignment scope, manual references, affected
+      seams, and expected `jd` default behavior before implementation
 
 ## Follow-up
 
 - [x] Extract `top1` to `top4` default resolution into a transfer-operation
       helper seam while preserving explicit and derived values
+- [x] Align omitted UNIX/PC job and UNIX/PC custom job `jd` values to the
+      JP1/AJS3 v13 default `cod`
 - [ ] Apply the same category-level value parsing audit/refactor workflow to
       another non-schedule parameter family before marking those categories
       aligned
@@ -109,3 +113,9 @@
 - 2026-04-27: `topN` default resolution now lives in
   `transferOperationHelpers.ts`; regression evidence covers explicit `topN`,
   derived `sav`, derived `del`, and the no-default case.
+- 2026-04-27: job end-judgment alignment is the next non-schedule parameter
+  family. The manual-backed behavior change is limited to omitted `jd`
+  resolving to `cod`; invalid pairing diagnostics remain deferred.
+- 2026-04-27: omitted UNIX/PC job and UNIX/PC custom job `jd` values now
+  resolve to `cod` through `jobEndJudgmentHelpers.ts`; explicit `jd` values
+  remain preserved.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -37,22 +37,23 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/align-transfer-operation-parameters`
-- Objective: continue JP1/AJS3 version 13 parameter alignment by extracting the
-  transfer-operation `top1` to `top4` default rule into a category-specific
-  domain helper seam.
-- Scope: update the SDD plan for the transfer-operation category, preserve
-  current explicit and derived `topN` values, and add focused regression
-  evidence for source/destination-driven defaults.
-- Out of scope: parser grammar changes, byte-length validation, macro-variable
-  validation, custom PC job invalidation, QUEUE job transfer-file behavior, and
-  UI changes.
-- Impact summary: domain parameter helper ownership changes only. User-visible
-  parser, list, flow, CSV, diagnostics, hover, telemetry, desktop extension,
-  and web extension behavior should remain unchanged.
-- Risks and assumptions: treat the JP1/AJS3 v13 UNIX/PC job and UNIX/PC custom
-  job references as the normative source for `topN` defaults; keep invalid
-  value handling deferred until a diagnostics/warnings policy is chosen.
+- Branch: `codex/align-job-end-judgment-parameters`
+- Objective: continue JP1/AJS3 version 13 parameter alignment by aligning the
+  job end-judgment `jd` default for UNIX/PC jobs and UNIX/PC custom jobs.
+- Status: implemented locally; validation completed on 2026-04-27.
+- Scope: record the SDD plan for the end-judgment category, preserve explicit
+  `jd` values, change omitted `jd` from the legacy `cond` fallback to the
+  manual-backed `cod` default, and add focused regression evidence.
+- Out of scope: parser grammar changes, byte-length validation, numeric range
+  validation, invalid `jd` / `abr` diagnostics, retry range diagnostics, and UI
+  changes.
+- Impact summary: domain parameter default behavior changes for omitted `jd`.
+  Parser, list, flow, CSV, diagnostics, hover, telemetry, desktop extension,
+  and web extension code paths should remain structurally unchanged.
+- Risks and assumptions: treat the JP1/AJS3 v13 UNIX/PC job, UNIX/PC custom
+  job, and `ajsprint -a` default table references as the normative source for
+  `jd=cod`; keep invalid value handling deferred until a diagnostics/warnings
+  policy is chosen.
 
 ## Wrapper Semantics Matrix
 
@@ -76,3 +77,10 @@ rules in `docs/specs/README.md`, not in this file.
 - docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when markdown
   structure or links need focused validation
 - code changes: follow `docs/specs/README.md`
+
+Current branch checks:
+
+- 2026-04-27: `npm run qlty`
+- 2026-04-27: `npm test`
+- 2026-04-27: `npm run test:web`
+- 2026-04-27: `npm run build`

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -21,10 +21,15 @@
    - Parameter value parsing must be verified by category against the official
      format before a category is marked aligned; avoid one-key-at-a-time slices
      when a shared helper boundary can cover the category.
-   - The active focused slice is the schedule-rule parameter family: `sd`,
-     `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`; use it
-     as the first category-level parser alignment pattern before applying the
-     same workflow to other parameter families.
+   - The first category-level parser alignment pattern has been applied to the
+     schedule-rule parameter family: `sd`, `ln`, `st`, `cy`, `sh`, `shd`,
+     `cftd`, `sy`, `ey`, `wc`, and `wt`.
+   - The next completed focused slices extracted transfer-operation `top1` to
+     `top4` defaults and aligned the job end-judgment `jd` default for
+     UNIX/PC jobs and UNIX/PC custom jobs.
+   - Continue applying the same audit, helper-boundary, and regression-test
+     workflow to other parameter families instead of checking isolated keys one
+     by one.
    - Keep behavior-preserving slices separate from behavior-changing manual
      alignment slices.
 

--- a/src/domain/models/parameters/Defaults.ts
+++ b/src/domain/models/parameters/Defaults.ts
@@ -1,7 +1,7 @@
 const parameterDefaults = {
   Ab: "exec",
   Pr: "1",
-  Jd: "cond",
+  Jd: "cod",
   Tho: "0",
   Abr: "n",
   Rec: "1",

--- a/src/domain/models/parameters/jobEndJudgmentHelpers.ts
+++ b/src/domain/models/parameters/jobEndJudgmentHelpers.ts
@@ -1,0 +1,3 @@
+import { DEFAULTS } from "./Defaults";
+
+export const resolveJobEndJudgmentDefaultRawValue = (): string => DEFAULTS.Jd;

--- a/src/domain/models/parameters/optionalScalarParameterBuilders.ts
+++ b/src/domain/models/parameters/optionalScalarParameterBuilders.ts
@@ -197,6 +197,7 @@ import {
 import { N } from "../units/N";
 import { UnitEntity } from "../units/UnitEntity";
 import { DEFAULTS } from "./Defaults";
+import { resolveJobEndJudgmentDefaultRawValue } from "./jobEndJudgmentHelpers";
 import {
   buildInheritedParameter,
   buildOptionalParameter,
@@ -426,7 +427,9 @@ export const optionalScalarParameterBuilders = {
   ),
   htstf: createOptionalScalarBuilder("htstf", (param) => new Htstf(param)),
   jc: createOptionalScalarBuilder("jc", (param) => new Jc(param)),
-  jd: createOptionalScalarBuilder("jd", (param) => new Jd(param), DEFAULTS.Jd),
+  jd: createOptionalScalarBuilder("jd", (param) => new Jd(param), {
+    resolveDefaultRawValue: resolveJobEndJudgmentDefaultRawValue,
+  }),
   jdf: createOptionalScalarBuilder("jdf", (param) => new Jdf(param)),
   jty: createOptionalScalarBuilder(
     "jty",

--- a/src/test/suite/jobEndJudgmentHelpers.test.ts
+++ b/src/test/suite/jobEndJudgmentHelpers.test.ts
@@ -1,0 +1,10 @@
+import * as assert from "assert";
+import { DEFAULTS } from "../../domain/models/parameters/Defaults";
+import { resolveJobEndJudgmentDefaultRawValue } from "../../domain/models/parameters/jobEndJudgmentHelpers";
+
+suite("Job end judgment helpers", () => {
+  test("resolves the JP1/AJS3 v13 default end judgment mode", () => {
+    assert.strictEqual(resolveJobEndJudgmentDefaultRawValue(), DEFAULTS.Jd);
+    assert.strictEqual(resolveJobEndJudgmentDefaultRawValue(), "cod");
+  });
+});

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import { ParamFactory } from "../../domain/models/parameters/ParameterFactory";
 import { DEFAULTS } from "../../domain/models/parameters/Defaults";
 import { J } from "../../domain/models/units/J";
+import { Cj } from "../../domain/models/units/Cj";
 import { N } from "../../domain/models/units/N";
 import { parseAjs } from "../../domain/services/parser/AjsParser";
 import { tyFactory } from "../../domain/utils/TyUtils";
@@ -206,6 +207,36 @@ unit=root,,jp1admin,;
 }
 `;
 
+const jobEndJudgmentDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=job1,j,+0+0;
+  el=custom,cj,+160+0;
+  unit=job1,,jp1admin,;
+  {
+    ty=j;
+  }
+  unit=custom,,jp1admin,;
+  {
+    ty=cj;
+  }
+}
+`;
+
+const explicitJobEndJudgmentDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=job1,j,+0+0;
+  unit=job1,,jp1admin,;
+  {
+    ty=j;
+    jd=ab;
+  }
+}
+`;
+
 const parseJob = (): J => {
   const result = parseAjs(definition);
   assert.deepStrictEqual(result.errors, []);
@@ -287,6 +318,23 @@ const parseRootGroup = () => {
 
 const parseTransferJob = (): J => {
   const result = parseAjs(transferDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as J;
+};
+
+const parseJobEndJudgmentUnits = (): { job: J; customJob: Cj } => {
+  const result = parseAjs(jobEndJudgmentDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return {
+    job: root.children[0] as J,
+    customJob: root.children[1] as Cj,
+  };
+};
+
+const parseExplicitJobEndJudgmentJob = (): J => {
+  const result = parseAjs(explicitJobEndJudgmentDefinition);
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as J;
@@ -606,5 +654,22 @@ suite("ParameterFactory", () => {
     assert.strictEqual(ParamFactory.top2(job)?.value(), "del");
     assert.strictEqual(ParamFactory.top3(job)?.value(), "del");
     assert.strictEqual(ParamFactory.top4(job)?.value(), "keep");
+  });
+
+  test("returns JP1/AJS3 v13 end-judgment defaults through the facade", () => {
+    const { job, customJob } = parseJobEndJudgmentUnits();
+
+    assert.strictEqual(ParamFactory.jd(job)?.value(), "cod");
+    assert.strictEqual(ParamFactory.jd(customJob)?.value(), "cod");
+    assert.strictEqual(ParamFactory.tho(job)?.value(), DEFAULTS.Tho);
+    assert.strictEqual(ParamFactory.abr(job)?.value(), DEFAULTS.Abr);
+    assert.strictEqual(ParamFactory.wth(job), undefined);
+    assert.strictEqual(ParamFactory.jdf(job), undefined);
+  });
+
+  test("preserves explicit end-judgment values through the facade", () => {
+    const job = parseExplicitJobEndJudgmentJob();
+
+    assert.strictEqual(ParamFactory.jd(job)?.value(), "ab");
   });
 });


### PR DESCRIPTION
## Summary

- Align omitted UNIX/PC job and UNIX/PC custom job `jd` defaults with JP1/AJS3 v13 by resolving them to `cod` while preserving explicit values.
- Add a small job end-judgment helper seam and focused regression coverage.
- Strengthen the SDD implementation approval gate, centralizing approval rules in `docs/specs/README.md` and updating Codex/task templates to reference the gate.

## Validation

- `npm test`
- `npm run qlty`
- `npm run test:web`
- `npm run build`
- `pnpm run qlty`
- `pnpm run lint:md`

Note: `pnpm run qlty` initially hit the local qlty log-file permission issue under sandboxing, then passed when rerun with elevated permissions. `npm run build` completed with existing webpack bundle-size warnings.