### PR TITLE
[codex] Align HTTP connection eu default

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -105,16 +105,14 @@ Each feature `TASKS.md` must include the approval evidence:
 ## Human Approval
 
 - Status: Pending | Approved
-- Approved by:
 - Approved at:
-- Approval text:
 - Approved scope:
 ```
 
-Implementation may start only when `Status: Approved` and `Approval text`
-records the human approval. If implementation reveals required changes
-outside the approved scope, stop again, update the impact record, and obtain
-additional clear approval before editing those areas.
+Implementation may start only when `Status: Approved` and `Approved scope`
+records the human-approved implementation boundary. If implementation reveals
+required changes outside the approved scope, stop again, update the impact
+record, and obtain additional clear approval before editing those areas.
 
 Before approval, Codex must report only this implementation-gate output and
 must not claim that implementation has started or completed:

--- a/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
+++ b/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
@@ -72,10 +72,10 @@ Implementation will not proceed until approval is given.
 
 After approval:
 
-- Record `Status: Approved`, the human approver, approval time, exact approval
-  text, and approved scope in TASKS.md before implementation.
+- Record `Status: Approved`, approval time, and approved scope in TASKS.md
+  before implementation.
 - Do not implement if TASKS.md does not contain `Status: Approved` and
-  `Approval text`.
+  `Approved scope`.
 - Inspect existing files and naming conventions.
 - Confirm every affected reference is either fixed or explicitly left
   unchanged in SPECS.md.

--- a/docs/specs/features/_templates/TASKS.template.md
+++ b/docs/specs/features/_templates/TASKS.template.md
@@ -10,9 +10,7 @@
 ## Human Approval
 
 - Status: Pending
-- Approved by:
 - Approved at:
-- Approval text:
 - Approved scope:
 
 Implementation must not start while Status is Pending.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/HTTP_CONNECTION_JOB_DEFAULT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/HTTP_CONNECTION_JOB_DEFAULT_ALIGNMENT.md
@@ -1,0 +1,79 @@
+# HTTP Connection Job Default Alignment
+
+## Purpose
+
+Record the JP1/AJS3 version 13 alignment slice for HTTP Connection job
+defaults. This is the next small non-schedule parameter-default candidate after
+job end-judgment alignment.
+
+This document focuses on the currently modeled HTTP Connection job defaults
+for `htknd`, `htexm`, `htspt`, `jd`, `abr`, `ha`, `eu`, `mm`, `nmg`, `ega`,
+and `uem`.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual sections:
+  - Command Reference, `5.2.27 HTTP Connection job definition`
+  - Command Reference, `ajsprint`, default values table
+- Source URLs:
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0242.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0121.HTM>
+
+## Slice Boundary
+
+- Domain seams:
+  `src/domain/models/units/Htpj.ts`,
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`, and
+  `src/domain/models/parameters/Defaults.ts`
+- Existing consumers:
+  `src/domain/models/units/Htpj.ts`, `src/domain/models/units/Rhtpj.ts`, and
+  `ParamFactory.eu`
+- Regression evidence:
+  `src/test/suite/parameterFactory.test.ts`; add focused helper/facade
+  evidence if a dedicated HTTP Connection job default seam is introduced
+- Out of scope:
+  parser grammar changes, command generation, byte-length validation, numeric
+  range validation, HTTP return-code mapping validation, and broader event/wait
+  default refactors
+
+## Investigation Notes
+
+- The existing generic `eu` builder applies `DEFAULTS.Eu`, currently `ent`, to
+  all unit wrappers that call `ParamFactory.eu`.
+- `Htpj.eu` currently calls `ParamFactory.eu(this)`, so omitted HTTP
+  Connection job `eu` values resolve through the same generic `ent` default as
+  other job families.
+- The `ajsprint -a` default values table lists HTTP Connection job `Eu` as
+  `def`, while most other modeled job families list `Eu` as `ent`.
+- The HTTP Connection job definition section also describes `eu={ent|def};`;
+  keep this slice explicit about which reference statement drives the behavior
+  change before implementation.
+
+## Expected Behavior If Approved
+
+- Explicit HTTP Connection job `eu` values are preserved.
+- Omitted HTTP Connection job `eu` resolves to `def` through a small
+  HTTP-connection-job-specific default seam.
+- Other unit families that already use the generic `eu` default continue to
+  resolve omitted `eu` as `ent`.
+- Existing HTTP Connection job defaults for `htknd`, `htexm`, `htspt`, `jd`,
+  `abr`, `ha`, `mm`, `nmg`, `ega`, and `uem` remain unchanged unless further
+  manual investigation proves a focused mismatch.
+
+## Alternatives
+
+- Leave `DEFAULTS.Eu` as the only `eu` default and document HTTP Connection
+  job `Eu` as unresolved because the definition section and `ajsprint -a`
+  default table need reconciliation.
+- Change `DEFAULTS.Eu` globally to `def`; rejected because many non-HTTP job
+  families are documented as `ent` and currently share this generic default.
+- Add a broad parameter coverage matrix before this behavior change; deferred
+  because the current workflow favors small category-level slices.
+
+## Follow-up
+
+- Reconcile the HTTP Connection job definition text and the `ajsprint -a`
+  default table if future evidence suggests this should remain `ent`.
+- Consider extracting a small execution-user default helper if additional
+  unit-type-specific `eu` defaults appear.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -35,31 +35,42 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   parameters in `JOB_END_JUDGMENT_ALIGNMENT.md`.
 - Aligned omitted UNIX/PC job and UNIX/PC custom job `jd` values to the
   JP1/AJS3 v13 default `cod` behind `jobEndJudgmentHelpers.ts`.
+- Investigated HTTP Connection job defaults in
+  `HTTP_CONNECTION_JOB_DEFAULT_ALIGNMENT.md` as the next small
+  parameter-default candidate.
+- Aligned omitted HTTP Connection job `eu` values to `def` through
+  `httpConnectionJobDefaultHelpers.ts` while preserving explicit values and
+  generic non-HTTP `eu=ent` behavior.
 
 ## Impact Investigation
 
-- Planned change: align the omitted `jd` default for UNIX/PC jobs and
-  UNIX/PC custom jobs with JP1/AJS3 version 13 by changing the default from
-  `cond` to `cod` and moving the category-specific default into a
-  job-end-judgment helper seam.
+- Planned change: align the omitted HTTP Connection job `eu` default with the
+  JP1/AJS3 version 13 `ajsprint -a` default values table by resolving `Htpj`
+  and `Rhtpj` omitted `eu` values to `def` while preserving the generic `eu`
+  default of `ent` for other job families.
 - Affected files:
+  `src/domain/models/units/Htpj.ts`,
   `src/domain/models/parameters/Defaults.ts`,
-  `src/domain/models/parameters/jobEndJudgmentHelpers.ts`,
   `src/domain/models/parameters/optionalScalarParameterBuilders.ts`,
-  `src/test/suite/jobEndJudgmentHelpers.test.ts`,
-  `src/test/suite/parameterFactory.test.ts`, and this feature's SDD docs.
-- Affected features: JP1/AJS parameter interpretation for UNIX/PC job and
-  UNIX/PC custom job end-judgment defaults.
-- Tests affected: parameter helper and parameter factory regression tests.
-- Breaking-change risk: medium. Omitted `jd` values will now surface as
-  `cod`, matching the v13 manual and `ajsprint -a` default table, but any
-  existing consumer that expected the previous `cond` fallback will observe a
-  changed default value.
-- Alternatives considered: leave `DEFAULTS.Jd` as-is and document the mismatch;
-  this was rejected because the roadmap prioritizes manual-backed parameter
-  alignment and the affected behavior has a focused regression boundary.
-- Approval: human approval to proceed was given on 2026-04-27 after branch
-  creation for `codex/align-job-end-judgment-parameters`.
+  a possible new HTTP Connection job default helper, focused parameter factory
+  tests, and this feature's SDD docs.
+- Affected features: JP1/AJS parameter interpretation for HTTP Connection job
+  execution-user defaults.
+- Tests affected: parameter factory regression tests; helper tests if a helper
+  seam is introduced.
+- Breaking-change risk: medium. Omitted HTTP Connection job `eu` values would
+  surface as `def`, matching the `ajsprint -a` default values table, but any
+  existing consumer that expected the generic `ent` fallback for HTTP
+  Connection jobs will observe a changed default value. The definition section
+  and `ajsprint -a` default table must remain explicitly cited because they are
+  the approval-sensitive reference boundary for this slice.
+- Alternatives considered: leave generic `DEFAULTS.Eu` behavior unchanged and
+  record the HTTP Connection job default as unresolved; change `DEFAULTS.Eu`
+  globally to `def`; or build a full parameter matrix before implementation.
+  The proposed small helper seam is preferred because it limits the behavior
+  change to `Htpj` and `Rhtpj`.
+- Approval: human approval to proceed was given on 2026-04-28 after the
+  investigation summary for HTTP Connection job `eu` default alignment.
 
 ## Follow-up
 
@@ -71,6 +82,9 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   defines `tsN` and `tdN` but not `topN`.
 - Revisit invalid `jd` / `abr` combinations when diagnostics behavior is
   explicit.
+- Reconcile HTTP Connection job `eu` wording across the definition section and
+  `ajsprint -a` default table if future evidence conflicts with the approved
+  behavior.
 
 ## Validation
 
@@ -84,3 +98,7 @@ Current branch validation:
 - 2026-04-27: `npm run qlty`
 - 2026-04-27: `npm run test:web`
 - 2026-04-27: `npm run build`
+- 2026-04-28: `npm test`
+- 2026-04-28: `npm run qlty`
+- 2026-04-28: `npm run test:web`
+- 2026-04-28: `npm run build`

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -32,6 +32,17 @@ JP1/AJS3 version 13 reference documents.
 - avoid bundling these reference-alignment slices with unrelated flow-graph or
   package-manager work
 
+## Durable Impact Analysis
+
+- Unit-type-specific defaults must not be collapsed into a single global
+  default when the JP1/AJS3 version 13 `ajsprint -a` default values table
+  distinguishes a unit family.
+- HTTP Connection job `eu` is approval-sensitive because the generic
+  `DEFAULTS.Eu` value is shared by many job families, while the `ajsprint -a`
+  default values table lists HTTP Connection job `Eu` separately as `def`.
+- A focused helper seam is preferred over changing `DEFAULTS.Eu` globally so
+  non-HTTP job families continue to preserve their existing `ent` default.
+
 ## Reference Documents
 
 - Definition File Reference:

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -50,6 +50,9 @@
       the helper-boundary extraction
 - [x] Record job end-judgment alignment scope, manual references, affected
       seams, and expected `jd` default behavior before implementation
+- [x] Record HTTP Connection job default alignment scope, manual references,
+      affected seams, alternatives, and expected omitted `eu` behavior before
+      implementation
 
 ## Follow-up
 
@@ -57,6 +60,8 @@
       helper seam while preserving explicit and derived values
 - [x] Align omitted UNIX/PC job and UNIX/PC custom job `jd` values to the
       JP1/AJS3 v13 default `cod`
+- [x] Align omitted HTTP Connection job `eu` values to the JP1/AJS3 v13
+      `ajsprint -a` default values table value `def`
 - [ ] Apply the same category-level value parsing audit/refactor workflow to
       another non-schedule parameter family before marking those categories
       aligned
@@ -119,3 +124,19 @@
 - 2026-04-27: omitted UNIX/PC job and UNIX/PC custom job `jd` values now
   resolve to `cod` through `jobEndJudgmentHelpers.ts`; explicit `jd` values
   remain preserved.
+- 2026-04-28: HTTP Connection job default alignment is the next small
+  parameter-default candidate. The proposed behavior change is limited to
+  omitted `eu` resolving to `def` for `Htpj` / `Rhtpj`, while other job
+  families continue to use generic `eu=ent`.
+- 2026-04-28: omitted HTTP Connection job `eu` values now resolve to `def`
+  through `httpConnectionJobDefaultHelpers.ts`; explicit HTTP Connection job
+  `eu` values and non-HTTP generic `eu=ent` behavior remain preserved.
+
+## Human Approval
+
+- Status: Approved
+- Approved at: 2026-04-28
+- Approved scope: Implement the recorded HTTP Connection job default alignment
+  slice by resolving omitted `eu` values to `def` for `Htpj` / `Rhtpj`, keeping
+  explicit `eu` values and non-HTTP job-family `eu` defaults unchanged, and
+  adding focused regression evidence.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -37,23 +37,24 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/align-job-end-judgment-parameters`
-- Objective: continue JP1/AJS3 version 13 parameter alignment by aligning the
-  job end-judgment `jd` default for UNIX/PC jobs and UNIX/PC custom jobs.
-- Status: implemented locally; validation completed on 2026-04-27.
-- Scope: record the SDD plan for the end-judgment category, preserve explicit
-  `jd` values, change omitted `jd` from the legacy `cond` fallback to the
-  manual-backed `cod` default, and add focused regression evidence.
-- Out of scope: parser grammar changes, byte-length validation, numeric range
-  validation, invalid `jd` / `abr` diagnostics, retry range diagnostics, and UI
-  changes.
-- Impact summary: domain parameter default behavior changes for omitted `jd`.
-  Parser, list, flow, CSV, diagnostics, hover, telemetry, desktop extension,
-  and web extension code paths should remain structurally unchanged.
-- Risks and assumptions: treat the JP1/AJS3 v13 UNIX/PC job, UNIX/PC custom
-  job, and `ajsprint -a` default table references as the normative source for
-  `jd=cod`; keep invalid value handling deferred until a diagnostics/warnings
-  policy is chosen.
+- Branch: `codex/align-http-connection-eu-default`
+- Objective: continue JP1/AJS3 version 13 parameter alignment with the next
+  small parameter-default slice for HTTP Connection job `eu`.
+- Status: implemented locally; validation completed on 2026-04-28.
+- Scope: preserve explicit HTTP Connection job `eu` values, change omitted
+  `eu` from the generic `ent` fallback to the `ajsprint -a` default table value
+  `def`, and keep other job families on the existing generic `eu=ent` default.
+- Out of scope: parser grammar changes, command generation, byte-length
+  validation, numeric range validation, HTTP return-code mapping validation,
+  broader event/wait default refactors, and global `DEFAULTS.Eu` changes.
+- Impact summary: domain parameter default behavior would change only for
+  omitted `eu` on `Htpj` / `Rhtpj`. Parser, list, flow, CSV, diagnostics,
+  hover, telemetry, desktop extension, and web extension code paths should
+  remain structurally unchanged.
+- Risks and assumptions: the approval-sensitive reference boundary is the
+  JP1/AJS3 v13 `ajsprint -a` default values table listing HTTP Connection job
+  `Eu=def`; the HTTP Connection job definition section should remain cited
+  because it also describes `eu={ent|def};`.
 
 ## Wrapper Semantics Matrix
 
@@ -84,3 +85,7 @@ Current branch checks:
 - 2026-04-27: `npm test`
 - 2026-04-27: `npm run test:web`
 - 2026-04-27: `npm run build`
+- 2026-04-28: `npm test`
+- 2026-04-28: `npm run qlty`
+- 2026-04-28: `npm run test:web`
+- 2026-04-28: `npm run build`

--- a/src/domain/models/parameters/Defaults.ts
+++ b/src/domain/models/parameters/Defaults.ts
@@ -8,6 +8,7 @@ const parameterDefaults = {
   Rei: "1",
   Ha: "n",
   Eu: "ent",
+  HttpConnectionJobEu: "def",
   Soa: "new",
   Sea: "new",
   Mm: "and",

--- a/src/domain/models/parameters/ParameterFactory.ts
+++ b/src/domain/models/parameters/ParameterFactory.ts
@@ -41,6 +41,8 @@ export class ParamFactory {
   static etn = optionalScalarParameterBuilders.etn;
   static ets = optionalScalarParameterBuilders.ets;
   static eu = optionalScalarParameterBuilders.eu;
+  static httpConnectionJobEu =
+    optionalScalarParameterBuilders.httpConnectionJobEu;
   static eun = optionalArrayParameterBuilders.eun;
   static ev = optionalScalarParameterBuilders.ev;
   static evdet = optionalScalarParameterBuilders.evdet;

--- a/src/domain/models/parameters/httpConnectionJobDefaultHelpers.ts
+++ b/src/domain/models/parameters/httpConnectionJobDefaultHelpers.ts
@@ -1,0 +1,4 @@
+import { DEFAULTS } from "./Defaults";
+
+export const resolveHttpConnectionJobEuDefaultRawValue = (): string =>
+  DEFAULTS.HttpConnectionJobEu;

--- a/src/domain/models/parameters/optionalScalarParameterBuilders.ts
+++ b/src/domain/models/parameters/optionalScalarParameterBuilders.ts
@@ -197,6 +197,7 @@ import {
 import { N } from "../units/N";
 import { UnitEntity } from "../units/UnitEntity";
 import { DEFAULTS } from "./Defaults";
+import { resolveHttpConnectionJobEuDefaultRawValue } from "./httpConnectionJobDefaultHelpers";
 import { resolveJobEndJudgmentDefaultRawValue } from "./jobEndJudgmentHelpers";
 import {
   buildInheritedParameter,
@@ -327,6 +328,11 @@ export const optionalScalarParameterBuilders = {
     DEFAULTS.Ets,
   ),
   eu: createOptionalScalarBuilder("eu", (param) => new Eu(param), DEFAULTS.Eu),
+  httpConnectionJobEu: createOptionalScalarBuilder(
+    "eu",
+    (param) => new Eu(param),
+    { resolveDefaultRawValue: resolveHttpConnectionJobEuDefaultRawValue },
+  ),
   ev: createOptionalScalarBuilder("ev", (param) => new Ev(param)),
   evdet: createOptionalScalarBuilder("evdet", (param) => new Evdet(param)),
   evesc: createOptionalScalarBuilder(

--- a/src/domain/models/units/Htpj.ts
+++ b/src/domain/models/units/Htpj.ts
@@ -116,7 +116,7 @@ export class Htpj extends WaitableUnitEntity {
   }
   // [eu={ent|def};]
   get eu() {
-    return ParamFactory.eu(this);
+    return ParamFactory.httpConnectionJobEu(this);
   }
 }
 export class Rhtpj extends Htpj {}

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -3,6 +3,7 @@ import { ParamFactory } from "../../domain/models/parameters/ParameterFactory";
 import { DEFAULTS } from "../../domain/models/parameters/Defaults";
 import { J } from "../../domain/models/units/J";
 import { Cj } from "../../domain/models/units/Cj";
+import { Htpj } from "../../domain/models/units/Htpj";
 import { N } from "../../domain/models/units/N";
 import { parseAjs } from "../../domain/services/parser/AjsParser";
 import { tyFactory } from "../../domain/utils/TyUtils";
@@ -237,6 +238,30 @@ unit=root,,jp1admin,;
 }
 `;
 
+const httpConnectionJobDefaultDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=http,htpj,+0+0;
+  el=explicit,rhtpj,+160+0;
+  unit=http,,jp1admin,;
+  {
+    ty=htpj;
+    htcfl="conn.conf";
+    htstf="status.log";
+    htrhf="header.log";
+  }
+  unit=explicit,,jp1admin,;
+  {
+    ty=rhtpj;
+    htcfl="conn.conf";
+    htstf="status.log";
+    htrhf="header.log";
+    eu=ent;
+  }
+}
+`;
+
 const parseJob = (): J => {
   const result = parseAjs(definition);
   assert.deepStrictEqual(result.errors, []);
@@ -338,6 +363,19 @@ const parseExplicitJobEndJudgmentJob = (): J => {
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as J;
+};
+
+const parseHttpConnectionJobs = (): {
+  httpJob: Htpj;
+  explicitHttpJob: Htpj;
+} => {
+  const result = parseAjs(httpConnectionJobDefaultDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return {
+    httpJob: root.children[0] as Htpj,
+    explicitHttpJob: root.children[1] as Htpj,
+  };
 };
 
 suite("ParameterFactory", () => {
@@ -671,5 +709,14 @@ suite("ParameterFactory", () => {
     const job = parseExplicitJobEndJudgmentJob();
 
     assert.strictEqual(ParamFactory.jd(job)?.value(), "ab");
+  });
+
+  test("returns HTTP Connection job execution-user defaults through the facade", () => {
+    const { httpJob, explicitHttpJob } = parseHttpConnectionJobs();
+    const genericJob = parseJob();
+
+    assert.strictEqual(httpJob.eu?.value(), DEFAULTS.HttpConnectionJobEu);
+    assert.strictEqual(explicitHttpJob.eu?.value(), "ent");
+    assert.strictEqual(ParamFactory.eu(genericJob)?.value(), DEFAULTS.Eu);
   });
 });


### PR DESCRIPTION
## Summary

- Align omitted HTTP Connection job `eu` values with the JP1/AJS3 v13 `ajsprint -a` default table by resolving `Htpj` / `Rhtpj` omissions to `def`.
- Preserve explicit HTTP Connection job `eu` values and keep the generic non-HTTP `eu=ent` behavior unchanged.
- Update SDD investigation, approval gate/template fields, and regression coverage for the new default seam.

## Validation

- `npm test`
- `npm run qlty`
- `npm run test:web`
- `npm run build`
- `npm run lint:md`

## Notes

- `npm run build` succeeds with existing webpack bundle-size warnings.
- The SDD approval evidence now avoids storing approver identity or raw approval text; it keeps `Status`, `Approved at`, and `Approved scope`.