### PR TITLE
[codex] Add Serena SDD guidance

### DIFF
--- a/.codex/skills/sdd-change/SKILL.md
+++ b/.codex/skills/sdd-change/SKILL.md
@@ -19,6 +19,8 @@ SDD investigation, approval, evidence, implementation, and validation flow.
 3. read the relevant files in `docs/specs/`
 4. run the investigation-only phase before implementation changes:
    - search affected functions, classes, components, and commands
+   - follow `docs/specs/README.md` semantic code navigation guidance when
+     Serena or an equivalent tool is available
    - list affected files, features, tests, docs, and breaking-change risk
    - when behavior scenarios exist, list changed, added, or removed scenarios
      and affected tests
@@ -53,6 +55,8 @@ Keep the notes short and focused on impact, decisions, and validation.
 - identify desktop and web entry points affected by the change
 - identify parser-related modules and generated grammar boundaries
 - identify direct VS Code API boundaries and adapter locations
+- apply semantic code navigation checks from `docs/specs/README.md` when
+  available
 - summarize architectural risks, test impact, and compatibility impact
 
 ### Planning

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,13 +67,15 @@ For non-trivial changes, follow this order:
 1. Read `docs/specs/README.md` first, especially the
    Implementation Change Gate.
 2. Read relevant feature and roadmap docs in `docs/specs/`.
-3. Update or create the relevant use-case spec.
-4. Write or update a short implementation plan in `PLANS.md`.
-5. Confirm acceptance criteria and required approval gates before editing
+3. Follow the semantic code navigation guidance in `docs/specs/README.md`
+   when Serena or an equivalent tool is available.
+4. Update or create the relevant use-case spec.
+5. Write or update a short implementation plan in `PLANS.md`.
+6. Confirm acceptance criteria and required approval gates before editing
    runtime code, tests, generated artifacts, or configuration.
-6. Implement.
-7. Run quality checks.
-8. Summarize impact and remaining risks.
+7. Implement.
+8. Run quality checks.
+9. Summarize impact and remaining risks.
 
 If the requested change is ambiguous, prefer documenting assumptions explicitly in `PLANS.md` instead of making hidden assumptions.
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -59,6 +59,40 @@ For docs-only changes:
   markdown-specific validation
 - repository `Verify` workflow should not be relied on as a required gate
 
+## Semantic Code Navigation
+
+When Serena or another semantic code navigation tool is available, use it
+during impact investigation and reference impact verification to identify
+affected symbols, references, call sites, and dependency impact.
+
+Use semantic analysis to reduce reference omissions, including transitive
+reference and dependency impact, in:
+
+- Phase 1 impact investigation before requesting approval
+- Phase 3 reference impact verification after approval
+
+Serena is supplemental tooling. It does not replace:
+
+- SDD artifacts
+- human approval
+- approval evidence
+- tests
+- validation
+
+Manual impact analysis remains required. Do not treat Serena-only results as
+proof that a change is safe.
+
+Minimal local setup:
+
+```bash
+uv tool install -p 3.13 serena-agent@latest --prerelease=allow
+serena init
+serena setup codex
+```
+
+If the MCP client cannot find `serena` on `PATH`, configure the Codex MCP
+server command with the absolute path to the installed `serena` executable.
+
 ## Implementation Change Gate
 
 Before editing runtime code, tests, generated artifacts, or configuration:
@@ -139,6 +173,8 @@ Implementation will not proceed until approval is given.
 
 After approval, expand the investigation into a complete reference impact
 check, list every required fix, and task the work before implementation.
+Use Serena or another semantic code navigation tool when available to verify
+affected references, call sites, transitive references, and dependency impact.
 Do not finish with only a subset of affected references updated.
 
 Implementation should then proceed in small meaningful blocks:

--- a/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
+++ b/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
@@ -39,6 +39,8 @@ in `docs/specs/README.md` `Implementation Change Gate`.
 Before editing:
 
 - Search affected functions, classes, components, commands, and DTOs.
+- Follow `docs/specs/README.md` semantic code navigation guidance when Serena
+  or an equivalent tool is available.
 - List changed areas, affected features, affected tests, related docs, and
   breaking-change risk.
 - When behavior scenarios exist, list changed, added, or removed scenarios and


### PR DESCRIPTION
## Summary

- Add Serena / semantic code navigation guidance to the SDD overview as the source of truth.
- Reference that guidance from AGENTS.md, the sdd-change Codex skill, and the implementation prompt template without duplicating the full policy.
- Document minimal Serena setup and clarify that semantic tooling supplements, but does not replace, SDD artifacts, approval evidence, tests, or validation.

## Validation

- pnpm run qlty
- git diff --check