### PR TITLE
[codex] Align QUEUE transfer file parameters

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -47,6 +47,10 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 - Aligned omitted JP1 event sending job `evsrc` values to `10` through
   `DEFAULTS.Evsrc`, while preserving explicit values and leaving normalized
   unit-list projection raw.
+- Investigated QUEUE job transfer-file alignment as the next non-schedule
+  parameter family. The candidate is behavior-preserving regression evidence
+  that `Qj` / `Rq` expose `ts1` to `ts4` and `td1` to `td4` without exposing or
+  deriving `top1` to `top4`.
 
 ## Impact Investigation
 
@@ -83,6 +87,38 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 - Approval: human approval to proceed was given on 2026-04-28 after the
   investigation summary for JP1 event sending job `evsrc` default alignment.
   The approved scope keeps unit-list normalized projection raw.
+
+### QUEUE Job Transfer-File Candidate
+
+- Planned change: add focused regression evidence for QUEUE job transfer-file
+  parameters, preserving explicit `ts1` to `ts4` and `td1` to `td4` values and
+  confirming `top1` to `top4` are not exposed or derived for `Qj` / `Rq`.
+- Affected files:
+  `src/domain/models/units/Qj.ts`,
+  `src/domain/models/parameters/ParameterFactory.ts`,
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`,
+  `src/domain/models/parameters/transferOperationHelpers.ts`,
+  `src/domain/models/parameters/transferOperationParameterBuilders.ts`,
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`,
+  focused parameter factory or helper tests,
+  focused unit-list tests if raw projection evidence is added, and this
+  feature's SDD docs.
+- Affected features: JP1/AJS parameter interpretation for QUEUE job
+  transfer-file parameters; unit-list group 15 transfer columns remain raw
+  normalized projection.
+- Tests affected: focused parameter factory tests for `Qj` / `Rq`; existing
+  transfer-operation helper tests for UNIX/PC job behavior must continue to
+  pass; unit-list tests only if the approved scope includes explicit raw
+  projection evidence.
+- Breaking-change risk: low if limited to regression evidence. Risk becomes
+  medium if implementation attempts to add `topN` to QUEUE jobs or changes
+  group 15 projection semantics.
+- Alternatives considered: add `topN` getters to QUEUE wrappers, rejected
+  because the JP1/AJS3 version 13 QUEUE job definition does not define `topN`;
+  make group 15 unit-type-aware, deferred as a separate unit-list behavior
+  slice; defer to a full parameter matrix, not preferred because the current
+  follow-up is already narrow and testable.
+- Approval: pending.
 
 ## Follow-up
 
@@ -122,3 +158,9 @@ Current branch validation:
 - 2026-04-28: `npm run build` completed with existing webpack asset-size
   warnings
 - 2026-04-28: `pnpm run qlty` passed after excluding `.serena/` from Qlty
+- 2026-04-29: `npm test`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-04-29: `pnpm run qlty`
+- 2026-04-29: `pnpm run lint:md`

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/QUEUE_TRANSFER_FILE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/QUEUE_TRANSFER_FILE_ALIGNMENT.md
@@ -1,0 +1,75 @@
+# QUEUE Transfer File Alignment
+
+## Purpose
+
+Record the JP1/AJS3 version 13 investigation for QUEUE job transfer-file
+parameters as the next non-schedule parameter family after the schedule-rule,
+transfer-operation, job end-judgment, HTTP Connection job, and JP1 event
+sending job slices.
+
+This slice covers only the QUEUE job `ts1` to `ts4` and `td1` to `td4`
+parameters.
+
+## Manual References
+
+- JP1/Automatic Job Management System 3 version 13 Command Reference,
+  5.2.7 QUEUE job definition:
+  <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0222.HTM>
+- Related non-QUEUE comparison: 5.2.6 UNIX/PC job definition and 5.2.24
+  UNIX/PC custom job definition define `top1` to `top4` in addition to
+  `ts1` to `ts4` and `td1` to `td4`.
+
+## Current Code Seams
+
+- `src/domain/models/units/Qj.ts` exposes `ts1` to `ts4` and `td1` to `td4`
+  through `ParamFactory`, but it does not expose `top1` to `top4`.
+- `src/domain/models/parameters/ParameterFactory.ts` routes `tsN` and `tdN`
+  through optional scalar builders for all wrappers that expose those keys.
+- `src/domain/models/parameters/transferOperationHelpers.ts` owns `topN`
+  default resolution, but that helper is intentionally limited to wrappers
+  whose definitions include `topN`.
+- `src/application/unit-list/buildUnitListRemainingGroups.ts` projects group
+  15 transfer columns from normalized raw parameters, including `ts1`, `td1`,
+  and `top1`.
+
+## Impact Investigation
+
+- QUEUE job definitions include `ts1` to `ts4` and `td1` to `td4`, but not
+  `top1` to `top4`.
+- Existing `Qj` / `Rq` wrappers already preserve this boundary by exposing
+  transfer source and destination parameters without transfer operation
+  getters.
+- Existing `buildTopParameter` behavior must not be broadened to QUEUE jobs
+  because doing so would synthesize `topN` behavior that the QUEUE job
+  definition does not define.
+- Group 15 projection remains raw normalized data. Explicit `tsN` and `tdN`
+  values can appear for QUEUE jobs, while `topN` remains absent unless the raw
+  definition contains it.
+
+## Planned Alignment
+
+- Add focused regression evidence that `Qj` / `Rq` expose explicit `tsN` and
+  `tdN` values while not exposing or deriving `topN`.
+- Keep `topN` default derivation limited to UNIX/PC job and UNIX/PC custom job
+  wrappers.
+- Do not add QUEUE-specific diagnostics, byte-length validation, macro
+  validation, or parser grammar changes in this slice.
+- Do not change normalized unit-list projection to synthesize transfer
+  operation defaults.
+
+## Alternatives
+
+- Add `topN` getters to `Qj` / `Rq`: rejected because the QUEUE job definition
+  does not define `top1` to `top4`.
+- Change group 15 projection to hide `tsN` / `tdN` for QUEUE jobs: rejected for
+  this slice because current projection is raw and behavior-preserving.
+- Defer QUEUE transfer-file coverage until a repository-wide parameter matrix:
+  possible, but less useful than adding focused regression evidence for a
+  documented follow-up boundary.
+
+## Follow-up
+
+- Add value and byte-length validation only after invalid JP1/AJS parameter
+  behavior is specified as diagnostics, warnings, or raw preservation.
+- Revisit whether group 15 should become unit-type-aware only as a separate
+  unit-list behavior slice.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -49,6 +49,11 @@ JP1/AJS3 version 13 reference documents.
   from normalized raw key/value data, so default-aware wrapper changes do not
   automatically change list projection unless that boundary is explicitly in
   scope.
+- QUEUE job transfer-file alignment is approval-sensitive because `Qj` / `Rq`
+  expose `ts1` to `ts4` and `td1` to `td4`, while the related UNIX/PC job and
+  UNIX/PC custom job definitions also define `top1` to `top4`. The QUEUE job
+  slice must preserve that distinction and must not broaden `topN` default
+  derivation to wrappers whose manual section does not define `topN`.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -56,6 +56,9 @@
 - [x] Record JP1 event sending job alignment scope, manual references,
       affected seams, alternatives, and expected omitted `evsrc` behavior
       before implementation
+- [x] Record QUEUE job transfer-file alignment scope, manual references,
+      affected seams, alternatives, and expected no-`topN` behavior before
+      implementation
 
 ## Follow-up
 
@@ -68,6 +71,9 @@
 - [x] Align omitted JP1 event sending job `evsrc` values to the JP1/AJS3 v13
       default `10`, preserving explicit values and deciding whether normalized
       unit-list projection should remain raw or become default-aware
+- [x] Add focused regression evidence that QUEUE job `ts1` to `ts4` and `td1`
+      to `td4` values are preserved while `top1` to `top4` are not exposed or
+      derived for `Qj` / `Rq`
 - [ ] Apply the same category-level value parsing audit/refactor workflow to
       another non-schedule parameter family before marking those categories
       aligned
@@ -145,19 +151,34 @@
 - 2026-04-28: omitted JP1 event sending job `evsrc` now resolves to `10`
   through `DEFAULTS.Evsrc`; explicit event sending job values remain preserved.
   Unit-list projection remains raw normalized key/value projection.
+- 2026-04-29: QUEUE job transfer-file alignment is the next non-schedule
+  parameter family. The proposed behavior-preserving change is limited to
+  focused regression evidence that `Qj` / `Rq` preserve explicit `ts1` to
+  `ts4` and `td1` to `td4` values without exposing or deriving `top1` to
+  `top4`, because JP1/AJS3 version 13 QUEUE job definitions do not define
+  `topN`.
+- 2026-04-29: QUEUE job transfer-file regression evidence now verifies `Qj`
+  and `Rq` preserve explicit transfer source/destination values and do not
+  expose transfer operation getters. Parser grammar, command generation,
+  validation behavior, and unit-list group 15 raw projection remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
-- Approved at: 2026-04-28
-- Approved scope: Implement the recorded JP1 event sending job arrival-check
-  default alignment by resolving omitted `evsrc` values to `10` for `Evsj` /
-  `Revsj`, preserving explicit `evsrc`, `evssv`, `evsrt`, and `evspl` values,
-  keeping normalized unit-list projection raw and unchanged, and adding focused
-  regression evidence.
+- Approved at: 2026-04-29
+- Approved scope: Implement the recorded QUEUE job transfer-file alignment by
+  adding focused regression evidence that `Qj` / `Rq` preserve explicit `ts1`
+  to `ts4` and `td1` to `td4` values without exposing or deriving `top1` to
+  `top4`; keep parser grammar, command generation, validation behavior, and
+  unit-list group 15 projection unchanged.
 
 ## Prior Approval Evidence
 
+- 2026-04-28: Approved JP1 event sending job arrival-check default alignment
+  by resolving omitted `evsrc` values to `10` for `Evsj` / `Revsj`, preserving
+  explicit `evsrc`, `evssv`, `evsrt`, and `evspl` values, keeping normalized
+  unit-list projection raw and unchanged, and adding focused regression
+  evidence.
 - 2026-04-28: Approved HTTP Connection job default alignment by resolving
   omitted `eu` values to `def` for `Htpj` / `Rhtpj`, keeping explicit `eu`
   values and non-HTTP job-family `eu` defaults unchanged, and adding focused

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -16,8 +16,8 @@ rules in `docs/specs/README.md`, not in this file.
 - Parameter-reference alignment should proceed in small JP1/AJS v13 slices
   with explicit manual coverage. For each parameter category, verify value
   parsing against the official format before claiming the category aligned.
-  The next active candidate is the JP1 event sending job arrival-check family:
-  `evssv`, `evsrt`, `evspl`, and `evsrc`.
+  The next active candidate is the QUEUE job transfer-file family: `ts1` to
+  `ts4` and `td1` to `td4`, with explicit no-`topN` behavior for `Qj` / `Rq`.
 - Read-only JP1/AJS WebAPI import stays beta until real JP1/AJS3 environment
   smoke verification and enough user feedback are recorded. Beta exit is
   feedback-gated and is not the next active implementation priority.
@@ -37,24 +37,23 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/align-event-send-job-evsrc-default`
+- Branch: `codex/align-queue-transfer-files`
 - Objective: continue JP1/AJS3 version 13 parameter alignment with the next
-  category-level candidate for JP1 event sending job arrival-check defaults.
+  non-schedule family: QUEUE job transfer-file parameters.
 - Status: implemented locally; validation completed.
-- Scope: preserve explicit JP1 event sending job `evssv`, `evsrt`, `evspl`,
-  and `evsrc` values; keep existing `evssv=no`, `evsrt=n`, and `evspl=10`
-  defaults; change omitted `evsrc` for `Evsj` / `Revsj` from the previous
-  generic `0` fallback to the manual default `10`.
+- Scope: preserve explicit QUEUE job `ts1` to `ts4` and `td1` to `td4` values
+  for `Qj` / `Rq`; add focused regression evidence that `top1` to `top4` are
+  not exposed or derived for QUEUE jobs.
 - Out of scope: parser grammar changes, command generation, byte-length
-  validation, numeric range validation, event arrival runtime behavior,
-  `evhst` requiredness diagnostics, and broader event receiving job semantics.
-- Impact summary: domain parameter default behavior changes only for omitted
-  `evsrc` on `Evsj` / `Revsj`. Unit-list projection remains raw normalized
-  key/value projection and does not synthesize omitted defaults.
-- Risks and assumptions: the approval-sensitive reference boundary is the
-  JP1/AJS3 v13 JP1 event sending job definition stating omitted `evsrc` is
-  assumed as `10`. A focused helper seam is preferred unless the complete
-  reference impact check proves a global `DEFAULTS.Evsrc` change is safe.
+  validation, macro-variable validation, transfer-file runtime behavior,
+  adding `topN` getters to `Qj` / `Rq`, and changing unit-list group 15 raw
+  projection semantics.
+- Impact summary: behavior should remain unchanged if implemented as focused
+  regression evidence. The key boundary is preventing the existing UNIX/PC
+  `topN` default helper from being broadened to QUEUE jobs.
+- Risks and assumptions: JP1/AJS3 version 13 QUEUE job definition lists `tsN`
+  and `tdN` but not `topN`; related UNIX/PC job definitions list all three.
+  Treating QUEUE as no-`topN` is the approval-sensitive distinction.
 
 ## Wrapper Semantics Matrix
 
@@ -95,3 +94,9 @@ Current branch checks:
 - 2026-04-28: `npm run build` completed with existing webpack asset-size
   warnings
 - 2026-04-28: `pnpm run qlty` passed after excluding `.serena/` from Qlty
+- 2026-04-29: `npm test`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-04-29: `pnpm run qlty`
+- 2026-04-29: `pnpm run lint:md`

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -6,6 +6,7 @@ import { Cj } from "../../domain/models/units/Cj";
 import { Evsj } from "../../domain/models/units/Evsj";
 import { Htpj } from "../../domain/models/units/Htpj";
 import { N } from "../../domain/models/units/N";
+import { Qj, Rq } from "../../domain/models/units/Qj";
 import { parseAjs } from "../../domain/services/parser/AjsParser";
 import { tyFactory } from "../../domain/utils/TyUtils";
 
@@ -209,6 +210,33 @@ unit=root,,jp1admin,;
 }
 `;
 
+const queueTransferDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=queue,qj,+0+0;
+  el=recovery,rq,+160+0;
+  unit=queue,,jp1admin,;
+  {
+    ty=qj;
+    ts1=queue-src-1;
+    td1=queue-dst-1;
+    ts2=queue-src-2;
+    td2=queue-dst-2;
+    ts3=queue-src-3;
+    td3=queue-dst-3;
+    ts4=queue-src-4;
+    td4=queue-dst-4;
+  }
+  unit=recovery,,jp1admin,;
+  {
+    ty=rq;
+    ts1=recovery-src-1;
+    td1=recovery-dst-1;
+  }
+}
+`;
+
 const jobEndJudgmentDefinition = `
 unit=root,,jp1admin,;
 {
@@ -368,6 +396,16 @@ const parseTransferJob = (): J => {
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as J;
+};
+
+const parseQueueTransferJobs = (): { queueJob: Qj; recoveryQueueJob: Rq } => {
+  const result = parseAjs(queueTransferDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return {
+    queueJob: root.children[0] as Qj,
+    recoveryQueueJob: root.children[1] as Rq,
+  };
 };
 
 const parseJobEndJudgmentUnits = (): { job: J; customJob: Cj } => {
@@ -727,6 +765,26 @@ suite("ParameterFactory", () => {
     assert.strictEqual(ParamFactory.top2(job)?.value(), "del");
     assert.strictEqual(ParamFactory.top3(job)?.value(), "del");
     assert.strictEqual(ParamFactory.top4(job)?.value(), "keep");
+  });
+
+  test("preserves QUEUE transfer files without deriving transfer operations", () => {
+    const { queueJob, recoveryQueueJob } = parseQueueTransferJobs();
+
+    assert.strictEqual(queueJob.ts1?.value(), "queue-src-1");
+    assert.strictEqual(queueJob.td1?.value(), "queue-dst-1");
+    assert.strictEqual(queueJob.ts2?.value(), "queue-src-2");
+    assert.strictEqual(queueJob.td2?.value(), "queue-dst-2");
+    assert.strictEqual(queueJob.ts3?.value(), "queue-src-3");
+    assert.strictEqual(queueJob.td3?.value(), "queue-dst-3");
+    assert.strictEqual(queueJob.ts4?.value(), "queue-src-4");
+    assert.strictEqual(queueJob.td4?.value(), "queue-dst-4");
+    assert.strictEqual(recoveryQueueJob.ts1?.value(), "recovery-src-1");
+    assert.strictEqual(recoveryQueueJob.td1?.value(), "recovery-dst-1");
+    assert.strictEqual("top1" in queueJob, false);
+    assert.strictEqual("top2" in queueJob, false);
+    assert.strictEqual("top3" in queueJob, false);
+    assert.strictEqual("top4" in queueJob, false);
+    assert.strictEqual("top1" in recoveryQueueJob, false);
   });
 
   test("returns JP1/AJS3 v13 end-judgment defaults through the facade", () => {


### PR DESCRIPTION
## Summary

- Document the JP1/AJS3 v13 QUEUE job transfer-file alignment scope and approval evidence.
- Add regression coverage that `Qj` / `Rq` preserve explicit `ts1` to `ts4` and `td1` to `td4` values.
- Verify QUEUE jobs do not expose or derive `top1` to `top4`, keeping the existing UNIX/PC transfer-operation boundary intact.

## Validation

- `npm test`
- `npm run test:web`
- `npm run build` (passed with existing webpack asset-size warnings)
- `pnpm run qlty`
- `pnpm run lint:md`

## Compatibility

No parser grammar, command generation, validation behavior, or unit-list group 15 raw projection changes are included.