### PR TITLE
[codex] Align wth end-judgment parameter

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
@@ -45,9 +45,33 @@ This document covers the currently modeled end-judgment defaults for `jd`,
 - Omitted `jd` resolves to `cod` for UNIX/PC jobs and UNIX/PC custom jobs.
 - Omitted `tho` remains `0`.
 - Omitted `abr` remains `n`.
+- Explicit `wth` values are read from the `wth` parameter, not from the
+  schedule-rule `wt` parameter.
 - `wth` and `jdf` are not synthesized when omitted.
 - Invalid combinations, such as `jd` values other than `cod` with `abr=y`,
   remain preserved raw values until the diagnostics policy is explicit.
+
+## WTH Key Mapping Follow-up
+
+- Current behavior:
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts` maps
+  `ParamFactory.wth` through `createOptionalScalarBuilder("wt", ...)`.
+- Current regression evidence:
+  `src/test/suite/parameterFactory.test.ts` explicitly preserves the legacy
+  `wth` to `wt` mapping.
+- Planned behavior if approved:
+  `ParamFactory.wth` reads `wth`, explicit `wth` values are preserved, omitted
+  `wth` remains undefined, and schedule-rule `wt` continues to be handled only
+  by the schedule-rule helper path.
+- Affected wrappers:
+  `J`, `Cj`, `Cpj`, `Fxj`, `Htpj`, `Qj`, and their recovery variants.
+- Affected tests:
+  replace the legacy mapping test with explicit `wth` preservation and
+  `wt`/`wth` non-confusion evidence; keep the existing omitted `wth` default
+  assertion.
+- Out of scope:
+  parser grammar changes, command generation, validation diagnostics, and
+  unit-list normalized raw projection changes.
 
 ## Follow-up
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -51,6 +51,10 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   parameter family. The candidate is behavior-preserving regression evidence
   that `Qj` / `Rq` expose `ts1` to `ts4` and `td1` to `td4` without exposing or
   deriving `top1` to `top4`.
+- Investigated job end-judgment `wth` key mapping as the next focused
+  non-schedule parameter correction.
+- Aligned `ParamFactory.wth` to read raw `wth`, replacing the legacy
+  `wth` to `wt` lookup while preserving schedule-rule `wt` behavior.
 
 ## Impact Investigation
 
@@ -118,7 +122,42 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   make group 15 unit-type-aware, deferred as a separate unit-list behavior
   slice; defer to a full parameter matrix, not preferred because the current
   follow-up is already narrow and testable.
-- Approval: pending.
+- Approval: completed in the prior QUEUE transfer-file slice; see
+  `TASKS.md` prior approval evidence.
+
+### WTH End-Judgment Key Mapping Candidate
+
+- Planned change: align `ParamFactory.wth` with the JP1/AJS3 v13
+  end-judgment parameter by reading raw `wth` instead of the schedule-rule
+  `wt` parameter.
+- Affected files:
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`,
+  `src/domain/models/parameters/ParameterFactory.ts`,
+  `src/domain/models/parameters/index.ts`,
+  `src/domain/models/units/J.ts`,
+  `src/domain/models/units/Cj.ts`,
+  `src/domain/models/units/Cpj.ts`,
+  `src/domain/models/units/Fxj.ts`,
+  `src/domain/models/units/Htpj.ts`,
+  `src/domain/models/units/Qj.ts`,
+  `src/test/suite/parameterFactory.test.ts`,
+  `src/test/suite/buildUnitListView.test.ts` if raw projection evidence needs
+  adjustment, and this feature's SDD docs.
+- Affected features: JP1/AJS parameter interpretation for job end-judgment
+  thresholds; unit-list group 11 raw threshold projection should remain
+  unchanged unless implementation reveals test gaps.
+- Tests affected: replace the legacy `wth` to `wt` regression with evidence
+  that explicit `wth` is preserved and schedule-rule `wt` does not satisfy
+  `ParamFactory.wth`; keep omitted `wth` undefined evidence.
+- Breaking-change risk: low-to-medium. The planned behavior matches the
+  parameter name used by wrappers and JP1/AJS3 v13 docs, but it intentionally
+  removes a documented legacy compatibility quirk.
+- Alternatives considered: leave the legacy `wth` to `wt` mapping and record it
+  as a known mismatch; support both `wth` and `wt` fallback, rejected because it
+  would continue mixing schedule-rule and end-judgment semantics; defer to a
+  full parameter matrix, rejected because this is a small, isolated correction.
+- Approval: human approval to proceed was given on 2026-04-29 after the
+  investigation summary for `wth` key mapping alignment.
 
 ## Follow-up
 
@@ -164,3 +203,8 @@ Current branch validation:
   warnings
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `pnpm run lint:md`
+- 2026-04-29: `npm test`
+- 2026-04-29: `pnpm run qlty`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -54,6 +54,11 @@ JP1/AJS3 version 13 reference documents.
   UNIX/PC custom job definitions also define `top1` to `top4`. The QUEUE job
   slice must preserve that distinction and must not broaden `topN` default
   derivation to wrappers whose manual section does not define `topN`.
+- Job end-judgment `wth` alignment is approval-sensitive because the current
+  factory preserves a legacy lookup from `wth` to the schedule-rule `wt`
+  parameter. Correct alignment should read explicit `wth` values without
+  synthesizing omitted values and without changing schedule-rule `wt`
+  projection.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -74,9 +74,8 @@
 - [x] Add focused regression evidence that QUEUE job `ts1` to `ts4` and `td1`
       to `td4` values are preserved while `top1` to `top4` are not exposed or
       derived for `Qj` / `Rq`
-- [ ] Apply the same category-level value parsing audit/refactor workflow to
-      another non-schedule parameter family before marking those categories
-      aligned
+- [x] Align `wth` key mapping so job end-judgment threshold parsing reads
+      `wth` rather than the schedule-rule `wt` parameter
 - [ ] Turn the audit notes into an explicit parameter-coverage matrix when
       category-level status needs tracking beyond the current audit summary
 - [ ] Continue schedule-rule helper-boundary alignment with the remaining
@@ -161,19 +160,35 @@
   and `Rq` preserve explicit transfer source/destination values and do not
   expose transfer operation getters. Parser grammar, command generation,
   validation behavior, and unit-list group 15 raw projection remain unchanged.
+- 2026-04-29: job end-judgment `wth` key mapping is the next focused
+  non-schedule parameter correction. Current code maps `ParamFactory.wth` to
+  raw `wt`, and current regression evidence preserves that legacy behavior.
+  The proposed implementation changes only the builder/test seam so explicit
+  `wth` is preserved and schedule-rule `wt` no longer satisfies
+  end-judgment threshold lookup.
+- 2026-04-29: `ParamFactory.wth` now reads raw `wth`; focused regression
+  evidence verifies explicit `wth` preservation and confirms raw `wt` no
+  longer satisfies end-judgment threshold lookup. Parser grammar, command
+  generation, validation behavior, schedule-rule `wt`, and unit-list
+  normalized raw projection remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-04-29
-- Approved scope: Implement the recorded QUEUE job transfer-file alignment by
-  adding focused regression evidence that `Qj` / `Rq` preserve explicit `ts1`
-  to `ts4` and `td1` to `td4` values without exposing or deriving `top1` to
-  `top4`; keep parser grammar, command generation, validation behavior, and
-  unit-list group 15 projection unchanged.
+- Approved scope: Align `wth` key mapping so job end-judgment threshold
+  parsing reads raw `wth` rather than the schedule-rule `wt` parameter; update
+  focused regression evidence; keep parser grammar, command generation,
+  validation behavior, schedule-rule `wt`, and unit-list normalized raw
+  projection unchanged.
 
 ## Prior Approval Evidence
 
+- 2026-04-29: Approved QUEUE job transfer-file alignment by adding focused
+  regression evidence that `Qj` / `Rq` preserve explicit `ts1` to `ts4` and
+  `td1` to `td4` values without exposing or deriving `top1` to `top4`, while
+  keeping parser grammar, command generation, validation behavior, and
+  unit-list group 15 projection unchanged.
 - 2026-04-28: Approved JP1 event sending job arrival-check default alignment
   by resolving omitted `evsrc` values to `10` for `Evsj` / `Revsj`, preserving
   explicit `evsrc`, `evssv`, `evsrt`, and `evspl` values, keeping normalized

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -16,8 +16,9 @@ rules in `docs/specs/README.md`, not in this file.
 - Parameter-reference alignment should proceed in small JP1/AJS v13 slices
   with explicit manual coverage. For each parameter category, verify value
   parsing against the official format before claiming the category aligned.
-  The next active candidate is the QUEUE job transfer-file family: `ts1` to
-  `ts4` and `td1` to `td4`, with explicit no-`topN` behavior for `Qj` / `Rq`.
+  The next active candidate is the job end-judgment `wth` key mapping, because
+  the current factory intentionally preserves a legacy `wth` to `wt` lookup
+  that conflicts with the JP1/AJS3 v13 end-judgment parameter name.
 - Read-only JP1/AJS WebAPI import stays beta until real JP1/AJS3 environment
   smoke verification and enough user feedback are recorded. Beta exit is
   feedback-gated and is not the next active implementation priority.
@@ -26,10 +27,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Continue category-level parameter parsing alignment. Use the schedule-rule
-   helper boundary as the first pattern, then apply the same audit/refactor
-   workflow to other parameter categories instead of checking isolated keys one
-   by one.
+1. Continue category-level parameter parsing alignment by correcting the
+   end-judgment `wth` lookup to read the `wth` parameter instead of the
+   schedule-rule `wt` parameter, after approval.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime
@@ -37,23 +37,24 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/align-queue-transfer-files`
-- Objective: continue JP1/AJS3 version 13 parameter alignment with the next
-  non-schedule family: QUEUE job transfer-file parameters.
+- Branch: `codex/align-wth-end-judgment`
+- Objective: continue JP1/AJS3 version 13 parameter alignment with a focused
+  job end-judgment correction for `wth`.
 - Status: implemented locally; validation completed.
-- Scope: preserve explicit QUEUE job `ts1` to `ts4` and `td1` to `td4` values
-  for `Qj` / `Rq`; add focused regression evidence that `top1` to `top4` are
-  not exposed or derived for QUEUE jobs.
-- Out of scope: parser grammar changes, command generation, byte-length
-  validation, macro-variable validation, transfer-file runtime behavior,
-  adding `topN` getters to `Qj` / `Rq`, and changing unit-list group 15 raw
-  projection semantics.
-- Impact summary: behavior should remain unchanged if implemented as focused
-  regression evidence. The key boundary is preventing the existing UNIX/PC
-  `topN` default helper from being broadened to QUEUE jobs.
-- Risks and assumptions: JP1/AJS3 version 13 QUEUE job definition lists `tsN`
-  and `tdN` but not `topN`; related UNIX/PC job definitions list all three.
-  Treating QUEUE as no-`topN` is the approval-sensitive distinction.
+- Scope: update the `ParamFactory.wth` builder to read the raw `wth`
+  parameter; preserve omitted `wth` as undefined; preserve schedule-rule `wt`
+  behavior through `ruleParameterBuilders.wt`; update focused regression
+  evidence.
+- Out of scope: parser grammar changes, command generation, byte-length or
+  numeric range validation, invalid `jd` / `abr` pairing diagnostics, retry
+  range diagnostics, and changing unit-list normalized raw projection.
+- Impact summary: behavior changes only for wrappers that expose `wth`
+  (`J`, `Cj`, `Cpj`, `Fxj`, `Htpj`, `Qj`, and recovery variants). Existing
+  callers should stop seeing schedule-rule `wt` as an end-judgment threshold.
+- Risks and assumptions: this intentionally breaks the legacy `wth` to `wt`
+  mapping test. The risk is low-to-medium because the current mapping is
+  documented as legacy behavior, but any downstream consumer depending on that
+  compatibility quirk will observe a changed value.
 
 ## Wrapper Semantics Matrix
 
@@ -100,3 +101,8 @@ Current branch checks:
   warnings
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `pnpm run lint:md`
+- 2026-04-29: `npm test`
+- 2026-04-29: `pnpm run qlty`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings

--- a/src/domain/models/parameters/optionalScalarParameterBuilders.ts
+++ b/src/domain/models/parameters/optionalScalarParameterBuilders.ts
@@ -626,5 +626,5 @@ export const optionalScalarParameterBuilders = {
   un: createOptionalScalarBuilder("un", (param) => new Un(param)),
   unit: createOptionalScalarBuilder("unit", (param) => new Unit(param)),
   wkp: createOptionalScalarBuilder("wkp", (param) => new Wkp(param)),
-  wth: createOptionalScalarBuilder("wt", (param) => new Wth(param)),
+  wth: createOptionalScalarBuilder("wth", (param) => new Wth(param)),
 } as const;

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -267,6 +267,25 @@ unit=root,,jp1admin,;
 }
 `;
 
+const wthKeyMappingDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=job1,j,+0+0;
+  el=job2,j,+160+0;
+  unit=job1,,jp1admin,;
+  {
+    ty=j;
+    wth=20;
+  }
+  unit=job2,,jp1admin,;
+  {
+    ty=j;
+    wt=00:30;
+  }
+}
+`;
+
 const httpConnectionJobDefaultDefinition = `
 unit=root,,jp1admin,;
 {
@@ -425,6 +444,19 @@ const parseExplicitJobEndJudgmentJob = (): J => {
   return root.children[0] as J;
 };
 
+const parseWthKeyMappingJobs = (): {
+  explicitWthJob: J;
+  scheduleWtOnlyJob: J;
+} => {
+  const result = parseAjs(wthKeyMappingDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return {
+    explicitWthJob: root.children[0] as J,
+    scheduleWtOnlyJob: root.children[1] as J,
+  };
+};
+
 const parseHttpConnectionJobs = (): {
   httpJob: Htpj;
   explicitHttpJob: Htpj;
@@ -473,14 +505,15 @@ suite("ParameterFactory", () => {
     assert.strictEqual(ab?.value(), DEFAULTS.Ab);
   });
 
-  test("preserves the legacy wth to wt mapping", () => {
-    const job = parseJob();
+  test("reads end-judgment wth without using schedule wt", () => {
+    const { explicitWthJob, scheduleWtOnlyJob } = parseWthKeyMappingJobs();
 
-    const wth = ParamFactory.wth(job);
+    const wth = ParamFactory.wth(explicitWthJob);
 
     assert.ok(wth);
-    assert.strictEqual(wth?.parameter, "wt");
-    assert.strictEqual(wth?.value(), "wait-target");
+    assert.strictEqual(wth?.parameter, "wth");
+    assert.strictEqual(wth?.value(), "20");
+    assert.strictEqual(ParamFactory.wth(scheduleWtOnlyJob), undefined);
   });
 
   test("returns explicit optional array parameters through the facade", () => {


### PR DESCRIPTION
## Summary

- Align `ParamFactory.wth` to read the JP1/AJS end-judgment `wth` parameter instead of the schedule-rule `wt` parameter.
- Replace the legacy mapping regression with focused evidence that explicit `wth` is preserved and raw `wt` no longer satisfies `wth` lookup.
- Update SDD planning, approval evidence, impact notes, and validation records for the slice.

## Why

The previous factory behavior preserved a legacy `wth` to `wt` lookup. That mixed the end-judgment threshold parameter with the schedule-rule wait-time parameter, which conflicts with the JP1/AJS3 v13 parameter boundary recorded in SDD.

## Validation

- `npm test`
- `pnpm run qlty`
- `npm run test:web`
- `npm run build` passed with existing webpack asset-size warnings
- `pnpm run lint:md`
- `git diff --check`

## Compatibility

This intentionally removes the legacy `wth -> wt` compatibility quirk. Parser grammar, command generation, validation behavior, schedule-rule `wt`, and unit-list normalized raw projection are unchanged.