### PR TITLE
[codex] Align wc wt effective pairing

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -1,0 +1,116 @@
+# Parameter Coverage Matrix
+
+## Purpose
+
+Track the JP1/AJS3 version 13 parameter-alignment status for the focused
+categories already investigated by this feature. This matrix turns the audit
+notes into a durable status index without claiming repository-wide parameter
+coverage.
+
+## Status Vocabulary
+
+- Aligned: implemented behavior and focused regression evidence match the
+  recorded JP1/AJS3 version 13 reference for the stated slice.
+- Partial: the implemented behavior covers the stated slice, but documented
+  follow-up remains before the category can be treated as fully aligned.
+- Deferred: the reference point is known, but implementation or validation is
+  intentionally out of scope for the current slices.
+- Raw projection: application list projection reads normalized key/value data
+  and does not synthesize wrapper defaults.
+
+## Coverage Entries
+
+### Schedule Rules
+
+- Keys: `sd`, `ln`, `st`, `cy`, `sh`, `shd`, `cftd`, `sy`, `ey`,
+  `wc`, and `wt`
+- Unit scope: jobnets
+- Status: partial
+- Owning seam:
+  `scheduleRuleHelpers.ts`, `ruleParameterBuilders.ts`, `Day.ts`, and
+  `Time.ts`
+- Evidence:
+  `scheduleRuleHelpers.test.ts`, `parameterFactory.test.ts`,
+  `parameterHelpers.test.ts`, `buildUnitListGroup10View.test.ts`, and
+  `buildUnitListView.test.ts`
+- Remaining gap:
+  range validation remains deferred. `wc` / `wt` effective-value pairing is
+  aligned in the domain wrapper boundary, while unit-list projection remains
+  raw by design.
+
+### Transfer Operation
+
+- Keys:
+  `top1` to `top4`, with `ts1` to `ts4` and `td1` to `td4` presence
+  checks
+- Unit scope: UNIX/PC jobs and UNIX/PC custom jobs
+- Status: aligned for default resolution
+- Owning seam:
+  `transferOperationHelpers.ts` and `transferOperationParameterBuilders.ts`
+- Evidence: `parameterHelpers.test.ts` and `parameterFactory.test.ts`
+- Remaining gap:
+  filename, byte-length, macro-variable, and invalid-combination validation
+  remain deferred
+
+### QUEUE Transfer Files
+
+- Keys: `ts1` to `ts4` and `td1` to `td4`
+- Unit scope: QUEUE jobs and recovery QUEUE jobs
+- Status: aligned for wrapper boundary
+- Owning seam: `Qj.ts` and `ParameterFactory.ts`
+- Evidence: `parameterFactory.test.ts`
+- Remaining gap:
+  group 15 remains raw projection; unit-type-aware list behavior is deferred
+
+### Job End Judgment
+
+- Keys: `jd`, `wth`, `tho`, `jdf`, and `abr`
+- Unit scope:
+  UNIX/PC jobs, UNIX/PC custom jobs, and wrappers exposing end-judgment fields
+- Status: partial
+- Owning seam:
+  `jobEndJudgmentHelpers.ts`, `optionalScalarParameterBuilders.ts`, and
+  `Defaults.ts`
+- Evidence: `parameterFactory.test.ts` and `jobEndJudgmentHelpers.test.ts`
+- Remaining gap:
+  range validation, `jd` / `abr` invalid-combination diagnostics, and retry
+  diagnostics remain deferred
+
+### HTTP Connection Job Defaults
+
+- Keys:
+  `eu` plus currently modeled `htknd`, `htexm`, `htspt`, `jd`, `abr`, `ha`,
+  `mm`, `nmg`, `ega`, and `uem`
+- Unit scope: HTTP Connection jobs and recovery HTTP Connection jobs
+- Status: partial
+- Owning seam: `Htpj.ts`, `optionalScalarParameterBuilders.ts`, and
+  `Defaults.ts`
+- Evidence: `parameterFactory.test.ts`
+- Remaining gap:
+  future reconciliation may be needed if the definition section and
+  `ajsprint -a` default table conflict for `eu`
+
+### JP1 Event Sending Job Arrival Check
+
+- Keys: `evssv`, `evsrt`, `evspl`, and `evsrc`
+- Unit scope:
+  JP1 event sending jobs and recovery JP1 event sending jobs
+- Status: partial
+- Owning seam: `Evsj.ts`, `optionalScalarParameterBuilders.ts`, and
+  `Defaults.ts`
+- Evidence: `parameterFactory.test.ts` and `buildUnitListView.test.ts`
+- Remaining gap:
+  unit-list projection remains raw; `evhst` requiredness and range validation
+  are deferred
+
+## Boundary Decisions
+
+- This matrix covers only categories with feature-local investigation records.
+  It is not a complete inventory of every key in `ParamFactory`.
+- Default-aware wrapper behavior and raw normalized list projection are tracked
+  separately because several list groups intentionally read raw key/value data.
+- Validation gaps are not treated as parser failures until the editor-feedback
+  behavior contract specifies diagnostics, warnings, or raw preservation.
+- New parameter categories should add a focused alignment document first, then
+  add or update one row here after the slice has reference notes, boundary
+  decisions, and regression evidence.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -55,6 +55,13 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   non-schedule parameter correction.
 - Aligned `ParamFactory.wth` to read raw `wth`, replacing the legacy
   `wth` to `wt` lookup while preserving schedule-rule `wt` behavior.
+- Added `PARAMETER_COVERAGE_MATRIX.md` as a docs-only category-level status
+  index for the alignment slices that already have focused investigation
+  records.
+- Investigated schedule-rule `wc` / `wt` pairing as the next approval-gated
+  behavior candidate.
+- Implemented domain-only `wc` / `wt` effective-value pairing while preserving
+  raw schedule-rule values and unit-list projection.
 
 ## Impact Investigation
 
@@ -159,12 +166,59 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 - Approval: human approval to proceed was given on 2026-04-29 after the
   investigation summary for `wth` key mapping alignment.
 
+### WC / WT Schedule-Rule Pairing Candidate
+
+- Planned change: add a small schedule-rule helper seam for `wc` / `wt`
+  effective start-condition monitoring values so a rule is treated as disabled
+  when either paired value for the same rule is `no`, while preserving raw
+  parameter parsing and current raw normalized projection unless separately
+  approved.
+- Affected files:
+  `src/domain/models/parameters/scheduleRuleHelpers.ts`,
+  `src/domain/models/parameters/ScheduleRule.ts`,
+  `src/domain/models/parameters/Time.ts`,
+  `src/domain/models/parameters/ruleParameterBuilders.ts`,
+  `src/domain/models/parameters/ParameterFactory.ts`,
+  `src/domain/models/units/N.ts`,
+  `src/application/unit-list/buildUnitListGroup10View.ts` if effective
+  projection is approved,
+  `src/application/unit-list/unitListViewHelpers.ts` if effective projection
+  is approved,
+  focused schedule-rule helper and parameter factory tests,
+  focused unit-list tests only if projection changes,
+  and this feature's SDD docs.
+- Affected features:
+  JP1/AJS parameter interpretation for jobnet start-condition monitoring;
+  unit-list group 10 schedule projection only if default-aware effective values
+  are explicitly approved.
+- Tests affected:
+  `src/test/suite/scheduleRuleHelpers.test.ts`,
+  `src/test/suite/parameterFactory.test.ts`,
+  `src/test/suite/parameterHelpers.test.ts` if builder output changes, and
+  `src/test/suite/buildUnitListGroup10View.test.ts` /
+  `src/test/suite/buildUnitListView.test.ts` only if projection changes.
+- Breaking-change risk:
+  medium. The manual-aligned effective behavior would treat some currently
+  visible paired values as disabled when the counterpart is `no`. Preserving
+  raw parameter values and limiting the first slice to domain effective helpers
+  keeps projection and dialog behavior stable.
+- Alternatives considered:
+  leave independent `wc` and `wt` values as-is and keep the matrix marked
+  partial; add diagnostics instead of changing interpretation, deferred until
+  editor-feedback behavior is explicit; update unit-list projection immediately,
+  deferred unless explicitly approved because list groups currently read raw
+  normalized key/value data.
+- Approval:
+  human approval to proceed was given on 2026-04-29 after the investigation
+  summary for domain-only `wc` / `wt` effective-value pairing.
+
 ## Follow-up
 
 - Apply the same value parsing audit/refactor workflow to other parameter
   categories before marking them official-reference aligned.
-- Build a parameter-coverage matrix when category-level status needs tracking
-  beyond the current audit summary.
+- Keep the parameter-coverage matrix current whenever a focused alignment
+  slice is added, completed, re-scoped, or deferred.
+- Revisit `wc` / `wt` unit-list projection only as a separate behavior slice.
 - Revisit QUEUE job transfer-file coverage separately because the manual
   defines `tsN` and `tdN` but not `topN`.
 - Revisit invalid `jd` / `abr` combinations when diagnostics behavior is
@@ -203,8 +257,17 @@ Current branch validation:
   warnings
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `pnpm run lint:md`
+- 2026-04-29: `pnpm run lint:md`
+- 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `npm test`
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `npm run test:web`
 - 2026-04-29: `npm run build` completed with existing webpack asset-size
   warnings
+- 2026-04-29: `npm test`
+- 2026-04-29: `pnpm run qlty`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-04-29: `pnpm run qlty`
+- 2026-04-29: `pnpm run lint:md`

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
@@ -99,11 +99,56 @@ This document covers only the jobnet schedule-rule family already called out in
 - `wc`
   - Covered: per-`sd` start-condition count; omitted value default `no`.
   - Seam: `parseWaitCountValue` and `Wc`.
-  - Remaining gap: range validation and paired `wt` invalidation.
+  - Remaining gap: range validation.
 - `wt`
   - Covered: per-`sd` monitoring end time; omitted value default `no`.
   - Seam: `parseWaitTimeValue` and `Wt`.
-  - Remaining gap: range validation and paired `wc` invalidation.
+  - Remaining gap: range validation.
+
+## WC / WT Pairing Candidate
+
+- Manual basis:
+  Command Reference, `5.2.4 Jobnet definition`, says `wt` and `wc` are
+  specified together for start-condition monitoring.
+- Current behavior:
+  `ruleParameterBuilders.wc` and `ruleParameterBuilders.wt` independently
+  align defaults to each `sd` rule. `Wc.numberOfTimes` and `Wt.time` expose the
+  parsed value without checking the paired parameter for the same rule.
+- Behavior candidate:
+  keep explicit raw `wc` and `wt` parameters parseable, but expose the
+  effective start-condition values as disabled when either paired value for the
+  same rule is `no`.
+- Affected seams:
+  `scheduleRuleHelpers.ts`, `ScheduleRule.ts`, `Time.ts`,
+  `ruleParameterBuilders.ts`, `ParamFactory.wc`, and `ParamFactory.wt`.
+- Affected application consumers:
+  group 10 unit-list projection through
+  `src/application/unit-list/buildUnitListGroup10View.ts` and
+  `src/application/unit-list/unitListViewHelpers.ts` if the approved behavior
+  includes default-aware or effective-value list projection.
+- Regression evidence needed:
+  focused domain tests for paired rule evaluation, and unit-list tests only if
+  projection behavior changes.
+- Approval-sensitive boundary:
+  raw normalized projection should remain unchanged unless explicitly approved.
+  Validation diagnostics and range checks remain separate follow-up work.
+
+## WC / WT Pairing Delivered Alignment
+
+- Domain helper:
+  `resolveEffectiveStartConditionMonitoringPair` resolves paired `wc` / `wt`
+  raw values and returns no effective values when either side is `no`, missing,
+  or unparsable.
+- Wrapper API:
+  `Wc.effectiveNumberOfTimes(waitTimeRawValue)` and
+  `Wt.effectiveTime(waitCountRawValue)` expose the paired effective values
+  without changing `Wc.numberOfTimes`, `Wt.time`, or `value()`.
+- Projection boundary:
+  normalized unit-list projection remains raw and unchanged.
+- Regression evidence:
+  `scheduleRuleHelpers.test.ts` covers helper-level pair resolution, and
+  `parameterFactory.test.ts` verifies raw values stay visible while effective
+  values are disabled for `no` pairs.
 
 ## Delivered Alignment
 
@@ -119,7 +164,7 @@ This document covers only the jobnet schedule-rule family already called out in
 
 - Add range validation only after deciding whether invalid JP1/AJS parameter
   values should become diagnostics, warnings, or preserved raw values.
-- Model `wc` / `wt` paired invalidation once the behavior contract is explicit
-  enough to test across domain and unit-list projection.
+- Revisit whether unit-list projection should consume effective `wc` / `wt`
+  values only as a separate projection behavior slice.
 - Apply this category-level parser alignment workflow to the next non-schedule
   parameter family before marking that category official-reference aligned.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -59,6 +59,14 @@ JP1/AJS3 version 13 reference documents.
   parameter. Correct alignment should read explicit `wth` values without
   synthesizing omitted values and without changing schedule-rule `wt`
   projection.
+- `PARAMETER_COVERAGE_MATRIX.md` is the feature-local status index for
+  investigated categories. It is intentionally narrower than `ParamFactory`
+  and must not be read as repository-wide JP1/AJS3 parameter coverage.
+- Schedule-rule `wc` / `wt` pairing is approval-sensitive because the current
+  wrappers expose both values independently, while the JP1/AJS3 version 13
+  jobnet definition treats `no` in either parameter as invalidating the paired
+  start-condition monitoring value. Any implementation must distinguish raw
+  parameter preservation from effective-value interpretation.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -76,11 +76,14 @@
       derived for `Qj` / `Rq`
 - [x] Align `wth` key mapping so job end-judgment threshold parsing reads
       `wth` rather than the schedule-rule `wt` parameter
-- [ ] Turn the audit notes into an explicit parameter-coverage matrix when
+- [x] Turn the audit notes into an explicit parameter-coverage matrix when
       category-level status needs tracking beyond the current audit summary
-- [ ] Continue schedule-rule helper-boundary alignment with the remaining
+- [x] Investigate schedule-rule helper-boundary alignment with the remaining
       grouped semantics, such as `wc` / `wt` pairing or range validation, when
       the behavior contract is explicit enough to test across the family
+- [x] Implement schedule-rule `wc` / `wt` effective-value pairing after human
+      approval clarifies whether the slice is domain-only or includes
+      unit-list projection
 
 ## Notes
 
@@ -171,19 +174,40 @@
   longer satisfies end-judgment threshold lookup. Parser grammar, command
   generation, validation behavior, schedule-rule `wt`, and unit-list
   normalized raw projection remain unchanged.
+- 2026-04-29: `PARAMETER_COVERAGE_MATRIX.md` now turns the current audit and
+  focused alignment records into an explicit category-level matrix. This is a
+  docs-only status index and does not broaden parameter coverage or approve
+  new runtime behavior.
+- 2026-04-29: schedule-rule `wc` / `wt` pairing is the next investigated
+  behavior candidate. The current code parses and defaults both parameters
+  independently, while the JP1/AJS3 v13 jobnet definition says they are
+  specified together and `no` in one parameter invalidates the paired
+  start-condition monitoring value. Implementation approval is pending.
+- 2026-04-29: schedule-rule `wc` / `wt` effective-value pairing is implemented
+  as a domain-only helper/API. Raw `Wc.numberOfTimes`, `Wt.time`, `value()`,
+  and normalized unit-list projection remain unchanged. Effective values are
+  empty when either paired value is `no`, missing, or unparsable.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-04-29
-- Approved scope: Align `wth` key mapping so job end-judgment threshold
-  parsing reads raw `wth` rather than the schedule-rule `wt` parameter; update
-  focused regression evidence; keep parser grammar, command generation,
-  validation behavior, schedule-rule `wt`, and unit-list normalized raw
-  projection unchanged.
+- Approved scope: Implement domain-only effective-value helper/tests for
+  schedule-rule `wc` / `wt` pairing, keeping raw normalized unit-list
+  projection unchanged. Do not change parser grammar, command generation,
+  validation diagnostics, generated artifacts, or configuration.
 
 ## Prior Approval Evidence
 
+- 2026-04-29: Approved domain-only effective-value helper/tests for
+  schedule-rule `wc` / `wt` pairing, keeping raw normalized unit-list
+  projection unchanged. Parser grammar, command generation, validation
+  diagnostics, generated artifacts, and configuration remained out of scope.
+- 2026-04-29: Approved `wth` key mapping alignment so job end-judgment
+  threshold parsing reads raw `wth` rather than the schedule-rule `wt`
+  parameter; update focused regression evidence; keep parser grammar, command
+  generation, validation behavior, schedule-rule `wt`, and unit-list
+  normalized raw projection unchanged.
 - 2026-04-29: Approved QUEUE job transfer-file alignment by adding focused
   regression evidence that `Qj` / `Rq` preserve explicit `ts1` to `ts4` and
   `td1` to `td4` values without exposing or deriving `top1` to `top4`, while

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -15,10 +15,11 @@ rules in `docs/specs/README.md`, not in this file.
   the same matching semantics.
 - Parameter-reference alignment should proceed in small JP1/AJS v13 slices
   with explicit manual coverage. For each parameter category, verify value
-  parsing against the official format before claiming the category aligned.
-  The next active candidate is the job end-judgment `wth` key mapping, because
-  the current factory intentionally preserves a legacy `wth` to `wt` lookup
-  that conflicts with the JP1/AJS3 v13 end-judgment parameter name.
+  parsing against the official format before claiming the category aligned. A
+  feature-local parameter coverage matrix now tracks the investigated
+  categories without claiming repository-wide coverage. Schedule-rule
+  `wc` / `wt` effective-value pairing is aligned in the domain boundary while
+  unit-list projection remains raw.
 - Read-only JP1/AJS WebAPI import stays beta until real JP1/AJS3 environment
   smoke verification and enough user feedback are recorded. Beta exit is
   feedback-gated and is not the next active implementation priority.
@@ -27,9 +28,8 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Continue category-level parameter parsing alignment by correcting the
-   end-judgment `wth` lookup to read the `wth` parameter instead of the
-   schedule-rule `wt` parameter, after approval.
+1. Continue category-level parameter parsing alignment by selecting the next
+   focused behavior contract and recording approval before implementation.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime
@@ -39,18 +39,26 @@ rules in `docs/specs/README.md`, not in this file.
 
 - Branch: `codex/align-wth-end-judgment`
 - Objective: continue JP1/AJS3 version 13 parameter alignment with a focused
-  job end-judgment correction for `wth`.
-- Status: implemented locally; validation completed.
+  job end-judgment correction for `wth`, then close the docs-only follow-up
+  that turns current audit notes into a category-level parameter coverage
+  matrix.
+- Status: implementation validation completed for `wth`; docs-only coverage
+  matrix update completed; domain-only `wc` / `wt` pairing implemented and
+  validated.
 - Scope: update the `ParamFactory.wth` builder to read the raw `wth`
   parameter; preserve omitted `wth` as undefined; preserve schedule-rule `wt`
   behavior through `ruleParameterBuilders.wt`; update focused regression
-  evidence.
+  evidence; add a docs-only parameter coverage matrix for already investigated
+  categories; investigate schedule-rule `wc` / `wt` effective-value pairing.
 - Out of scope: parser grammar changes, command generation, byte-length or
   numeric range validation, invalid `jd` / `abr` pairing diagnostics, retry
   range diagnostics, and changing unit-list normalized raw projection.
 - Impact summary: behavior changes only for wrappers that expose `wth`
   (`J`, `Cj`, `Cpj`, `Fxj`, `Htpj`, `Qj`, and recovery variants). Existing
   callers should stop seeing schedule-rule `wt` as an end-judgment threshold.
+  The coverage matrix itself is docs-only and does not broaden runtime
+  behavior. The `wc` / `wt` investigation does not change runtime behavior
+  until approved; the approved domain helper preserves raw projection.
 - Risks and assumptions: this intentionally breaks the legacy `wth` to `wt`
   mapping test. The risk is low-to-medium because the current mapping is
   documented as legacy behavior, but any downstream consumer depending on that
@@ -101,8 +109,17 @@ Current branch checks:
   warnings
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `pnpm run lint:md`
+- 2026-04-29: `pnpm run lint:md`
+- 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `npm test`
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `npm run test:web`
 - 2026-04-29: `npm run build` completed with existing webpack asset-size
   warnings
+- 2026-04-29: `npm test`
+- 2026-04-29: `pnpm run qlty`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-04-29: `pnpm run qlty`
+- 2026-04-29: `pnpm run lint:md`

--- a/src/domain/models/parameters/ScheduleRule.ts
+++ b/src/domain/models/parameters/ScheduleRule.ts
@@ -8,6 +8,7 @@ import {
   parseScheduleByDaysFromStartValue,
   parseShiftDaysValue,
   parseWaitCountValue,
+  resolveEffectiveStartConditionMonitoringPair,
 } from "./scheduleRuleHelpers";
 
 interface ScheduleRule {
@@ -195,5 +196,14 @@ export class Wc extends Parameter implements ScheduleRule {
 
   get numberOfTimes() {
     return this._numberOfTimes ?? "1";
+  }
+
+  effectiveNumberOfTimes(
+    waitTimeRawValue: string | undefined,
+  ): string | undefined {
+    return resolveEffectiveStartConditionMonitoringPair(
+      this.value(),
+      waitTimeRawValue,
+    ).numberOfTimes;
   }
 }

--- a/src/domain/models/parameters/Time.ts
+++ b/src/domain/models/parameters/Time.ts
@@ -5,6 +5,7 @@ import {
   parseDelayTimeValue,
   parseStartTimeValue,
   parseWaitTimeValue,
+  resolveEffectiveStartConditionMonitoringPair,
 } from "./scheduleRuleHelpers";
 
 type ParseTimeValue = (rawValue: string | undefined) =>
@@ -69,5 +70,12 @@ export class Sy extends Time {
 export class Wt extends Time {
   constructor(arg: ParamInternal) {
     super(arg, parseWaitTimeValue);
+  }
+
+  effectiveTime(waitCountRawValue: string | undefined): string | undefined {
+    return resolveEffectiveStartConditionMonitoringPair(
+      waitCountRawValue,
+      this.value(),
+    ).time;
   }
 }

--- a/src/domain/models/parameters/scheduleRuleHelpers.ts
+++ b/src/domain/models/parameters/scheduleRuleHelpers.ts
@@ -2,7 +2,7 @@ export const resolveScheduleRuleNumber = (
   rawRuleNumber: string | undefined,
 ): number => (rawRuleNumber === undefined ? 1 : Number(rawRuleNumber));
 
-type ParsedRuleValue = {
+export type ParsedRuleValue = {
   rule: number;
   value: string;
 };
@@ -87,6 +87,33 @@ export const parseAnyScheduleTimeValue = (
 export const parseWaitCountValue = (
   rawValue: string | undefined,
 ): ParsedRuleValue | undefined => parseRuleValue(rawValue, /^(no|\d{1,3}|un)$/);
+
+export type EffectiveStartConditionMonitoringPair = {
+  numberOfTimes?: string;
+  time?: string;
+};
+
+export const resolveEffectiveStartConditionMonitoringPair = (
+  waitCountRawValue: string | undefined,
+  waitTimeRawValue: string | undefined,
+): EffectiveStartConditionMonitoringPair => {
+  const waitCount = parseWaitCountValue(waitCountRawValue ?? "no");
+  const waitTime = parseWaitTimeValue(waitTimeRawValue ?? "no");
+
+  if (
+    waitCount === undefined ||
+    waitTime === undefined ||
+    waitCount.value === "no" ||
+    waitTime.value === "no"
+  ) {
+    return {};
+  }
+
+  return {
+    numberOfTimes: waitCount.value,
+    time: waitTime.value,
+  };
+};
 
 export type ParsedScheduleByDaysFromStartValue = {
   rule: number;

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -154,6 +154,27 @@ unit=root,,jp1admin,;
 }
 `;
 
+const scheduleWaitPairingDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=jobnet,n,+0+0;
+  unit=jobnet,,jp1admin,;
+  {
+    ty=n;
+    sd=1,en;
+    sd=2,en;
+    sd=3,en;
+    wc=4;
+    wt=no;
+    wc=2,no;
+    wt=2,01:00;
+    wc=3,un;
+    wt=3,un;
+  }
+}
+`;
+
 const nestedScheduleDefinition = `
 unit=root,,jp1admin,;
 {
@@ -383,6 +404,13 @@ const parseUndefinedScheduleJobnet = (): N => {
 
 const parseScheduleRelativeTimeJobnet = (): N => {
   const result = parseAjs(scheduleRelativeTimeDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return root.children[0] as N;
+};
+
+const parseScheduleWaitPairingJobnet = (): N => {
+  const result = parseAjs(scheduleWaitPairingDefinition);
   assert.deepStrictEqual(result.errors, []);
   const root = tyFactory(result.rootUnits[0]);
   return root.children[0] as N;
@@ -769,6 +797,34 @@ suite("ParameterFactory", () => {
     assert.deepStrictEqual(
       ey?.map((parameter) => parameter?.time),
       [undefined, "U60"],
+    );
+  });
+
+  test("resolves effective wc and wt pairs without changing raw values", () => {
+    const jobnet = parseScheduleWaitPairingJobnet();
+
+    const wc = ParamFactory.wc(jobnet);
+    const wt = ParamFactory.wt(jobnet);
+
+    assert.deepStrictEqual(
+      wc?.map((parameter) => parameter?.numberOfTimes),
+      ["4", "no", "un"],
+    );
+    assert.deepStrictEqual(
+      wt?.map((parameter) => parameter?.time),
+      ["no", "01:00", "un"],
+    );
+    assert.deepStrictEqual(
+      wc?.map((parameter, index) =>
+        parameter?.effectiveNumberOfTimes(wt?.[index]?.value()),
+      ),
+      [undefined, undefined, "un"],
+    );
+    assert.deepStrictEqual(
+      wt?.map((parameter, index) =>
+        parameter?.effectiveTime(wc?.[index]?.value()),
+      ),
+      [undefined, undefined, "un"],
     );
   });
 

--- a/src/test/suite/scheduleRuleHelpers.test.ts
+++ b/src/test/suite/scheduleRuleHelpers.test.ts
@@ -10,6 +10,7 @@ import {
   parseStartTimeValue,
   parseWaitCountValue,
   parseWaitTimeValue,
+  resolveEffectiveStartConditionMonitoringPair,
 } from "../../domain/models/parameters/scheduleRuleHelpers";
 
 suite("Schedule rule helpers", () => {
@@ -92,5 +93,27 @@ suite("Schedule rule helpers", () => {
     assert.strictEqual(parseCycleValue("(3,q)"), undefined);
     assert.strictEqual(parseClosedDaySubstitutionValue("before"), undefined);
     assert.strictEqual(parseScheduleByDaysFromStartValue("be,3,9x"), undefined);
+  });
+
+  test("resolves effective wc and wt pairs", () => {
+    assert.deepStrictEqual(
+      resolveEffectiveStartConditionMonitoringPair("4", "00:30"),
+      {
+        numberOfTimes: "4",
+        time: "00:30",
+      },
+    );
+    assert.deepStrictEqual(
+      resolveEffectiveStartConditionMonitoringPair("no", "00:30"),
+      {},
+    );
+    assert.deepStrictEqual(
+      resolveEffectiveStartConditionMonitoringPair("4", "no"),
+      {},
+    );
+    assert.deepStrictEqual(
+      resolveEffectiveStartConditionMonitoringPair(undefined, "00:30"),
+      {},
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add a JP1/AJS3 v13 schedule-rule helper for effective `wc` / `wt` start-condition monitoring pairs.
- Expose domain-only effective APIs on `Wc` and `Wt` while preserving raw/default values and normalized unit-list projection.
- Add focused regression coverage and update SDD tracking docs, including a parameter coverage matrix.

## Why

JP1/AJS3 v13 treats `wc` and `wt` as paired start-condition monitoring parameters. If either side is `no`, the paired value is ineffective. The existing domain model parsed and defaulted both parameters independently, so this slice adds explicit effective-value interpretation without changing raw parameter display behavior.

## Validation

- `pnpm run qlty`
- `pnpm run lint:md`
- `npm test`
- `npm run test:web`
- `npm run build` passed with existing webpack asset-size warnings

## Compatibility

- `engines.vscode` unchanged.
- Parser grammar, command generation, validation diagnostics, generated artifacts, configuration, and unit-list raw projection are unchanged.