### PR TITLE
[codex] Align wc wt unit-list projection

### DIFF
--- a/docs/requirements/use-cases/uc-build-unit-list.md
+++ b/docs/requirements/use-cases/uc-build-unit-list.md
@@ -46,6 +46,12 @@ Scenario: Encoded sample definitions remain supported
   Given a representative UTF-8 or Shift_JIS JP1/AJS sample definition
   When the unit-list document DTO is built
   Then the output preserves the expected unit-list content
+
+Scenario: Start-condition monitoring projection uses effective schedule pairs
+  Given a jobnet schedule rule has paired start-condition monitoring values
+  When either the `wc` count or `wt` time disables monitoring for that pair
+  Then the unit-list schedule definition output shows empty effective values
+  for both start-condition monitoring columns
 ```
 
 ## Acceptance Notes
@@ -53,6 +59,8 @@ Scenario: Encoded sample definitions remain supported
 - desktop and web table viewers can consume the same DTO shape
 - representative fixtures in `sample/` should be reusable for regression tests,
   especially UTF-8, Shift_JIS, and large-definition coverage
+- raw parameter preservation and effective schedule-rule display can differ
+  when the JP1/AJS3 reference defines cross-parameter interpretation
 
 ## Risks Or Edge Cases
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -35,8 +35,7 @@ coverage.
   `buildUnitListView.test.ts`
 - Remaining gap:
   range validation remains deferred. `wc` / `wt` effective-value pairing is
-  aligned in the domain wrapper boundary, while unit-list projection remains
-  raw by design.
+  aligned in the domain wrapper boundary and unit-list group 10 projection.
 
 ### Transfer Operation
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -62,6 +62,10 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   behavior candidate.
 - Implemented domain-only `wc` / `wt` effective-value pairing while preserving
   raw schedule-rule values and unit-list projection.
+- Investigated unit-list group 10 projection for `wc` / `wt` as the next
+  approval-gated behavior candidate after domain-only pairing.
+- Implemented unit-list group 10 projection for effective `wc` / `wt` values
+  while preserving raw parser, wrapper, and normalized parameter values.
 
 ## Impact Investigation
 
@@ -212,13 +216,50 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   human approval to proceed was given on 2026-04-29 after the investigation
   summary for domain-only `wc` / `wt` effective-value pairing.
 
+### WC / WT Unit-List Projection Candidate
+
+- Planned change:
+  change unit-list group 10 start-condition projection to consume effective
+  `wc` / `wt` pairing semantics instead of displaying raw independent values.
+- Affected files:
+  `src/application/unit-list/buildUnitListGroup10View.ts`,
+  `src/application/unit-list/unitListViewHelpers.ts` if a projection helper is
+  added, `src/test/suite/buildUnitListGroup10View.test.ts`,
+  `src/test/suite/buildUnitListView.test.ts` if the full unit-list fixture
+  needs explicit coverage, `docs/requirements/use-cases/uc-build-unit-list.md`,
+  `SCHEDULE_RULE_ALIGNMENT.md`, `SPECS.md`, `TASKS.md`, and branch-level
+  `docs/specs/plans.md`.
+- Affected functions/classes/components:
+  `buildUnitListGroup10View`, `parseWc`, `parseTimeValue`, the
+  `UnitListGroup10View.waitCounts` and `waitTimes` DTO fields, and the group
+  10 table columns that render those arrays.
+- Affected features:
+  JP1/AJS table viewer group 10 schedule definition columns; build-unit-list
+  application use case; schedule-rule parameter interpretation.
+- Tests affected:
+  focused group 10 unit-list tests; full build-unit-list tests only if needed
+  to lock the DTO-level behavior; existing domain tests for
+  `resolveEffectiveStartConditionMonitoringPair` should continue to pass.
+- Breaking-change risk:
+  medium. This intentionally changes user-visible table output for definitions
+  where one side of a `wc` / `wt` pair disables start-condition monitoring.
+  Raw parser output, raw domain wrapper values, and normalized key/value
+  storage remain unchanged.
+- Alternatives considered:
+  keep group 10 raw by design and leave the matrix gap visible; add separate
+  raw and effective columns, rejected for this slice because it expands UI and
+  localization scope; add diagnostics instead of projection changes, deferred
+  until editor-feedback behavior explicitly owns cross-parameter warnings.
+- Approval:
+  human approval to proceed was given on 2026-04-29 after the investigation
+  summary for unit-list group 10 effective `wc` / `wt` projection.
+
 ## Follow-up
 
 - Apply the same value parsing audit/refactor workflow to other parameter
   categories before marking them official-reference aligned.
 - Keep the parameter-coverage matrix current whenever a focused alignment
   slice is added, completed, re-scoped, or deferred.
-- Revisit `wc` / `wt` unit-list projection only as a separate behavior slice.
 - Revisit QUEUE job transfer-file coverage separately because the manual
   defines `tsN` and `tdN` but not `topN`.
 - Revisit invalid `jd` / `abr` combinations when diagnostics behavior is

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
@@ -150,6 +150,44 @@ This document covers only the jobnet schedule-rule family already called out in
   `parameterFactory.test.ts` verifies raw values stay visible while effective
   values are disabled for `no` pairs.
 
+## WC / WT Unit-List Projection Candidate
+
+- Planned change:
+  make unit-list group 10 start-condition columns display effective `wc` /
+  `wt` values from the existing paired domain semantics instead of raw
+  independent parsed values.
+- Current behavior:
+  `buildUnitListGroup10View.ts` reads normalized raw `wc` and `wt` values
+  independently through `findAjsUnitParameterValues(...)`, then maps them with
+  `parseWc` and `parseTimeValue`.
+- Expected behavior:
+  paired values display only when both values for the same schedule-rule row
+  are effective. If either side is `no`, missing, or unparsable, both group 10
+  start-condition cells for that pair display empty values.
+- Affected seams:
+  `src/application/unit-list/buildUnitListGroup10View.ts`,
+  `src/application/unit-list/unitListViewHelpers.ts`, and the existing
+  schedule-rule helper `resolveEffectiveStartConditionMonitoringPair`.
+- Regression evidence needed:
+  focused group 10 unit-list tests for `wc=4` / `wt=no`, `wc=2,no` /
+  `wt=2,01:00`, and a valid `wc` / `wt` pair that remains visible.
+- Approval-sensitive boundary:
+  parser grammar, raw domain wrappers, normalized raw parameter storage,
+  diagnostics, and generated artifacts remain out of scope.
+
+## WC / WT Unit-List Projection Delivered Alignment
+
+- Projection behavior:
+  unit-list group 10 start-condition columns now display effective `wc` /
+  `wt` values from the paired helper. Disabled, missing, or unparsable pairs
+  display empty count and time cells.
+- Raw preservation:
+  parser output, raw domain wrapper values, and normalized raw parameter
+  storage remain unchanged.
+- Regression evidence:
+  `buildUnitListGroup10View.test.ts` covers disabled `wc=4` / `wt=no`,
+  disabled `wc=2,no` / `wt=2,01:00`, and valid `wc=3,un` / `wt=3,un`.
+
 ## Delivered Alignment
 
 - `ln`: root-jobnet values are ignored while nested jobnet values remain sorted
@@ -164,7 +202,5 @@ This document covers only the jobnet schedule-rule family already called out in
 
 - Add range validation only after deciding whether invalid JP1/AJS parameter
   values should become diagnostics, warnings, or preserved raw values.
-- Revisit whether unit-list projection should consume effective `wc` / `wt`
-  values only as a separate projection behavior slice.
 - Apply this category-level parser alignment workflow to the next non-schedule
   parameter family before marking that category official-reference aligned.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -67,6 +67,11 @@ JP1/AJS3 version 13 reference documents.
   jobnet definition treats `no` in either parameter as invalidating the paired
   start-condition monitoring value. Any implementation must distinguish raw
   parameter preservation from effective-value interpretation.
+- Unit-list group 10 `wc` / `wt` projection is a separate approval-sensitive
+  boundary from domain interpretation because it is user-visible table output.
+  If approved, it should consume the existing paired effective-value semantics
+  while preserving parser output, raw domain wrapper values, and normalized raw
+  parameter storage.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -84,6 +84,12 @@
 - [x] Implement schedule-rule `wc` / `wt` effective-value pairing after human
       approval clarifies whether the slice is domain-only or includes
       unit-list projection
+- [x] Investigate unit-list group 10 projection for schedule-rule `wc` / `wt`
+      effective values as a separate behavior slice after domain-only pairing
+- [x] Record human approval before changing unit-list projection behavior
+- [x] Implement group 10 effective `wc` / `wt` projection only after approval
+- [x] Add focused group 10 regression evidence for disabled and valid pairs
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -187,15 +193,35 @@
   as a domain-only helper/API. Raw `Wc.numberOfTimes`, `Wt.time`, `value()`,
   and normalized unit-list projection remain unchanged. Effective values are
   empty when either paired value is `no`, missing, or unparsable.
+- 2026-04-29: unit-list group 10 `wc` / `wt` projection is the next
+  approval-gated behavior candidate. The proposed scope is limited to table
+  DTO projection using the existing effective pairing semantics; parser
+  grammar, raw wrappers, normalized raw parameter storage, diagnostics,
+  generated artifacts, configuration, dependency versions, and
+  `engines.vscode` remain out of scope.
+- 2026-04-29: unit-list group 10 `wc` / `wt` projection now consumes the
+  existing effective pairing semantics. Disabled pairs display empty
+  start-condition monitoring values, valid pairs remain visible, and raw
+  parser/domain/normalized values remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-04-29
-- Approved scope: Implement domain-only effective-value helper/tests for
-  schedule-rule `wc` / `wt` pairing, keeping raw normalized unit-list
-  projection unchanged. Do not change parser grammar, command generation,
-  validation diagnostics, generated artifacts, or configuration.
+- Approved scope: User replied "OK.Proceed." after the unit-list group 10
+  effective projection approval request. Approved changes are limited to
+  making group 10 `wc` / `wt` schedule-rule start-condition columns consume
+  existing effective pairing semantics, adding focused regression evidence,
+  updating SDD tracking, and running validation. Parser grammar, raw domain
+  wrappers, normalized raw parameter storage, diagnostics, generated artifacts,
+  configuration, dependency versions, and `engines.vscode` changes are out of
+  scope.
+
+Current implementation gate: unit-list group 10 effective projection for
+schedule-rule `wc` / `wt` pairing.
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
 
 ## Prior Approval Evidence
 
@@ -222,3 +248,13 @@
   omitted `eu` values to `def` for `Htpj` / `Rhtpj`, keeping explicit `eu`
   values and non-HTTP job-family `eu` defaults unchanged, and adding focused
   regression evidence.
+
+## Validation
+
+- 2026-04-29: `pnpm run test:compile`
+- 2026-04-29: `npm test`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-04-29: `pnpm run lint:md`
+- 2026-04-29: `pnpm run qlty`

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -31,41 +31,36 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Prepare build/test performance for PR review or merge after final human
-   confirmation.
-2. Continue category-level parameter parsing alignment by selecting the next
+1. Continue category-level parameter parsing alignment by selecting the next
    focused behavior contract and recording approval before implementation.
-3. Keep WebAPI import beta feedback and real-environment smoke evidence
+2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
-4. Keep compatibility risk visible for every shared or extension-runtime
+3. Keep compatibility risk visible for every shared or extension-runtime
    change.
 
 ## Current Branch Plan
 
-- Branch: `codex/build-test-performance`.
-- Objective: complete the build/test performance feature in one PR-sized
-  feature branch by repeating SDD investigation, approval, implementation,
-  validation, push, and CI review per slice.
-- Status: Slice-1, Slice-2, Slice-3, Slice-4, Slice-5, and Slice-7 are
-  implemented in draft PR #222. CI completed successfully through Slice-7 per
-  human confirmation, and Slice-3 CI also completed successfully per human
-  confirmation. Slice-8 Playwright browser cache completed successfully with
-  cache-miss and cache-hit CI evidence per human confirmation. Slice-6 was
-  investigated and deferred from this branch because it is primarily output
-  ownership cleanup with low direct speedup and higher test-launcher risk.
-- Scope: keep changes focused on validation performance command ownership,
-  ANTLR generation freshness, webpack development speed, type-check ownership,
-  CI rebuild reduction, and cache behavior as described by the feature docs.
-- Out of scope: product behavior changes, parser grammar changes, generated
-  parser semantic changes, dependency modernization unrelated to validation
-  performance, and raising `engines.vscode`.
-- Impact summary: Slice-8 affects `.github/workflows/verify.yml` only, adding
-  a conservative Playwright browser cache while preserving pnpm dependency
-  caching and the existing Playwright install command.
-- Risks and assumptions: performance reductions are hypotheses until measured.
-  Slice-8 cache risk is controlled by keeping cache misses first-class and
-  deferring VS Code test binary caching until the VS Code binary version input
-  is explicit.
+- Branch: not created for implementation while approval is pending.
+- Objective: continue the JP1/AJS3 v13 parameter alignment feature with a
+  focused unit-list projection slice for schedule-rule `wc` / `wt` effective
+  start-condition monitoring values.
+- Status: build/test performance PR #222 is merged with successful CI. The
+  current slice implements unit-list group 10 projection for the already
+  implemented domain effective `wc` / `wt` pairing.
+- Scope: update SDD records and request approval for changing unit-list
+  projection from raw independent `wc` / `wt` values to paired effective values
+  for the group 10 start-condition columns.
+- Out of scope: parser grammar changes, command generation, diagnostics,
+  generated artifacts, dependency changes, `engines.vscode`, and broader
+  schedule-rule range validation.
+- Impact summary: the candidate affects
+  `src/application/unit-list/buildUnitListGroup10View.ts`,
+  `src/application/unit-list/unitListViewHelpers.ts`, group 10 unit-list
+  regression tests, and the schedule-rule SDD documents.
+- Risks and assumptions: behavior changes are user-visible in the table viewer
+  because paired values such as `wc=4` with `wt=no` would display as empty
+  effective start-condition monitoring values instead of raw independent
+  values. Raw parameter parsing and domain wrapper raw values remain preserved.
 
 ## Build/Test Performance SDD
 
@@ -79,7 +74,7 @@ rules in `docs/specs/README.md`, not in this file.
   optimization; Slice-5, type-check responsibility; Slice-7, CI rebuild
   reduction; Slice-8, Playwright browser cache.
 - Next implementation slice:
-  none; Slice-6 is deferred as future cleanup.
+  none; PR #222 is merged and Slice-6 is deferred as future cleanup.
 - Roadmap:
   Phase 1 covers Slice-1, Slice-2, and Slice-4; Phase 2 covers Slice-5 and
   Slice-7; Phase 3 covers Slice-3, Slice-6, and Slice-8.
@@ -93,7 +88,9 @@ rules in `docs/specs/README.md`, not in this file.
 - `docs/specs/features/build-test-performance/`:
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
-  active JP1/AJS3 version 13 alignment records and coverage matrix.
+  active JP1/AJS3 version 13 alignment records and coverage matrix. Current
+  slice: unit-list group 10 projection for effective schedule-rule `wc` /
+  `wt` pairing.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:
@@ -113,3 +110,10 @@ Current branch checks:
 
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `pnpm run lint:md`
+- 2026-04-29: `pnpm run test:compile`
+- 2026-04-29: `npm test`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-04-29: `pnpm run lint:md`
+- 2026-04-29: `pnpm run qlty`

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -12,17 +12,7 @@
 
 ## Current Roadmap
 
-1. Improve build/test validation performance through SDD-defined slices.
-
-   - Start with Slice-1, separating test execution from build preparation.
-   - Keep Slices 2 through 8 draft-level until Slice-1 timing evidence is
-     recorded.
-   - Preserve desktop tests, web tests, production build validation, generated
-     parser correctness, and VS Code `^1.75.0` compatibility.
-   - Phase 1 order is Slice-1, Slice-2, then Slice-4; Phase 2 is Slice-5 then
-     Slice-7; Phase 3 is Slice-3, Slice-6, then Slice-8.
-
-2. Re-base parameter interpretation on JP1/Automatic Job Management System 3
+1. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
 
    - Start from the documented audit of current shared parameter-semantics
@@ -42,10 +32,13 @@
    - Continue applying the same audit, helper-boundary, and regression-test
      workflow to other parameter families instead of checking isolated keys one
      by one.
+   - Unit-list group 10 projection now consumes effective schedule-rule
+     `wc` / `wt` start-condition monitoring values after the domain-only
+     pairing API was implemented.
    - Keep behavior-preserving slices separate from behavior-changing manual
      alignment slices.
 
-3. Keep read-only JP1/AJS WebAPI import in beta while feedback is limited.
+2. Keep read-only JP1/AJS WebAPI import in beta while feedback is limited.
 
    - Keep transport, authentication, and endpoint details in infrastructure.
    - Keep generated OpenAPI mocks and stubs reproducible from repository-local
@@ -55,7 +48,7 @@
    - Offer the feature as beta until smoke verification against a real JP1/AJS3
      environment and enough user feedback are recorded.
 
-4. Maintain normalized-model convergence.
+3. Maintain normalized-model convergence.
 
    - Prefer stable `AjsDocument` / `AjsUnit` contracts for application-facing
      behavior.
@@ -63,7 +56,7 @@
      consumers.
    - Promote only cross-consumer semantics into normalized helpers.
 
-5. Introduce stricter parser/infrastructure boundaries.
+4. Introduce stricter parser/infrastructure boundaries.
 
    - Define an application-facing parser or document-loading port.
    - Move concrete parser orchestration behind an adapter boundary when
@@ -72,7 +65,7 @@
      application use cases.
    - Preserve current desktop and web extension behavior while migrating.
 
-6. Use Qlty findings as architectural feedback.
+5. Use Qlty findings as architectural feedback.
 
    - Treat recurring duplication, complexity, and nested-control-flow findings
      as prioritized refactoring candidates.
@@ -80,19 +73,22 @@
 
 ## Deferred / Optional Slices
 
-1. Introduce a shared search use case only if list, flow, or another non-table
+1. Build/test performance Slice-6 output directory ownership cleanup is
+   deferred until packaging, caching, or stale output issues make it a concrete
+   blocker. PR #222 delivered the other build/test performance slices.
+2. Introduce a shared search use case only if list, flow, or another non-table
    consumer needs common query semantics.
-2. Extend JP1/AJS WebAPI support beyond read-only import only after the initial
+3. Extend JP1/AJS WebAPI support beyond read-only import only after the initial
    boundary, authentication model, and beta feedback are stable.
-3. Revisit viewer-specific bundle-size reductions only if a future
+4. Revisit viewer-specific bundle-size reductions only if a future
    compatibility, startup, or payload target creates stronger pressure.
-4. Replace the custom `UnitEntity` hash implementation only after identity and
+5. Replace the custom `UnitEntity` hash implementation only after identity and
    compatibility checks are refreshed.
-5. Consolidate i18n translation files only when duplication is high enough to
+6. Consolidate i18n translation files only when duplication is high enough to
    justify a targeted cleanup.
-6. Add deeper JP1/AJS View interaction parity only after the current visual
+7. Add deeper JP1/AJS View interaction parity only after the current visual
    refresh and nested expansion behavior settle.
-7. Revisit directory structure under `src/extension/webview/` only if the
+8. Revisit directory structure under `src/extension/webview/` only if the
    remaining files stop reading as one cohesive viewer module.
 
 ## Done Criteria For A Slice

--- a/src/application/unit-list/buildUnitListGroup10View.ts
+++ b/src/application/unit-list/buildUnitListGroup10View.ts
@@ -5,6 +5,7 @@ import {
 } from "../../domain/models/ajs/AjsDocument";
 import type { UnitListGroup10View } from "./buildUnitListView";
 import {
+  buildEffectiveStartConditionMonitoringViews,
   parseCftd,
   parseCy,
   parseLnParentRule,
@@ -12,48 +13,54 @@ import {
   parseSh,
   parseShd,
   parseTimeValue,
-  parseWc,
 } from "./unitListViewHelpers";
 
 export const buildUnitListGroup10View = (
   unit: AjsUnit,
-): UnitListGroup10View => ({
-  deleteAfterExecution: findAjsUnitParameterValue(unit, "de"),
-  executionDate: findAjsUnitParameterValue(unit, "ed"),
-  jobGroupPath: findAjsUnitParameterValue(unit, "jc"),
-  exclusiveJobnetName: findAjsUnitParameterValue(unit, "ejn"),
-  parentRules: unit.isRootJobnet
-    ? []
-    : findAjsUnitParameterValues(unit, "ln").map(parseLnParentRule),
-  scheduleDateTypes: findAjsUnitParameterValues(unit, "sd").map(
-    (value) => parseSd(value).type,
-  ),
-  scheduleDateYearMonths: findAjsUnitParameterValues(unit, "sd").map(
-    (value) => parseSd(value).yearMonth,
-  ),
-  scheduleDateDays: findAjsUnitParameterValues(unit, "sd").map(
-    (value) => parseSd(value).day,
-  ),
-  startTimes: findAjsUnitParameterValues(unit, "st").map((value) =>
-    parseTimeValue(value, "+00:00"),
-  ),
-  cycles: findAjsUnitParameterValues(unit, "cy").map(parseCy),
-  substitutes: findAjsUnitParameterValues(unit, "sh").map(parseSh),
-  shiftDays: findAjsUnitParameterValues(unit, "shd").map(parseShd),
-  scheduleByDaysFromStart: findAjsUnitParameterValues(unit, "cftd").map(
-    (value) => parseCftd(value).scheduleByDaysFromStart,
-  ),
-  maxShiftableDays: findAjsUnitParameterValues(unit, "cftd").map(
-    (value) => parseCftd(value).maxShiftableDays,
-  ),
-  startRangeTimes: findAjsUnitParameterValues(unit, "sy").map((value) =>
-    parseTimeValue(value),
-  ),
-  endRangeTimes: findAjsUnitParameterValues(unit, "ey").map((value) =>
-    parseTimeValue(value),
-  ),
-  waitCounts: findAjsUnitParameterValues(unit, "wc").map(parseWc),
-  waitTimes: findAjsUnitParameterValues(unit, "wt").map((value) =>
-    parseTimeValue(value),
-  ),
-});
+): UnitListGroup10View => {
+  const waitCountValues = findAjsUnitParameterValues(unit, "wc");
+  const waitTimeValues = findAjsUnitParameterValues(unit, "wt");
+  const waitViews = buildEffectiveStartConditionMonitoringViews(
+    waitCountValues,
+    waitTimeValues,
+  );
+
+  return {
+    deleteAfterExecution: findAjsUnitParameterValue(unit, "de"),
+    executionDate: findAjsUnitParameterValue(unit, "ed"),
+    jobGroupPath: findAjsUnitParameterValue(unit, "jc"),
+    exclusiveJobnetName: findAjsUnitParameterValue(unit, "ejn"),
+    parentRules: unit.isRootJobnet
+      ? []
+      : findAjsUnitParameterValues(unit, "ln").map(parseLnParentRule),
+    scheduleDateTypes: findAjsUnitParameterValues(unit, "sd").map(
+      (value) => parseSd(value).type,
+    ),
+    scheduleDateYearMonths: findAjsUnitParameterValues(unit, "sd").map(
+      (value) => parseSd(value).yearMonth,
+    ),
+    scheduleDateDays: findAjsUnitParameterValues(unit, "sd").map(
+      (value) => parseSd(value).day,
+    ),
+    startTimes: findAjsUnitParameterValues(unit, "st").map((value) =>
+      parseTimeValue(value, "+00:00"),
+    ),
+    cycles: findAjsUnitParameterValues(unit, "cy").map(parseCy),
+    substitutes: findAjsUnitParameterValues(unit, "sh").map(parseSh),
+    shiftDays: findAjsUnitParameterValues(unit, "shd").map(parseShd),
+    scheduleByDaysFromStart: findAjsUnitParameterValues(unit, "cftd").map(
+      (value) => parseCftd(value).scheduleByDaysFromStart,
+    ),
+    maxShiftableDays: findAjsUnitParameterValues(unit, "cftd").map(
+      (value) => parseCftd(value).maxShiftableDays,
+    ),
+    startRangeTimes: findAjsUnitParameterValues(unit, "sy").map((value) =>
+      parseTimeValue(value),
+    ),
+    endRangeTimes: findAjsUnitParameterValues(unit, "ey").map((value) =>
+      parseTimeValue(value),
+    ),
+    waitCounts: waitViews.waitCounts,
+    waitTimes: waitViews.waitTimes,
+  };
+};

--- a/src/application/unit-list/unitListViewHelpers.ts
+++ b/src/application/unit-list/unitListViewHelpers.ts
@@ -14,6 +14,7 @@ import {
   parseScheduleDateValue,
   parseShiftDaysValue,
   parseWaitCountValue,
+  resolveEffectiveStartConditionMonitoringPair,
 } from "../../domain/models/parameters/scheduleRuleHelpers";
 import { WeekSymbol, isWeekSymbol } from "../../domain/values/AjsType";
 
@@ -173,3 +174,24 @@ export const parseCftd = (
 
 export const parseWc = (value: string): string =>
   parseWaitCountValue(value)?.value ?? "1";
+
+export const buildEffectiveStartConditionMonitoringViews = (
+  waitCountValues: string[],
+  waitTimeValues: string[],
+): { waitCounts: string[]; waitTimes: string[] } => {
+  const pairCount = Math.max(waitCountValues.length, waitTimeValues.length);
+  const waitCounts: string[] = [];
+  const waitTimes: string[] = [];
+
+  for (let index = 0; index < pairCount; index += 1) {
+    const effectivePair = resolveEffectiveStartConditionMonitoringPair(
+      waitCountValues[index],
+      waitTimeValues[index],
+    );
+
+    waitCounts.push(effectivePair.numberOfTimes ?? "");
+    waitTimes.push(effectivePair.time ?? "");
+  }
+
+  return { waitCounts, waitTimes };
+};

--- a/src/test/suite/buildUnitListGroup10View.test.ts
+++ b/src/test/suite/buildUnitListGroup10View.test.ts
@@ -51,6 +51,19 @@ unit=root,,jp1admin,;
 }
 `;
 
+const startConditionMonitoringDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  wc=4;
+  wt=no;
+  wc=2,no;
+  wt=2,01:00;
+  wc=3,un;
+  wt=3,un;
+}
+`;
+
 suite("Build Unit List Group 10 View", () => {
   test("projects schedule-related group10 fields from unit parameters", () => {
     const result = parseAjs(definition);
@@ -118,5 +131,17 @@ suite("Build Unit List Group 10 View", () => {
 
     assert.deepStrictEqual(buildUnitListGroup10View(jobnet).parentRules, []);
     assert.deepStrictEqual(buildUnitListGroup10View(subnet).parentRules, ["2"]);
+  });
+
+  test("projects effective start-condition monitoring pairs", () => {
+    const result = parseAjs(startConditionMonitoringDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const root = document.rootUnits[0];
+
+    const view = buildUnitListGroup10View(root);
+
+    assert.deepStrictEqual(view.waitCounts, ["", "", "un"]);
+    assert.deepStrictEqual(view.waitTimes, ["", "", "un"]);
   });
 });


### PR DESCRIPTION
## Summary

- make unit-list group 10 wc/wt start-condition columns consume existing effective pairing semantics
- add focused regression coverage for disabled and valid wc/wt pairs
- update SDD plans, roadmap, use case, and parameter coverage records

## Impact

Definitions where one side of a wc/wt pair disables start-condition monitoring now show empty effective values in the table viewer. Parser output, raw domain wrapper values, normalized raw parameter storage, generated artifacts, dependencies, and engines.vscode remain unchanged.

## Validation

- pnpm run test:compile
- npm test
- npm run test:web
- npm run build (passed with existing webpack asset-size warnings)
- pnpm run lint:md
- pnpm run qlty