### PR TITLE
[codex] Align event send group14 projection

### DIFF
--- a/docs/requirements/use-cases/uc-build-unit-list-view.md
+++ b/docs/requirements/use-cases/uc-build-unit-list-view.md
@@ -56,6 +56,12 @@ Scenario: Desktop and web viewers share the row shape
   Given a normalized JP1/AJS document
   When table row view models are built
   Then desktop and web viewers can consume the same row shape
+
+Scenario: JP1 event sending job arrival-check defaults are projected
+  Given a normalized JP1/AJS document with a JP1 event sending job
+  When table row view models are built
+  Then omitted group 14 arrival-check values display their JP1/AJS defaults
+  And explicit group 14 arrival-check values remain visible
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
@@ -48,6 +48,9 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
   `evsrc` from normalized unit parameters by key, so a default change in the
   domain wrapper path does not automatically change normalized list projection
   unless that path is intentionally updated.
+- Unit-list group 14 projection is now the next approval-gated behavior
+  candidate because the domain wrapper defaults are implemented, but the table
+  viewer still displays empty cells for omitted arrival-check parameters.
 
 ## Expected Behavior If Approved
 
@@ -68,6 +71,10 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
   `Evsj`; `Revsj` receives the same behavior through inheritance.
 - Normalized unit-list projection remains raw key/value projection and does not
   synthesize omitted event sending job defaults.
+- Unit-list group 14 JP1 event sending job arrival-check projection now
+  displays the existing domain defaults for omitted `evssv`, `evsrt`,
+  `evspl`, and `evsrc` values. Explicit normalized values remain preserved,
+  and non-event-sending jobs do not synthesize these defaults.
 
 ## Alternatives
 
@@ -81,10 +88,38 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 
 ## Follow-up
 
-- Decide whether normalized unit-list projection should display JP1 event
-  sending job defaults or continue showing only explicit normalized
-  parameters.
 - Revisit `evhst` requiredness when `evsrt=y` only after diagnostics behavior
   is explicitly scoped.
 - Add range validation for `evspl` and `evsrc` only after invalid JP1/AJS
   parameter handling is defined across domain and diagnostics.
+
+## Unit-List Group 14 Projection Candidate
+
+- Planned change:
+  make group 14 JP1 event sending job arrival-check columns consume existing
+  domain default semantics for omitted `evssv`, `evsrt`, `evspl`, and
+  `evsrc`, while preserving explicit normalized values.
+- Affected files:
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`,
+  `src/application/unit-list/buildUnitListView.ts` only if helper typing
+  changes, focused unit-list tests, this document, `SPECS.md`, `TASKS.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, and branch-level `docs/specs/plans.md`.
+- Affected features:
+  JP1/AJS table viewer group 14 action job definition columns; build-unit-list
+  application use case; JP1 event sending job parameter interpretation.
+- Tests affected:
+  focused `buildUnitListRemainingGroups` or `buildUnitListView` regression
+  evidence for omitted and explicit `evssv`, `evsrt`, `evspl`, and `evsrc`.
+- Breaking-change risk:
+  medium. This intentionally changes user-visible table output for definitions
+  that omit JP1 event sending job arrival-check parameters. Raw parser output
+  and normalized key/value storage remain unchanged.
+- Alternatives considered:
+  keep group 14 raw by design and leave the matrix gap visible; add separate
+  raw and default-aware columns, rejected for this slice because it expands UI
+  and localization scope; add diagnostics for `evhst` requiredness or numeric
+  ranges first, deferred because diagnostics policy is a separate behavior
+  contract.
+- Approval:
+  human approval to proceed was given on 2026-04-29 after the investigation
+  summary for unit-list group 14 default-aware projection.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -99,8 +99,8 @@ coverage.
   `Defaults.ts`
 - Evidence: `parameterFactory.test.ts` and `buildUnitListView.test.ts`
 - Remaining gap:
-  unit-list projection remains raw; `evhst` requiredness and range validation
-  are deferred
+  unit-list group 14 default-aware projection is aligned for these defaults;
+  `evhst` requiredness and range validation are deferred
 
 ## Boundary Decisions
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -66,6 +66,12 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   approval-gated behavior candidate after domain-only pairing.
 - Implemented unit-list group 10 projection for effective `wc` / `wt` values
   while preserving raw parser, wrapper, and normalized parameter values.
+- Investigated JP1 event sending job unit-list group 14 projection for
+  default-aware `evssv`, `evsrt`, `evspl`, and `evsrc` values as the next
+  approval-gated behavior candidate after the group 10 slice.
+- Implemented unit-list group 14 projection for JP1 event sending job
+  arrival-check defaults while preserving explicit normalized values and raw
+  storage.
 
 ## Impact Investigation
 
@@ -253,6 +259,48 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 - Approval:
   human approval to proceed was given on 2026-04-29 after the investigation
   summary for unit-list group 10 effective `wc` / `wt` projection.
+
+### JP1 Event Sending Job Group 14 Projection Candidate
+
+- Planned change:
+  change unit-list group 14 JP1 event sending job arrival-check projection to
+  display existing domain defaults for omitted `evssv`, `evsrt`, `evspl`, and
+  `evsrc`, while preserving explicit normalized values.
+- Affected files:
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`,
+  `src/application/unit-list/buildUnitListView.ts` only if helper typing
+  changes, `src/test/suite/buildUnitListRemainingGroups.test.ts` or
+  `src/test/suite/buildUnitListView.test.ts`, `EVENT_SEND_JOB_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `TASKS.md`, and branch-level
+  `docs/specs/plans.md`.
+- Affected functions/classes/components:
+  `buildUnitListRemainingGroups`, `UnitListGroup14View.actionSeverity`,
+  `UnitListGroup14View.actionStartType`,
+  `UnitListGroup14View.actionInterval`,
+  `UnitListGroup14View.actionCount`, and the group 14 table columns that
+  render those DTO fields.
+- Affected features:
+  JP1/AJS table viewer group 14 action job definition columns;
+  build-unit-list application use case; JP1 event sending job parameter
+  interpretation.
+- Tests affected:
+  focused unit-list tests for omitted event sending job arrival-check
+  parameters and explicit value preservation; existing `parameterFactory`
+  default tests should continue to pass unchanged.
+- Breaking-change risk:
+  medium. This intentionally changes user-visible table output for definitions
+  where JP1 event sending job `evssv`, `evsrt`, `evspl`, or `evsrc` are
+  omitted. Raw parser output, raw domain wrapper values, and normalized
+  key/value storage remain unchanged.
+- Alternatives considered:
+  keep group 14 raw by design and leave the matrix gap visible; add separate
+  raw and default-aware columns, rejected for this slice because it expands UI
+  and localization scope; prioritize `evhst` requiredness diagnostics first,
+  deferred until editor-feedback behavior explicitly owns cross-parameter
+  diagnostics.
+- Approval:
+  human approval to proceed was given on 2026-04-29 after the investigation
+  summary for unit-list group 14 default-aware projection.
 
 ## Follow-up
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -72,6 +72,11 @@ JP1/AJS3 version 13 reference documents.
   If approved, it should consume the existing paired effective-value semantics
   while preserving parser output, raw domain wrapper values, and normalized raw
   parameter storage.
+- JP1 event sending job unit-list group 14 projection is a separate
+  approval-sensitive boundary from domain defaults because it is user-visible
+  table output. If approved, it should consume the existing wrapper/default
+  semantics for `evssv`, `evsrt`, `evspl`, and `evsrc` while preserving parser
+  output and normalized raw parameter storage.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -90,6 +90,13 @@
 - [x] Implement group 10 effective `wc` / `wt` projection only after approval
 - [x] Add focused group 10 regression evidence for disabled and valid pairs
 - [x] Run required code-change validation after implementation
+- [x] Investigate unit-list group 14 projection for JP1 event sending job
+      arrival-check defaults as a separate behavior slice
+- [x] Record human approval before changing unit-list group 14 projection
+- [x] Implement group 14 default-aware projection only after approval
+- [x] Add focused group 14 regression evidence for omitted defaults and
+      explicit value preservation
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -203,28 +210,49 @@
   existing effective pairing semantics. Disabled pairs display empty
   start-condition monitoring values, valid pairs remain visible, and raw
   parser/domain/normalized values remain unchanged.
+- 2026-04-29: unit-list group 14 JP1 event sending job projection is the next
+  approval-gated behavior candidate. The proposed scope is limited to table
+  DTO projection using the existing domain defaults for omitted `evssv`,
+  `evsrt`, `evspl`, and `evsrc`; parser grammar, raw domain wrappers,
+  normalized raw parameter storage, diagnostics, generated artifacts,
+  configuration, dependency versions, and `engines.vscode` remain out of
+  scope.
+- 2026-04-29: unit-list group 14 JP1 event sending job projection now consumes
+  existing defaults for omitted `evssv`, `evsrt`, `evspl`, and `evsrc`.
+  Explicit normalized values remain visible, non-event-sending jobs do not
+  synthesize these defaults, and raw parser/domain/normalized values remain
+  unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-04-29
-- Approved scope: User replied "OK.Proceed." after the unit-list group 10
-  effective projection approval request. Approved changes are limited to
-  making group 10 `wc` / `wt` schedule-rule start-condition columns consume
-  existing effective pairing semantics, adding focused regression evidence,
+- Approved scope: User replied "OK.Proceed." after the unit-list group 14 JP1
+  event sending job default-aware projection approval request. Approved
+  changes are limited to making group 14 `evssv`, `evsrt`, `evspl`, and
+  `evsrc` arrival-check columns consume existing domain defaults for omitted
+  values, preserving explicit values, adding focused regression evidence,
   updating SDD tracking, and running validation. Parser grammar, raw domain
   wrappers, normalized raw parameter storage, diagnostics, generated artifacts,
   configuration, dependency versions, and `engines.vscode` changes are out of
   scope.
 
-Current implementation gate: unit-list group 10 effective projection for
-schedule-rule `wc` / `wt` pairing.
+Current implementation gate: unit-list group 14 default-aware projection for
+JP1 event sending job arrival-check defaults.
 
 Implementation must not start while Status is Pending.
 Only clear human approval can change Status to Approved.
 
 ## Prior Approval Evidence
 
+- 2026-04-29: Approved unit-list group 10 effective projection for
+  schedule-rule `wc` / `wt` pairing. Approved changes were limited to making
+  group 10 `wc` / `wt` schedule-rule start-condition columns consume existing
+  effective pairing semantics, adding focused regression evidence, updating
+  SDD tracking, and running validation. Parser grammar, raw domain wrappers,
+  normalized raw parameter storage, diagnostics, generated artifacts,
+  configuration, dependency versions, and `engines.vscode` changes were out of
+  scope.
 - 2026-04-29: Approved domain-only effective-value helper/tests for
   schedule-rule `wc` / `wt` pairing, keeping raw normalized unit-list
   projection unchanged. Parser grammar, command generation, validation
@@ -251,6 +279,14 @@ Only clear human approval can change Status to Approved.
 
 ## Validation
 
+- 2026-04-29: `pnpm run test:compile`
+- 2026-04-29: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
+- 2026-04-29: `npm test`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-04-29: `pnpm run lint:md`
 - 2026-04-29: `pnpm run test:compile`
 - 2026-04-29: `npm test`
 - 2026-04-29: `npm run test:web`

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -31,8 +31,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Continue category-level parameter parsing alignment by selecting the next
-   focused behavior contract and recording approval before implementation.
+1. Prepare JP1 event sending job unit-list group 14 projection as the next
+   focused parameter-alignment behavior contract, then record approval before
+   implementation.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime
@@ -40,27 +41,31 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: not created for implementation while approval is pending.
+- Branch: `codex/event-send-group14-projection`.
 - Objective: continue the JP1/AJS3 v13 parameter alignment feature with a
-  focused unit-list projection slice for schedule-rule `wc` / `wt` effective
-  start-condition monitoring values.
-- Status: build/test performance PR #222 is merged with successful CI. The
-  current slice implements unit-list group 10 projection for the already
-  implemented domain effective `wc` / `wt` pairing.
-- Scope: update SDD records and request approval for changing unit-list
-  projection from raw independent `wc` / `wt` values to paired effective values
-  for the group 10 start-condition columns.
+  focused unit-list projection slice for JP1 event sending job group 14
+  arrival-check defaults.
+- Status: schedule-rule `wc` / `wt` domain pairing and group 10 projection are
+  delivered. Unit-list group 14 now consumes the existing JP1 event sending job
+  arrival-check defaults after approval.
+- Scope: make group 14 JP1 event sending job arrival-check columns display
+  existing domain defaults for omitted `evssv`, `evsrt`, `evspl`, and
+  `evsrc` values.
 - Out of scope: parser grammar changes, command generation, diagnostics,
-  generated artifacts, dependency changes, `engines.vscode`, and broader
-  schedule-rule range validation.
+  generated artifacts, dependency changes, `engines.vscode`, JP1 event
+  destination host requiredness, byte-length validation, numeric range
+  validation, and broader raw projection policy changes.
 - Impact summary: the candidate affects
-  `src/application/unit-list/buildUnitListGroup10View.ts`,
-  `src/application/unit-list/unitListViewHelpers.ts`, group 10 unit-list
-  regression tests, and the schedule-rule SDD documents.
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`,
+  `src/application/unit-list/buildUnitListView.ts` DTO fields only if helper
+  typing requires it, focused unit-list regression tests, and the JP1 event
+  sending job SDD documents. Existing domain default behavior in
+  `ParamFactory.evssv`, `ParamFactory.evsrt`, `ParamFactory.evspl`, and
+  `ParamFactory.evsrc` should be reused rather than changed.
 - Risks and assumptions: behavior changes are user-visible in the table viewer
-  because paired values such as `wc=4` with `wt=no` would display as empty
-  effective start-condition monitoring values instead of raw independent
-  values. Raw parameter parsing and domain wrapper raw values remain preserved.
+  because omitted group 14 arrival-check fields would display defaults instead
+  of empty cells. Raw parser output and normalized parameter storage remain
+  preserved.
 
 ## Build/Test Performance SDD
 
@@ -89,8 +94,7 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: unit-list group 10 projection for effective schedule-rule `wc` /
-  `wt` pairing.
+  slice: JP1 event sending job unit-list group 14 default-aware projection.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:
@@ -117,3 +121,11 @@ Current branch checks:
   warnings
 - 2026-04-29: `pnpm run lint:md`
 - 2026-04-29: `pnpm run qlty`
+- 2026-04-29: `pnpm run test:compile`
+- 2026-04-29: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
+- 2026-04-29: `npm test`
+- 2026-04-29: `npm run test:web`
+- 2026-04-29: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-04-29: `pnpm run lint:md`

--- a/src/application/unit-list/buildUnitListRemainingGroups.ts
+++ b/src/application/unit-list/buildUnitListRemainingGroups.ts
@@ -2,6 +2,8 @@ import {
   AjsUnit,
   findAjsUnitParameterValue,
 } from "../../domain/models/ajs/AjsDocument";
+import { DEFAULTS } from "../../domain/models/parameters/Defaults";
+import type { ParamSymbol } from "../../domain/values/AjsType";
 import type {
   UnitListGroup1View,
   UnitListGroup2View,
@@ -20,6 +22,18 @@ import type {
   UnitListGroup19View,
   UnitListLinkedUnitView,
 } from "./buildUnitListView";
+
+const isEventSendingJob = (unit: AjsUnit): boolean =>
+  unit.unitType === "evsj" || unit.unitType === "revsj";
+
+const findEventSendingJobDefaultAwareParameterValue = (
+  unit: AjsUnit,
+  key: ParamSymbol,
+  defaultValue: string,
+): string | undefined =>
+  isEventSendingJob(unit)
+    ? (findAjsUnitParameterValue(unit, key) ?? defaultValue)
+    : findAjsUnitParameterValue(unit, key);
 
 export const buildUnitListRemainingGroups = (
   unit: AjsUnit,
@@ -138,10 +152,26 @@ export const buildUnitListRemainingGroups = (
     actionEventId: findAjsUnitParameterValue(unit, "evsid"),
     actionHostName: findAjsUnitParameterValue(unit, "evhst"),
     actionMessage: findAjsUnitParameterValue(unit, "evsms"),
-    actionSeverity: findAjsUnitParameterValue(unit, "evssv"),
-    actionStartType: findAjsUnitParameterValue(unit, "evsrt"),
-    actionInterval: findAjsUnitParameterValue(unit, "evspl"),
-    actionCount: findAjsUnitParameterValue(unit, "evsrc"),
+    actionSeverity: findEventSendingJobDefaultAwareParameterValue(
+      unit,
+      "evssv",
+      DEFAULTS.Evssv,
+    ),
+    actionStartType: findEventSendingJobDefaultAwareParameterValue(
+      unit,
+      "evsrt",
+      DEFAULTS.Evsrt,
+    ),
+    actionInterval: findEventSendingJobDefaultAwareParameterValue(
+      unit,
+      "evspl",
+      DEFAULTS.Evspl,
+    ),
+    actionCount: findEventSendingJobDefaultAwareParameterValue(
+      unit,
+      "evsrc",
+      DEFAULTS.Evsrc,
+    ),
     platformMethod: findAjsUnitParameterValue(unit, "pfm"),
   },
   group15: {

--- a/src/test/suite/buildUnitListRemainingGroups.test.ts
+++ b/src/test/suite/buildUnitListRemainingGroups.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import { parseAjs } from "../../domain/services/parser/AjsParser";
 import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
+import { DEFAULTS } from "../../domain/models/parameters/Defaults";
 import { buildUnitListRemainingGroups } from "../../application/unit-list/buildUnitListRemainingGroups";
 
 const definition = `
@@ -40,6 +41,29 @@ unit=root,,jp1admin,;
   {
     ty=rc;
     cond="AJSROOT" = "ready";
+  }
+}
+`;
+
+const eventSendingJobDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  unit=event-defaults,,jp1admin,;
+  {
+    ty=evsj;
+  }
+  unit=event-explicit,,jp1admin,;
+  {
+    ty=revsj;
+    evssv=wr;
+    evsrt=y;
+    evspl=5;
+    evsrc=7;
+  }
+  unit=regular-job,,jp1admin,;
+  {
+    ty=j;
   }
 }
 `;
@@ -106,5 +130,37 @@ suite("Build Unit List Remaining Groups", () => {
       startConditionView.group9.startCondition,
       '"AJSROOT" = "ready"',
     );
+  });
+
+  test("projects JP1 event sending job arrival-check defaults for group 14", () => {
+    const result = parseAjs(eventSendingJobDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const eventDefaults = document.rootUnits[0]?.children[0];
+    const eventExplicit = document.rootUnits[0]?.children[1];
+    const regularJob = document.rootUnits[0]?.children[2];
+
+    assert.ok(eventDefaults);
+    assert.ok(eventExplicit);
+    assert.ok(regularJob);
+
+    const defaultView = buildUnitListRemainingGroups(eventDefaults, [], []);
+    const explicitView = buildUnitListRemainingGroups(eventExplicit, [], []);
+    const regularView = buildUnitListRemainingGroups(regularJob, [], []);
+
+    assert.strictEqual(defaultView.group14.actionSeverity, DEFAULTS.Evssv);
+    assert.strictEqual(defaultView.group14.actionStartType, DEFAULTS.Evsrt);
+    assert.strictEqual(defaultView.group14.actionInterval, DEFAULTS.Evspl);
+    assert.strictEqual(defaultView.group14.actionCount, DEFAULTS.Evsrc);
+
+    assert.strictEqual(explicitView.group14.actionSeverity, "wr");
+    assert.strictEqual(explicitView.group14.actionStartType, "y");
+    assert.strictEqual(explicitView.group14.actionInterval, "5");
+    assert.strictEqual(explicitView.group14.actionCount, "7");
+
+    assert.strictEqual(regularView.group14.actionSeverity, undefined);
+    assert.strictEqual(regularView.group14.actionStartType, undefined);
+    assert.strictEqual(regularView.group14.actionInterval, undefined);
+    assert.strictEqual(regularView.group14.actionCount, undefined);
   });
 });


### PR DESCRIPTION
## Summary

- Project JP1 event sending job group 14 arrival-check defaults for omitted evssv, evsrt, evspl, and evsrc values.
- Preserve explicit group 14 values and avoid synthesizing defaults for non-event-sending jobs.
- Update SDD and use-case docs with the approved behavior slice, impact, approval evidence, and validation record.

## Validation

- pnpm run test:compile
- pnpm run qlty
- npm test
- npm run test:web
- npm run build (completed with existing webpack asset-size warnings)
- pnpm run lint:md