### PR TITLE
[codex] Align file monitoring group13 projection

### DIFF
--- a/docs/requirements/use-cases/uc-build-unit-list-view.md
+++ b/docs/requirements/use-cases/uc-build-unit-list-view.md
@@ -62,6 +62,12 @@ Scenario: JP1 event sending job arrival-check defaults are projected
   When table row view models are built
   Then omitted group 14 arrival-check values display their JP1/AJS defaults
   And explicit group 14 arrival-check values remain visible
+
+Scenario: File monitoring job defaults are projected
+  Given a normalized JP1/AJS document with a file monitoring job
+  When table row view models are built
+  Then omitted group 13 file monitoring values display their JP1/AJS defaults
+  And explicit group 13 file monitoring values remain visible
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/FILE_MONITORING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/FILE_MONITORING_JOB_ALIGNMENT.md
@@ -1,0 +1,91 @@
+# File Monitoring Job Alignment
+
+## Purpose
+
+Record the JP1/AJS3 version 13 alignment slice for file monitoring job
+defaults and unit-list projection behavior.
+
+This document focuses on the currently modeled file monitoring job parameters
+`flwf`, `flwc`, `flwi`, `flco`, and `ets` for `Flwj` / `Rflwj`.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual section: Command Reference, `5.2.10 File monitoring job definition`
+- Source URL:
+  <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0225.HTM>
+
+## Slice Boundary
+
+- Domain seams:
+  `src/domain/models/units/Flwj.ts`,
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`, and
+  `src/domain/models/parameters/Defaults.ts`
+- Existing consumers:
+  `src/domain/models/units/Flwj.ts`,
+  `src/domain/models/units/Rflwj.ts`, and
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`
+- Regression evidence:
+  `src/test/suite/parameterFactory.test.ts` if domain defaults change, and
+  focused `src/test/suite/buildUnitListRemainingGroups.test.ts` or
+  `src/test/suite/buildUnitListView.test.ts` evidence if projection changes
+- Out of scope:
+  parser grammar changes, command generation, byte-length validation,
+  wildcard validation, numeric range validation, `flwc` invalid-combination
+  diagnostics, timeout behavior, generated artifacts, configuration,
+  dependency versions, and `engines.vscode`
+
+## Investigation Notes
+
+- `Flwj` / `Rflwj` expose `flwf`, `flwc`, `flwi`, `flco`, and `ets` through
+  `ParamFactory`.
+- `DEFAULTS.Flwc`, `DEFAULTS.Flwi`, `DEFAULTS.Flco`, and `DEFAULTS.Ets`
+  already match the manual defaults for file monitoring condition, monitoring
+  interval, close-mode handling, and timeout action.
+- `flwf` has no default and should remain raw/optional.
+- `buildUnitListRemainingGroups.ts` projects group 13 file monitoring columns
+  from normalized unit parameters by key, so existing domain defaults do not
+  appear in the table viewer unless this projection boundary is intentionally
+  updated.
+- `ParamFactory.ets` is shared by multiple event/wait job wrappers, so any
+  change to the generic default path would affect more than file monitoring
+  jobs. The proposed slice should reuse the existing default only at the group
+  13 projection boundary for `Flwj` / `Rflwj`.
+
+## Delivered Alignment
+
+- Unit-list group 13 file monitoring job projection now displays the existing
+  domain defaults for omitted `flwc`, `flwi`, `flco`, and `ets` values.
+- Explicit normalized values remain preserved.
+- Omitted `flwf` remains empty because no monitored-file-name default exists.
+- Non-file-monitoring jobs do not synthesize these file monitoring defaults.
+
+## Expected Behavior If Approved
+
+- Explicit file monitoring job `flwc`, `flwi`, `flco`, and `ets` values remain
+  visible in group 13.
+- Omitted file monitoring job `flwc`, `flwi`, `flco`, and `ets` values display
+  their existing JP1/AJS defaults in group 13.
+- Omitted `flwf` remains empty because the manual does not define a default
+  monitored file name.
+- Non-file-monitoring jobs do not synthesize file monitoring defaults in group 13.
+- Raw parser output, raw domain wrapper values, and normalized key/value
+  storage remain unchanged.
+
+## Alternatives
+
+- Keep group 13 raw by design and leave the matrix gap visible.
+- Add separate raw and default-aware columns; rejected for this slice because
+  it expands UI and localization scope.
+- Change domain defaults or introduce a new file-monitoring helper seam;
+  deferred because existing default values already match the manual and the
+  behavior gap is projection-only.
+- Add diagnostics for `flwc` invalid combinations, wildcard restrictions, or
+  numeric ranges first; deferred because diagnostics policy is a separate
+  behavior contract.
+
+## Follow-up
+
+- Revisit `flwc` invalid combinations, `flwi` range validation, wildcard
+  restrictions, and `flco` pairing diagnostics only after editor-feedback
+  behavior explicitly owns invalid JP1/AJS parameter handling.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -102,6 +102,21 @@ coverage.
   unit-list group 14 default-aware projection is aligned for these defaults;
   `evhst` requiredness and range validation are deferred
 
+### File Monitoring Job Defaults
+
+- Keys: `flwf`, `flwc`, `flwi`, `flco`, and `ets`
+- Unit scope: file monitoring jobs and recovery file monitoring jobs
+- Status: partial
+- Owning seam: `Flwj.ts`, `optionalScalarParameterBuilders.ts`, and
+  `Defaults.ts`
+- Evidence:
+  `parameterFactory.test.ts` for existing domain default seams and
+  `buildUnitListRemainingGroups.test.ts` for group 13 projection
+- Remaining gap:
+  unit-list group 13 default-aware projection is aligned for these defaults;
+  `flwc` invalid-combination diagnostics, wildcard restrictions, byte-length
+  validation, and range validation are deferred
+
 ## Boundary Decisions
 
 - This matrix covers only categories with feature-local investigation records.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -72,6 +72,11 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 - Implemented unit-list group 14 projection for JP1 event sending job
   arrival-check defaults while preserving explicit normalized values and raw
   storage.
+- Investigated file monitoring job unit-list group 13 projection for
+  default-aware `flwc`, `flwi`, `flco`, and `ets` values as the next
+  approval-gated behavior candidate after the group 14 slice.
+- Implemented unit-list group 13 projection for file monitoring job defaults
+  while preserving explicit normalized values and raw storage.
 
 ## Impact Investigation
 
@@ -302,6 +307,52 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   human approval to proceed was given on 2026-04-29 after the investigation
   summary for unit-list group 14 default-aware projection.
 
+### File Monitoring Job Group 13 Projection Candidate
+
+- Planned change:
+  change unit-list group 13 file monitoring job projection to display existing
+  domain defaults for omitted `flwc`, `flwi`, `flco`, and `ets`, while
+  preserving explicit normalized values.
+- Affected files:
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`,
+  `src/application/unit-list/buildUnitListView.ts` only if helper typing
+  changes, `src/test/suite/buildUnitListRemainingGroups.test.ts` or
+  `src/test/suite/buildUnitListView.test.ts`,
+  `FILE_MONITORING_JOB_ALIGNMENT.md`, `PARAMETER_COVERAGE_MATRIX.md`,
+  `SPECS.md`, `TASKS.md`, `docs/requirements/use-cases/uc-build-unit-list-view.md`,
+  and branch-level `docs/specs/plans.md`.
+- Affected functions/classes/components:
+  `buildUnitListRemainingGroups`,
+  `UnitListGroup13View.monitoredFileCondition`,
+  `UnitListGroup13View.monitoredFileCloseMode`,
+  `UnitListGroup13View.monitoringInterval`,
+  `UnitListGroup13View.eventTimeoutAction`, and the group 13 table columns
+  that render those DTO fields.
+- Affected features:
+  JP1/AJS table viewer group 13 event job definition columns;
+  build-unit-list application use case; file monitoring job parameter
+  interpretation.
+- Tests affected:
+  focused unit-list tests for omitted file monitoring job defaults and
+  explicit value preservation; existing domain default behavior should
+  continue to pass unchanged.
+- Breaking-change risk:
+  medium. This intentionally changes user-visible table output for definitions
+  where file monitoring job `flwc`, `flwi`, `flco`, or `ets` are omitted. Raw
+  parser output, raw domain wrapper values, and normalized key/value storage
+  remain unchanged.
+- Alternatives considered:
+  keep group 13 raw by design and leave the matrix gap visible; add separate
+  raw and default-aware columns, rejected for this slice because it expands UI
+  and localization scope; change domain defaults or add a file-monitoring
+  helper seam, deferred because the behavior gap is projection-only; prioritize
+  diagnostics for `flwc` invalid combinations, wildcard restrictions, or
+  numeric ranges first, deferred until editor-feedback behavior explicitly
+  owns invalid JP1/AJS parameter handling.
+- Approval:
+  human approval to proceed was given on 2026-05-01 after the investigation
+  summary for unit-list group 13 default-aware projection.
+
 ## Follow-up
 
 - Apply the same value parsing audit/refactor workflow to other parameter
@@ -317,6 +368,9 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   behavior.
 - Revisit JP1 event sending job `evhst` requiredness when `evsrt=y` after the
   diagnostics behavior contract is explicit.
+- Revisit file monitoring job `flwc` invalid combinations, `flwi` range
+  validation, wildcard restrictions, and `flco` pairing diagnostics after the
+  editor-feedback behavior contract is explicit.
 
 ## Validation
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -77,6 +77,11 @@ JP1/AJS3 version 13 reference documents.
   table output. If approved, it should consume the existing wrapper/default
   semantics for `evssv`, `evsrt`, `evspl`, and `evsrc` while preserving parser
   output and normalized raw parameter storage.
+- File monitoring job unit-list group 13 projection is a separate
+  approval-sensitive boundary from domain defaults because it is user-visible
+  table output. If approved, it should consume the existing wrapper/default
+  semantics for `flwc`, `flwi`, `flco`, and `ets` while preserving parser
+  output and normalized raw parameter storage.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -97,6 +97,14 @@
 - [x] Add focused group 14 regression evidence for omitted defaults and
       explicit value preservation
 - [x] Run required code-change validation after implementation
+- [x] Investigate unit-list group 13 projection for file monitoring job
+      defaults as a separate behavior slice
+- [x] Record human approval before changing unit-list group 13 projection
+- [x] Implement group 13 file monitoring default-aware projection only after
+      approval
+- [x] Add focused group 13 regression evidence for omitted defaults and
+      explicit value preservation
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -222,29 +230,47 @@
   Explicit normalized values remain visible, non-event-sending jobs do not
   synthesize these defaults, and raw parser/domain/normalized values remain
   unchanged.
+- 2026-05-01: unit-list group 13 file monitoring job projection is the next
+  approval-gated behavior candidate. The proposed scope is limited to table
+  DTO projection using the existing domain defaults for omitted `flwc`,
+  `flwi`, `flco`, and `ets`; parser grammar, raw domain wrappers, normalized
+  raw parameter storage, diagnostics, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` remain out of scope.
+- 2026-05-01: unit-list group 13 file monitoring job projection now consumes
+  existing defaults for omitted `flwc`, `flwi`, `flco`, and `ets`. Explicit
+  normalized values remain visible, omitted `flwf` remains empty,
+  non-file-monitoring jobs do not synthesize these defaults, and raw
+  parser/domain/normalized values remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
-- Approved at: 2026-04-29
-- Approved scope: User replied "OK.Proceed." after the unit-list group 14 JP1
-  event sending job default-aware projection approval request. Approved
-  changes are limited to making group 14 `evssv`, `evsrt`, `evspl`, and
-  `evsrc` arrival-check columns consume existing domain defaults for omitted
-  values, preserving explicit values, adding focused regression evidence,
-  updating SDD tracking, and running validation. Parser grammar, raw domain
-  wrappers, normalized raw parameter storage, diagnostics, generated artifacts,
-  configuration, dependency versions, and `engines.vscode` changes are out of
-  scope.
+- Approved at: 2026-05-01
+- Approved scope: User replied "OK.Proceed." after the unit-list group 13 file
+  monitoring job default-aware projection approval request. Approved changes
+  are limited to making group 13 `flwc`, `flwi`, `flco`, and `ets` columns
+  consume existing domain defaults for omitted values, preserving explicit
+  values, adding focused regression evidence, updating SDD tracking, and
+  running validation. Parser grammar, raw domain wrappers, normalized raw
+  parameter storage, diagnostics, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` changes are out of scope.
 
-Current implementation gate: unit-list group 14 default-aware projection for
-JP1 event sending job arrival-check defaults.
+Current implementation gate: unit-list group 13 default-aware projection for
+file monitoring job defaults.
 
 Implementation must not start while Status is Pending.
 Only clear human approval can change Status to Approved.
 
 ## Prior Approval Evidence
 
+- 2026-04-29: Approved unit-list group 14 default-aware projection for JP1
+  event sending job arrival-check defaults. Approved changes were limited to
+  making group 14 `evssv`, `evsrt`, `evspl`, and `evsrc` arrival-check
+  columns consume existing domain defaults for omitted values, preserving
+  explicit values, adding focused regression evidence, updating SDD tracking,
+  and running validation. Parser grammar, raw domain wrappers, normalized raw
+  parameter storage, diagnostics, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` changes were out of scope.
 - 2026-04-29: Approved unit-list group 10 effective projection for
   schedule-rule `wc` / `wt` pairing. Approved changes were limited to making
   group 10 `wc` / `wt` schedule-rule start-condition columns consume existing
@@ -279,6 +305,14 @@ Only clear human approval can change Status to Approved.
 
 ## Validation
 
+- 2026-05-01: `pnpm run test:compile`
+- 2026-05-01: `pnpm run qlty`
+- 2026-05-01: `npm test`
+- 2026-05-01: `npm run test:web` completed with exit code 0 and shutdown-time
+  `ECONNRESET` / premature-close noise
+- 2026-05-01: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-01: `pnpm run lint:md`
 - 2026-04-29: `pnpm run test:compile`
 - 2026-04-29: `pnpm run qlty` required an escalated rerun after a sandboxed
   log-file permission failure

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -18,8 +18,8 @@ rules in `docs/specs/README.md`, not in this file.
   parsing against the official format before claiming the category aligned. A
   feature-local parameter coverage matrix now tracks the investigated
   categories without claiming repository-wide coverage. Schedule-rule
-  `wc` / `wt` effective-value pairing is aligned in the domain boundary while
-  unit-list projection remains raw.
+  `wc` / `wt` effective-value pairing is aligned in the domain boundary and
+  unit-list projection.
 - Read-only JP1/AJS WebAPI import stays beta until real JP1/AJS3 environment
   smoke verification and enough user feedback are recorded. Beta exit is
   feedback-gated and is not the next active implementation priority.
@@ -31,7 +31,7 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Prepare JP1 event sending job unit-list group 14 projection as the next
+1. Prepare file monitoring job unit-list group 13 projection as the next
    focused parameter-alignment behavior contract, then record approval before
    implementation.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
@@ -41,31 +41,30 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/event-send-group14-projection`.
+- Branch: `codex/file-monitoring-group13-projection`.
 - Objective: continue the JP1/AJS3 v13 parameter alignment feature with a
-  focused unit-list projection slice for JP1 event sending job group 14
-  arrival-check defaults.
-- Status: schedule-rule `wc` / `wt` domain pairing and group 10 projection are
-  delivered. Unit-list group 14 now consumes the existing JP1 event sending job
-  arrival-check defaults after approval.
-- Scope: make group 14 JP1 event sending job arrival-check columns display
-  existing domain defaults for omitted `evssv`, `evsrt`, `evspl`, and
-  `evsrc` values.
+  focused unit-list projection slice for file monitoring job group 13
+  defaults.
+- Status: unit-list group 14 JP1 event sending job projection is merged in
+  PR #224. The current slice is approved for implementation.
+- Scope: make group 13 file monitoring job columns display existing domain
+  defaults for omitted `flwc`, `flwi`, `flco`, and `ets` values.
 - Out of scope: parser grammar changes, command generation, diagnostics,
-  generated artifacts, dependency changes, `engines.vscode`, JP1 event
-  destination host requiredness, byte-length validation, numeric range
-  validation, and broader raw projection policy changes.
+  generated artifacts, dependency changes, `engines.vscode`, file name
+  byte-length validation, wildcard validation, `flwc` invalid-combination
+  diagnostics, numeric range validation, and broader raw projection policy
+  changes.
 - Impact summary: the candidate affects
   `src/application/unit-list/buildUnitListRemainingGroups.ts`,
   `src/application/unit-list/buildUnitListView.ts` DTO fields only if helper
-  typing requires it, focused unit-list regression tests, and the JP1 event
-  sending job SDD documents. Existing domain default behavior in
-  `ParamFactory.evssv`, `ParamFactory.evsrt`, `ParamFactory.evspl`, and
-  `ParamFactory.evsrc` should be reused rather than changed.
+  typing requires it, focused unit-list regression tests, and the file
+  monitoring job SDD documents. Existing domain default behavior in
+  `ParamFactory.flwc`, `ParamFactory.flwi`, `ParamFactory.flco`, and
+  `ParamFactory.ets` should be reused rather than changed.
 - Risks and assumptions: behavior changes are user-visible in the table viewer
-  because omitted group 14 arrival-check fields would display defaults instead
-  of empty cells. Raw parser output and normalized parameter storage remain
-  preserved.
+  because omitted group 13 file monitoring fields would display defaults
+  instead of empty cells. Raw parser output and normalized parameter storage
+  remain preserved.
 
 ## Build/Test Performance SDD
 
@@ -94,7 +93,7 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: JP1 event sending job unit-list group 14 default-aware projection.
+  slice: file monitoring job unit-list group 13 default-aware projection.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:
@@ -120,6 +119,17 @@ Current branch checks:
 - 2026-04-29: `npm run build` completed with existing webpack asset-size
   warnings
 - 2026-04-29: `pnpm run lint:md`
+- 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
+- 2026-05-01: `pnpm run test:compile`
+- 2026-05-01: `pnpm run qlty`
+- 2026-05-01: `npm test`
+- 2026-05-01: `npm run test:web` completed with exit code 0 and shutdown-time
+  `ECONNRESET` / premature-close noise
+- 2026-05-01: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-01: `pnpm run lint:md`
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `pnpm run test:compile`
 - 2026-04-29: `pnpm run qlty` required an escalated rerun after a sandboxed

--- a/src/application/unit-list/buildUnitListRemainingGroups.ts
+++ b/src/application/unit-list/buildUnitListRemainingGroups.ts
@@ -26,14 +26,42 @@ import type {
 const isEventSendingJob = (unit: AjsUnit): boolean =>
   unit.unitType === "evsj" || unit.unitType === "revsj";
 
+const isFileMonitoringJob = (unit: AjsUnit): boolean =>
+  unit.unitType === "flwj" || unit.unitType === "rflwj";
+
+const findDefaultAwareParameterValue = (
+  unit: AjsUnit,
+  key: ParamSymbol,
+  defaultValue: string,
+  isDefaultAwareUnit: boolean,
+): string | undefined =>
+  isDefaultAwareUnit
+    ? (findAjsUnitParameterValue(unit, key) ?? defaultValue)
+    : findAjsUnitParameterValue(unit, key);
+
 const findEventSendingJobDefaultAwareParameterValue = (
   unit: AjsUnit,
   key: ParamSymbol,
   defaultValue: string,
 ): string | undefined =>
-  isEventSendingJob(unit)
-    ? (findAjsUnitParameterValue(unit, key) ?? defaultValue)
-    : findAjsUnitParameterValue(unit, key);
+  findDefaultAwareParameterValue(
+    unit,
+    key,
+    defaultValue,
+    isEventSendingJob(unit),
+  );
+
+const findFileMonitoringJobDefaultAwareParameterValue = (
+  unit: AjsUnit,
+  key: ParamSymbol,
+  defaultValue: string,
+): string | undefined =>
+  findDefaultAwareParameterValue(
+    unit,
+    key,
+    defaultValue,
+    isFileMonitoringJob(unit),
+  );
 
 export const buildUnitListRemainingGroups = (
   unit: AjsUnit,
@@ -140,13 +168,29 @@ export const buildUnitListRemainingGroups = (
     timeoutInterval: findAjsUnitParameterValue(unit, "tmitv"),
     eventTimeout: findAjsUnitParameterValue(unit, "etn"),
     monitoredFileName: findAjsUnitParameterValue(unit, "flwf"),
-    monitoredFileCondition: findAjsUnitParameterValue(unit, "flwc"),
-    monitoredFileCloseMode: findAjsUnitParameterValue(unit, "flco"),
-    monitoringInterval: findAjsUnitParameterValue(unit, "flwi"),
+    monitoredFileCondition: findFileMonitoringJobDefaultAwareParameterValue(
+      unit,
+      "flwc",
+      DEFAULTS.Flwc,
+    ),
+    monitoredFileCloseMode: findFileMonitoringJobDefaultAwareParameterValue(
+      unit,
+      "flco",
+      DEFAULTS.Flco,
+    ),
+    monitoringInterval: findFileMonitoringJobDefaultAwareParameterValue(
+      unit,
+      "flwi",
+      DEFAULTS.Flwi,
+    ),
     waitEventId: findAjsUnitParameterValue(unit, "evwid"),
     waitHostName: findAjsUnitParameterValue(unit, "evhst"),
     waitMessage: findAjsUnitParameterValue(unit, "evwms"),
-    eventTimeoutAction: findAjsUnitParameterValue(unit, "ets"),
+    eventTimeoutAction: findFileMonitoringJobDefaultAwareParameterValue(
+      unit,
+      "ets",
+      DEFAULTS.Ets,
+    ),
   },
   group14: {
     actionEventId: findAjsUnitParameterValue(unit, "evsid"),

--- a/src/test/suite/buildUnitListRemainingGroups.test.ts
+++ b/src/test/suite/buildUnitListRemainingGroups.test.ts
@@ -68,6 +68,30 @@ unit=root,,jp1admin,;
 }
 `;
 
+const fileMonitoringJobDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  unit=file-defaults,,jp1admin,;
+  {
+    ty=flwj;
+  }
+  unit=file-explicit,,jp1admin,;
+  {
+    ty=rflwj;
+    flwf="watch.txt";
+    flwc=c:d:s;
+    flco=y;
+    flwi=30;
+    ets=wr;
+  }
+  unit=regular-job,,jp1admin,;
+  {
+    ty=j;
+  }
+}
+`;
+
 suite("Build Unit List Remaining Groups", () => {
   test("projects all remaining group fields from unit parameters", () => {
     const result = parseAjs(definition);
@@ -162,5 +186,45 @@ suite("Build Unit List Remaining Groups", () => {
     assert.strictEqual(regularView.group14.actionStartType, undefined);
     assert.strictEqual(regularView.group14.actionInterval, undefined);
     assert.strictEqual(regularView.group14.actionCount, undefined);
+  });
+
+  test("projects file monitoring job defaults for group 13", () => {
+    const result = parseAjs(fileMonitoringJobDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const fileDefaults = document.rootUnits[0]?.children[0];
+    const fileExplicit = document.rootUnits[0]?.children[1];
+    const regularJob = document.rootUnits[0]?.children[2];
+
+    assert.ok(fileDefaults);
+    assert.ok(fileExplicit);
+    assert.ok(regularJob);
+
+    const defaultView = buildUnitListRemainingGroups(fileDefaults, [], []);
+    const explicitView = buildUnitListRemainingGroups(fileExplicit, [], []);
+    const regularView = buildUnitListRemainingGroups(regularJob, [], []);
+
+    assert.strictEqual(defaultView.group13.monitoredFileName, undefined);
+    assert.strictEqual(
+      defaultView.group13.monitoredFileCondition,
+      DEFAULTS.Flwc,
+    );
+    assert.strictEqual(
+      defaultView.group13.monitoredFileCloseMode,
+      DEFAULTS.Flco,
+    );
+    assert.strictEqual(defaultView.group13.monitoringInterval, DEFAULTS.Flwi);
+    assert.strictEqual(defaultView.group13.eventTimeoutAction, DEFAULTS.Ets);
+
+    assert.strictEqual(explicitView.group13.monitoredFileName, '"watch.txt"');
+    assert.strictEqual(explicitView.group13.monitoredFileCondition, "c:d:s");
+    assert.strictEqual(explicitView.group13.monitoredFileCloseMode, "y");
+    assert.strictEqual(explicitView.group13.monitoringInterval, "30");
+    assert.strictEqual(explicitView.group13.eventTimeoutAction, "wr");
+
+    assert.strictEqual(regularView.group13.monitoredFileCondition, undefined);
+    assert.strictEqual(regularView.group13.monitoredFileCloseMode, undefined);
+    assert.strictEqual(regularView.group13.monitoringInterval, undefined);
+    assert.strictEqual(regularView.group13.eventTimeoutAction, undefined);
   });
 });


### PR DESCRIPTION
## Summary

- Project file monitoring job group 13 defaults for omitted flwc, flwi, flco, and ets values.
- Preserve explicit file monitoring values, keep omitted flwf empty, and avoid synthesizing defaults for non-file-monitoring jobs.
- Update SDD and use-case docs with the approved behavior slice, impact, approval evidence, and validation record.

## Validation

- pnpm run test:compile
- pnpm run qlty
- npm test
- npm run test:web (exit code 0; shutdown-time ECONNRESET / premature-close noise)
- npm run build (completed with existing webpack asset-size warnings)
- pnpm run lint:md