### PR TITLE
Align execution-interval control job defaults

### DIFF
--- a/docs/requirements/use-cases/uc-build-unit-list-view.md
+++ b/docs/requirements/use-cases/uc-build-unit-list-view.md
@@ -68,6 +68,12 @@ Scenario: File monitoring job defaults are projected
   When table row view models are built
   Then omitted group 13 file monitoring values display their JP1/AJS defaults
   And explicit group 13 file monitoring values remain visible
+
+Scenario: Execution-interval control job defaults are projected
+  Given a normalized JP1/AJS document with an execution-interval control job
+  When table row view models are built
+  Then omitted group 13 execution-interval control values display JP1/AJS defaults
+  And explicit group 13 execution-interval control values remain visible
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
@@ -1,0 +1,68 @@
+# Execution-Interval Control Job Alignment
+
+## Purpose
+
+Track the JP1/AJS3 version 13 alignment slice for execution-interval control
+job defaults and unit-list group 13 projection.
+
+## Reference
+
+- JP1/AJS3 version 13 Command Reference, "Execution-interval control job
+  definition"
+- Parameters in scope:
+  `tmitv=wait-time`, `etn={y|n}`, and `ets={kl|nr|wr|an}`
+
+The reference defines omitted values as:
+
+- `tmitv`: `10`
+- `etn`: `n`
+- `ets`: `kl`
+
+## Current Behavior
+
+- `Tmwj.tmitv` delegates to `ParamFactory.tmitv`, and `ParamFactory.tmitv`
+  currently has no default value.
+- `Tmwj.etn` and `Tmwj.ets` delegate to factory builders that already use
+  `DEFAULTS.Etn` and `DEFAULTS.Ets`.
+- Unit-list group 13 currently reads normalized raw values for `tmitv` and
+  `etn`.
+- Unit-list group 13 now uses default-aware `ets` projection only for file
+  monitoring jobs, not for execution-interval control jobs.
+
+## Proposed Scope
+
+After human approval, align execution-interval control job behavior by:
+
+- adding a `tmitv` default of `10` at the domain parameter boundary;
+- projecting omitted `tmitv`, `etn`, and `ets` defaults for `tmwj` / `rtmwj`
+  in unit-list group 13;
+- preserving explicit normalized values;
+- leaving non-execution-interval-control jobs unchanged.
+
+## Non-Goals
+
+- parser grammar changes
+- command generation changes
+- diagnostics or range validation
+- generated artifact changes
+- dependency or configuration changes
+- `engines.vscode` changes
+- broad wait-job default reconciliation outside `tmwj` / `rtmwj`
+
+## Impact
+
+- Domain behavior changes for omitted `Tmwj.tmitv`, because the wrapper would
+  return `10` instead of no value.
+- Unit-list group 13 output changes for omitted execution-interval control job
+  `tmitv`, `etn`, and `ets`, because the table would display defaults instead
+  of empty cells.
+- Raw parser output and normalized key/value storage should remain unchanged.
+
+## Alternatives
+
+- Keep group 13 raw by design and leave the gap visible in the matrix.
+- Project defaults for group 13 only, without adding a domain `tmitv` default.
+  This avoids wrapper behavior change but leaves domain and projection
+  semantics inconsistent.
+- Defer the slice until all wait-job defaults are reconciled. This is broader
+  than the current focused manual-backed behavior gap.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -117,6 +117,23 @@ coverage.
   `flwc` invalid-combination diagnostics, wildcard restrictions, byte-length
   validation, and range validation are deferred
 
+### Execution-Interval Control Job Defaults
+
+- Keys: `tmitv`, `etn`, and `ets`
+- Unit scope:
+  execution-interval control jobs and recovery execution-interval control jobs
+- Status: partial
+- Owning seam:
+  `Tmwj.ts`, `optionalScalarParameterBuilders.ts`, `Defaults.ts`, and
+  `buildUnitListRemainingGroups.ts`
+- Evidence:
+  `parameterFactory.test.ts` for domain defaults and
+  `buildUnitListRemainingGroups.test.ts` for group 13 projection
+- Remaining gap:
+  execution-interval control job defaults and unit-list group 13 projection
+  are aligned for these values; range validation and broader wait-job default
+  reconciliation are deferred
+
 ## Boundary Decisions
 
 - This matrix covers only categories with feature-local investigation records.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -77,6 +77,12 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   approval-gated behavior candidate after the group 14 slice.
 - Implemented unit-list group 13 projection for file monitoring job defaults
   while preserving explicit normalized values and raw storage.
+- Investigated execution-interval control job defaults and unit-list group 13
+  projection for omitted `tmitv`, `etn`, and `ets` values as the next
+  approval-gated behavior candidate after the file monitoring slice.
+- Implemented execution-interval control job `tmitv=10`, `etn=n`, and
+  `ets=kl` defaults and group 13 default-aware projection while preserving
+  explicit normalized values and raw storage.
 
 ## Impact Investigation
 
@@ -353,6 +359,57 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   human approval to proceed was given on 2026-05-01 after the investigation
   summary for unit-list group 13 default-aware projection.
 
+### Execution-Interval Control Job Defaults Candidate
+
+- Planned change:
+  align omitted execution-interval control job `tmitv`, `etn`, and `ets`
+  behavior with the JP1/AJS3 version 13 execution-interval control job
+  definition. The recommended implementation adds a `tmitv=10` domain default
+  and makes unit-list group 13 display defaults for omitted `tmwj` / `rtmwj`
+  values while preserving explicit normalized values.
+- Affected files:
+  `src/domain/models/parameters/Defaults.ts`,
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`,
+  `src/domain/models/units/Tmwj.ts` as the wrapper consumer,
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`,
+  `src/application/unit-list/buildUnitListView.ts` only if helper typing
+  changes, `src/test/suite/parameterFactory.test.ts`,
+  `src/test/suite/buildUnitListRemainingGroups.test.ts` or
+  `src/test/suite/buildUnitListView.test.ts`,
+  `EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `TASKS.md`, and branch-level
+  `docs/specs/plans.md`.
+- Affected functions/classes/components:
+  `ParamFactory.tmitv`, `optionalScalarParameterBuilders.tmitv`,
+  `DEFAULTS`, `Tmwj.tmitv`, `Tmwj.etn`, `Tmwj.ets`,
+  `buildUnitListRemainingGroups`, `UnitListGroup13View.timeoutInterval`,
+  `UnitListGroup13View.eventTimeout`,
+  `UnitListGroup13View.eventTimeoutAction`, and the group 13 table columns
+  that render those DTO fields.
+- Affected features:
+  JP1/AJS parameter interpretation for execution-interval control jobs;
+  JP1/AJS table viewer group 13 event job definition columns;
+  build-unit-list application use case.
+- Tests affected:
+  focused parameter factory tests for omitted and explicit `tmitv`, `etn`, and
+  `ets` behavior; focused unit-list tests for omitted execution-interval
+  control job defaults, explicit value preservation, and non-target job
+  behavior.
+- Breaking-change risk:
+  medium. Omitted `tmitv` would become visible through the domain wrapper as
+  `10`, and omitted group 13 execution-interval control job fields would
+  display defaults instead of empty cells. The planned scope preserves raw
+  parser output and normalized key/value storage.
+- Alternatives considered:
+  keep group 13 raw by design and leave the matrix gap visible; add
+  projection-only defaults without adding a `tmitv` domain default, rejected as
+  less domain-aligned; broaden the slice to all wait-job defaults, deferred
+  because it expands the approval and regression surface.
+- Approval:
+  human approval to proceed was given on 2026-05-01 after the investigation
+  summary for execution-interval control job defaults and unit-list group 13
+  projection.
+
 ## Follow-up
 
 - Apply the same value parsing audit/refactor workflow to other parameter
@@ -371,6 +428,8 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 - Revisit file monitoring job `flwc` invalid combinations, `flwi` range
   validation, wildcard restrictions, and `flco` pairing diagnostics after the
   editor-feedback behavior contract is explicit.
+- Revisit execution-interval control job `tmitv` range validation and broader
+  wait-job default reconciliation after the focused default/projection slice.
 
 ## Validation
 
@@ -400,6 +459,16 @@ Current branch validation:
   warnings
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `pnpm run lint:md`
+- 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
+- 2026-05-01: `pnpm run test:compile`
+- 2026-05-01: `npm test`
+- 2026-05-01: `pnpm run qlty`
+- 2026-05-01: `npm run test:web` completed with exit code 0 and existing
+  localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `npm run build` completed with existing webpack asset-size
+  warnings
 - 2026-04-29: `pnpm run lint:md`
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `npm test`

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -82,6 +82,16 @@ JP1/AJS3 version 13 reference documents.
   table output. If approved, it should consume the existing wrapper/default
   semantics for `flwc`, `flwi`, `flco`, and `ets` while preserving parser
   output and normalized raw parameter storage.
+- Execution-interval control job defaults are approval-sensitive because
+  JP1/AJS3 version 13 defines omitted `tmitv`, `etn`, and `ets` behavior for
+  `tmwj` / `rtmwj`, while current code only has generic defaults for `etn` and
+  `ets`. `ParamFactory.tmitv` is referenced only through `Tmwj.tmitv` today,
+  but adding a wrapper default is still a domain behavior change.
+- Execution-interval control job unit-list group 13 projection is a separate
+  approval-sensitive boundary from domain defaults because it is user-visible
+  table output. If approved, it should consume execution-interval defaults for
+  `tmitv`, `etn`, and `ets` while preserving explicit normalized values,
+  parser output, and normalized raw parameter storage.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -105,6 +105,14 @@
 - [x] Add focused group 13 regression evidence for omitted defaults and
       explicit value preservation
 - [x] Run required code-change validation after implementation
+- [x] Investigate execution-interval control job defaults and unit-list group
+      13 projection as a separate behavior slice
+- [x] Record human approval before changing execution-interval control job
+      default or projection behavior
+- [x] Implement execution-interval control job defaults only after approval
+- [x] Add focused execution-interval control job regression evidence for
+      omitted defaults, explicit value preservation, and non-target jobs
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -241,27 +249,49 @@
   normalized values remain visible, omitted `flwf` remains empty,
   non-file-monitoring jobs do not synthesize these defaults, and raw
   parser/domain/normalized values remain unchanged.
+- 2026-05-01: execution-interval control job defaults are the next
+  approval-gated behavior candidate. The proposed scope is limited to
+  `tmwj` / `rtmwj` omitted `tmitv=10`, `etn=n`, and `ets=kl` behavior plus
+  unit-list group 13 default-aware projection. Parser grammar, normalized raw
+  parameter storage, diagnostics, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` remain out of scope.
+- 2026-05-01: execution-interval control job defaults now resolve omitted
+  `tmitv`, `etn`, and `ets` values to `10`, `n`, and `kl`. Unit-list group 13
+  projection consumes those defaults for `tmwj` / `rtmwj`, explicit normalized
+  values remain visible, non-execution-interval-control jobs do not synthesize
+  those defaults, and raw parser/normalized values remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-01
-- Approved scope: User replied "OK.Proceed." after the unit-list group 13 file
+- Approved scope: User replied "OK. Proceed." after the execution-interval
+  control job defaults and unit-list group 13 projection approval request.
+  Approved changes are limited to aligning omitted `tmwj` / `rtmwj`
+  `tmitv=10`, `etn=n`, and `ets=kl` behavior, making group 13 projection
+  consume those defaults for execution-interval control jobs, preserving
+  explicit values and non-target job behavior, adding focused regression
+  evidence, updating SDD tracking, and running validation. Parser grammar,
+  normalized raw parameter storage, diagnostics, generated artifacts,
+  configuration, dependency versions, and `engines.vscode` changes are out of
+  scope.
+
+Current implementation gate: execution-interval control job defaults and
+unit-list group 13 projection for `tmitv`, `etn`, and `ets`.
+
+## Prior Approval Evidence
+
+- 2026-05-01: User replied "OK.Proceed." after the unit-list group 13 file
   monitoring job default-aware projection approval request. Approved changes
-  are limited to making group 13 `flwc`, `flwi`, `flco`, and `ets` columns
+  were limited to making group 13 `flwc`, `flwi`, `flco`, and `ets` columns
   consume existing domain defaults for omitted values, preserving explicit
   values, adding focused regression evidence, updating SDD tracking, and
   running validation. Parser grammar, raw domain wrappers, normalized raw
   parameter storage, diagnostics, generated artifacts, configuration,
-  dependency versions, and `engines.vscode` changes are out of scope.
-
-Current implementation gate: unit-list group 13 default-aware projection for
-file monitoring job defaults.
+  dependency versions, and `engines.vscode` changes were out of scope.
 
 Implementation must not start while Status is Pending.
 Only clear human approval can change Status to Approved.
-
-## Prior Approval Evidence
 
 - 2026-04-29: Approved unit-list group 14 default-aware projection for JP1
   event sending job arrival-check defaults. Approved changes were limited to

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -31,9 +31,8 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Prepare file monitoring job unit-list group 13 projection as the next
-   focused parameter-alignment behavior contract, then record approval before
-   implementation.
+1. Choose the next JP1/AJS3 v13 parameter-alignment slice after
+   execution-interval control job defaults.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime
@@ -41,30 +40,33 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/file-monitoring-group13-projection`.
+- Branch: `codex/interval-control-defaults`.
 - Objective: continue the JP1/AJS3 v13 parameter alignment feature with a
-  focused unit-list projection slice for file monitoring job group 13
-  defaults.
-- Status: unit-list group 14 JP1 event sending job projection is merged in
-  PR #224. The current slice is approved for implementation.
-- Scope: make group 13 file monitoring job columns display existing domain
-  defaults for omitted `flwc`, `flwi`, `flco`, and `ets` values.
+  focused implementation of execution-interval control job defaults and group
+  13 projection.
+- Status: unit-list group 13 file monitoring job projection is merged in
+  PR #225. The current slice is approved and implemented locally.
+- Scope: align omitted `tmitv`, `etn`, and `ets` behavior on
+  execution-interval control jobs (`tmwj` / `rtmwj`) and make unit-list group
+  13 projection default-aware for those values.
 - Out of scope: parser grammar changes, command generation, diagnostics,
-  generated artifacts, dependency changes, `engines.vscode`, file name
-  byte-length validation, wildcard validation, `flwc` invalid-combination
-  diagnostics, numeric range validation, and broader raw projection policy
-  changes.
+  generated artifacts, dependency changes, `engines.vscode`, numeric range
+  validation, invalid-combination diagnostics, and broader raw projection
+  policy changes.
 - Impact summary: the candidate affects
+  `src/domain/models/parameters/Defaults.ts`,
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`,
   `src/application/unit-list/buildUnitListRemainingGroups.ts`,
   `src/application/unit-list/buildUnitListView.ts` DTO fields only if helper
-  typing requires it, focused unit-list regression tests, and the file
-  monitoring job SDD documents. Existing domain default behavior in
-  `ParamFactory.flwc`, `ParamFactory.flwi`, `ParamFactory.flco`, and
-  `ParamFactory.ets` should be reused rather than changed.
+  typing requires it, focused parameter factory and unit-list regression
+  tests, and the execution-interval control job SDD documents. Existing
+  domain default behavior in `ParamFactory.etn` and `ParamFactory.ets` is
+  reused; `ParamFactory.tmitv` now uses `DEFAULTS.Tmitv`.
 - Risks and assumptions: behavior changes are user-visible in the table viewer
-  because omitted group 13 file monitoring fields would display defaults
-  instead of empty cells. Raw parser output and normalized parameter storage
-  remain preserved.
+  because omitted execution-interval control job group 13 fields would display
+  defaults instead of empty cells. Adding a `tmitv` domain default is also
+  observable through the `Tmwj.tmitv` wrapper. Raw parser output and
+  normalized parameter storage remain preserved.
 
 ## Build/Test Performance SDD
 
@@ -93,7 +95,8 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: file monitoring job unit-list group 13 default-aware projection.
+  slice: execution-interval control job defaults and unit-list group 13
+  default-aware projection.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:
@@ -119,6 +122,16 @@ Current branch checks:
 - 2026-04-29: `npm run build` completed with existing webpack asset-size
   warnings
 - 2026-04-29: `pnpm run lint:md`
+- 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
+- 2026-05-01: `pnpm run test:compile`
+- 2026-05-01: `npm test`
+- 2026-05-01: `pnpm run qlty`
+- 2026-05-01: `npm run test:web` completed with exit code 0 and existing
+  localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `npm run build` completed with existing webpack asset-size
+  warnings
 - 2026-05-01: `pnpm run lint:md`
 - 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
   log-file permission failure

--- a/src/application/unit-list/buildUnitListRemainingGroups.ts
+++ b/src/application/unit-list/buildUnitListRemainingGroups.ts
@@ -29,6 +29,9 @@ const isEventSendingJob = (unit: AjsUnit): boolean =>
 const isFileMonitoringJob = (unit: AjsUnit): boolean =>
   unit.unitType === "flwj" || unit.unitType === "rflwj";
 
+const isExecutionIntervalControlJob = (unit: AjsUnit): boolean =>
+  unit.unitType === "tmwj" || unit.unitType === "rtmwj";
+
 const findDefaultAwareParameterValue = (
   unit: AjsUnit,
   key: ParamSymbol,
@@ -61,6 +64,26 @@ const findFileMonitoringJobDefaultAwareParameterValue = (
     key,
     defaultValue,
     isFileMonitoringJob(unit),
+  );
+
+const findExecutionIntervalControlJobDefaultAwareParameterValue = (
+  unit: AjsUnit,
+  key: ParamSymbol,
+  defaultValue: string,
+): string | undefined =>
+  findDefaultAwareParameterValue(
+    unit,
+    key,
+    defaultValue,
+    isExecutionIntervalControlJob(unit),
+  );
+
+const findGroup13EventTimeoutAction = (unit: AjsUnit): string | undefined =>
+  findDefaultAwareParameterValue(
+    unit,
+    "ets",
+    DEFAULTS.Ets,
+    isFileMonitoringJob(unit) || isExecutionIntervalControlJob(unit),
   );
 
 export const buildUnitListRemainingGroups = (
@@ -165,8 +188,16 @@ export const buildUnitListRemainingGroups = (
     judgmentFileName: findAjsUnitParameterValue(unit, "ejf"),
   },
   group13: {
-    timeoutInterval: findAjsUnitParameterValue(unit, "tmitv"),
-    eventTimeout: findAjsUnitParameterValue(unit, "etn"),
+    timeoutInterval: findExecutionIntervalControlJobDefaultAwareParameterValue(
+      unit,
+      "tmitv",
+      DEFAULTS.Tmitv,
+    ),
+    eventTimeout: findExecutionIntervalControlJobDefaultAwareParameterValue(
+      unit,
+      "etn",
+      DEFAULTS.Etn,
+    ),
     monitoredFileName: findAjsUnitParameterValue(unit, "flwf"),
     monitoredFileCondition: findFileMonitoringJobDefaultAwareParameterValue(
       unit,
@@ -186,11 +217,7 @@ export const buildUnitListRemainingGroups = (
     waitEventId: findAjsUnitParameterValue(unit, "evwid"),
     waitHostName: findAjsUnitParameterValue(unit, "evhst"),
     waitMessage: findAjsUnitParameterValue(unit, "evwms"),
-    eventTimeoutAction: findFileMonitoringJobDefaultAwareParameterValue(
-      unit,
-      "ets",
-      DEFAULTS.Ets,
-    ),
+    eventTimeoutAction: findGroup13EventTimeoutAction(unit),
   },
   group14: {
     actionEventId: findAjsUnitParameterValue(unit, "evsid"),

--- a/src/domain/models/parameters/Defaults.ts
+++ b/src/domain/models/parameters/Defaults.ts
@@ -22,6 +22,7 @@ const parameterDefaults = {
   St: "+00:00",
   Stt: "00:00",
   Wt: "no",
+  Tmitv: "10",
   Cd: "n",
   Cftd: "no",
   Cgs: "y",

--- a/src/domain/models/parameters/optionalScalarParameterBuilders.ts
+++ b/src/domain/models/parameters/optionalScalarParameterBuilders.ts
@@ -613,7 +613,11 @@ export const optionalScalarParameterBuilders = {
     (param) => new Tho(param),
     DEFAULTS.Tho,
   ),
-  tmitv: createOptionalScalarBuilder("tmitv", (param) => new Tmitv(param)),
+  tmitv: createOptionalScalarBuilder(
+    "tmitv",
+    (param) => new Tmitv(param),
+    DEFAULTS.Tmitv,
+  ),
   ts1: createOptionalScalarBuilder("ts1", (param) => new Ts1(param)),
   ts2: createOptionalScalarBuilder("ts2", (param) => new Ts2(param)),
   ts3: createOptionalScalarBuilder("ts3", (param) => new Ts3(param)),

--- a/src/test/suite/buildUnitListRemainingGroups.test.ts
+++ b/src/test/suite/buildUnitListRemainingGroups.test.ts
@@ -92,6 +92,28 @@ unit=root,,jp1admin,;
 }
 `;
 
+const executionIntervalControlJobDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  unit=interval-defaults,,jp1admin,;
+  {
+    ty=tmwj;
+  }
+  unit=interval-explicit,,jp1admin,;
+  {
+    ty=rtmwj;
+    tmitv=30;
+    etn=y;
+    ets=wr;
+  }
+  unit=regular-job,,jp1admin,;
+  {
+    ty=j;
+  }
+}
+`;
+
 suite("Build Unit List Remaining Groups", () => {
   test("projects all remaining group fields from unit parameters", () => {
     const result = parseAjs(definition);
@@ -225,6 +247,35 @@ suite("Build Unit List Remaining Groups", () => {
     assert.strictEqual(regularView.group13.monitoredFileCondition, undefined);
     assert.strictEqual(regularView.group13.monitoredFileCloseMode, undefined);
     assert.strictEqual(regularView.group13.monitoringInterval, undefined);
+    assert.strictEqual(regularView.group13.eventTimeoutAction, undefined);
+  });
+
+  test("projects execution-interval control job defaults for group 13", () => {
+    const result = parseAjs(executionIntervalControlJobDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const intervalDefaults = document.rootUnits[0]?.children[0];
+    const intervalExplicit = document.rootUnits[0]?.children[1];
+    const regularJob = document.rootUnits[0]?.children[2];
+
+    assert.ok(intervalDefaults);
+    assert.ok(intervalExplicit);
+    assert.ok(regularJob);
+
+    const defaultView = buildUnitListRemainingGroups(intervalDefaults, [], []);
+    const explicitView = buildUnitListRemainingGroups(intervalExplicit, [], []);
+    const regularView = buildUnitListRemainingGroups(regularJob, [], []);
+
+    assert.strictEqual(defaultView.group13.timeoutInterval, DEFAULTS.Tmitv);
+    assert.strictEqual(defaultView.group13.eventTimeout, DEFAULTS.Etn);
+    assert.strictEqual(defaultView.group13.eventTimeoutAction, DEFAULTS.Ets);
+
+    assert.strictEqual(explicitView.group13.timeoutInterval, "30");
+    assert.strictEqual(explicitView.group13.eventTimeout, "y");
+    assert.strictEqual(explicitView.group13.eventTimeoutAction, "wr");
+
+    assert.strictEqual(regularView.group13.timeoutInterval, undefined);
+    assert.strictEqual(regularView.group13.eventTimeout, undefined);
     assert.strictEqual(regularView.group13.eventTimeoutAction, undefined);
   });
 });

--- a/src/test/suite/parameterFactory.test.ts
+++ b/src/test/suite/parameterFactory.test.ts
@@ -7,6 +7,7 @@ import { Evsj } from "../../domain/models/units/Evsj";
 import { Htpj } from "../../domain/models/units/Htpj";
 import { N } from "../../domain/models/units/N";
 import { Qj, Rq } from "../../domain/models/units/Qj";
+import { Tmwj } from "../../domain/models/units/Tmwj";
 import { parseAjs } from "../../domain/services/parser/AjsParser";
 import { tyFactory } from "../../domain/utils/TyUtils";
 
@@ -352,6 +353,26 @@ unit=root,,jp1admin,;
 }
 `;
 
+const executionIntervalControlJobDefaultDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  el=interval,tmwj,+0+0;
+  el=explicit,rtmwj,+160+0;
+  unit=interval,,jp1admin,;
+  {
+    ty=tmwj;
+  }
+  unit=explicit,,jp1admin,;
+  {
+    ty=rtmwj;
+    tmitv=30;
+    etn=y;
+    ets=wr;
+  }
+}
+`;
+
 const parseJob = (): J => {
   const result = parseAjs(definition);
   assert.deepStrictEqual(result.errors, []);
@@ -508,6 +529,19 @@ const parseEventSendingJobs = (): {
   return {
     eventJob: root.children[0] as Evsj,
     explicitEventJob: root.children[1] as Evsj,
+  };
+};
+
+const parseExecutionIntervalControlJobs = (): {
+  intervalJob: Tmwj;
+  explicitIntervalJob: Tmwj;
+} => {
+  const result = parseAjs(executionIntervalControlJobDefaultDefinition);
+  assert.deepStrictEqual(result.errors, []);
+  const root = tyFactory(result.rootUnits[0]);
+  return {
+    intervalJob: root.children[0] as Tmwj,
+    explicitIntervalJob: root.children[1] as Tmwj,
   };
 };
 
@@ -913,5 +947,17 @@ suite("ParameterFactory", () => {
     assert.strictEqual(explicitEventJob.evsrt?.value(), "y");
     assert.strictEqual(explicitEventJob.evspl?.value(), "5");
     assert.strictEqual(explicitEventJob.evsrc?.value(), "7");
+  });
+
+  test("returns execution-interval control job defaults through the facade", () => {
+    const { intervalJob, explicitIntervalJob } =
+      parseExecutionIntervalControlJobs();
+
+    assert.strictEqual(intervalJob.tmitv?.value(), DEFAULTS.Tmitv);
+    assert.strictEqual(intervalJob.etn?.value(), DEFAULTS.Etn);
+    assert.strictEqual(intervalJob.ets?.value(), DEFAULTS.Ets);
+    assert.strictEqual(explicitIntervalJob.tmitv?.value(), "30");
+    assert.strictEqual(explicitIntervalJob.etn?.value(), "y");
+    assert.strictEqual(explicitIntervalJob.ets?.value(), "wr");
   });
 });


### PR DESCRIPTION
## Summary
- add JP1/AJS3 v13 default handling for execution-interval control job tmitv=10
- make unit-list group 13 projection default-aware for tmwj/rtmwj tmitv, etn, and ets
- update focused SDD/use-case docs and regression coverage

## Validation
- pnpm run test:compile
- npm test
- pnpm run qlty
- npm run test:web
- npm run build
- pnpm run lint:md
- git diff --check

Notes: npm run test:web completed with the existing localhost dev-extension package.nls.json 404 noise. npm run build completed with existing webpack asset-size warnings.