### PR TITLE
Hide QUEUE group15 transfer operations

### DIFF
--- a/docs/requirements/use-cases/uc-build-unit-list-view.md
+++ b/docs/requirements/use-cases/uc-build-unit-list-view.md
@@ -74,6 +74,13 @@ Scenario: Execution-interval control job defaults are projected
   When table row view models are built
   Then omitted group 13 execution-interval control values display JP1/AJS defaults
   And explicit group 13 execution-interval control values remain visible
+
+Scenario: QUEUE job transfer operations are not projected
+  Given a normalized JP1/AJS document with a QUEUE job
+  When table row view models are built
+  Then group 15 displays QUEUE job transfer source and destination values
+  And group 15 does not display QUEUE job transfer operation values
+  And non-QUEUE group 15 transfer operation values remain visible
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -59,7 +59,8 @@ coverage.
 - Owning seam: `Qj.ts` and `ParameterFactory.ts`
 - Evidence: `parameterFactory.test.ts`
 - Remaining gap:
-  group 15 remains raw projection; unit-type-aware list behavior is deferred
+  group 15 unit-type-aware projection now hides `topN` on QUEUE jobs; byte
+  length, macro-variable, and invalid-combination validation remain deferred
 
 ### Job End Judgment
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -83,6 +83,12 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 - Implemented execution-interval control job `tmitv=10`, `etn=n`, and
   `ets=kl` defaults and group 13 default-aware projection while preserving
   explicit normalized values and raw storage.
+- Investigated QUEUE job unit-list group 15 projection as the next
+  approval-gated behavior candidate after the execution-interval control job
+  slice.
+- Implemented QUEUE job unit-list group 15 projection so `qj` / `rq`
+  transfer-operation values are hidden while transfer source/destination and
+  non-QUEUE `topN` projection remain visible.
 
 ## Impact Investigation
 
@@ -152,6 +158,46 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   follow-up is already narrow and testable.
 - Approval: completed in the prior QUEUE transfer-file slice; see
   `TASKS.md` prior approval evidence.
+
+### QUEUE Job Group 15 Projection Candidate
+
+- Planned change:
+  make unit-list group 15 transfer-operation projection unit-type-aware for
+  QUEUE jobs by hiding `top1` to `top4` values on `qj` / `rq`, while
+  preserving explicit `ts1` to `ts4` and `td1` to `td4` projection and
+  preserving non-QUEUE `topN` projection.
+- Affected files:
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`,
+  `src/application/unit-list/buildUnitListView.ts` only if helper typing
+  changes, `src/test/suite/buildUnitListRemainingGroups.test.ts` or
+  `src/test/suite/buildUnitListView.test.ts`,
+  `QUEUE_TRANSFER_FILE_ALIGNMENT.md`, `PARAMETER_COVERAGE_MATRIX.md`,
+  `SPECS.md`, `TASKS.md`, `docs/requirements/use-cases/uc-build-unit-list-view.md`,
+  and branch-level `docs/specs/plans.md`.
+- Affected functions/classes/components:
+  `buildUnitListRemainingGroups`,
+  `UnitListGroup15View.terminationStatus1` to `terminationStatus4`,
+  `UnitListGroup15View.terminationDelay1` to `terminationDelay4`,
+  `UnitListGroup15View.terminationOperation1` to `terminationOperation4`, and
+  the group 15 table columns that render those DTO fields.
+- Affected features:
+  JP1/AJS table viewer group 15 transfer-file columns; build-unit-list
+  application use case; QUEUE job transfer-file parameter interpretation.
+- Tests affected:
+  focused unit-list tests for QUEUE jobs with explicit `tsN`, `tdN`, and raw
+  `topN`; non-QUEUE tests proving existing `topN` projection remains visible.
+- Breaking-change risk:
+  medium. This intentionally changes user-visible table output for QUEUE job
+  definitions that contain raw `top1` to `top4` values. Raw parser output and
+  normalized key/value storage remain unchanged.
+- Alternatives considered:
+  keep group 15 raw by design and leave the matrix gap visible; add `topN`
+  getters to `Qj` / `Rq`, rejected because the QUEUE job definition does not
+  define `top1` to `top4`; add diagnostics first, deferred until
+  editor-feedback behavior explicitly owns invalid JP1/AJS parameter handling.
+- Approval:
+  human approval to proceed was given on 2026-05-01 after the investigation
+  summary for QUEUE job unit-list group 15 projection.
 
 ### WTH End-Judgment Key Mapping Candidate
 
@@ -469,6 +515,17 @@ Current branch validation:
   localhost dev-extension `package.nls.json` 404 noise
 - 2026-05-01: `npm run build` completed with existing webpack asset-size
   warnings
+- 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run test:compile`
+- 2026-05-01: `npm test`
+- 2026-05-01: `pnpm run qlty`
+- 2026-05-01: `npm run test:web` completed with exit code 0 and existing
+  localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
 - 2026-04-29: `pnpm run lint:md`
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `npm test`

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/QUEUE_TRANSFER_FILE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/QUEUE_TRANSFER_FILE_ALIGNMENT.md
@@ -73,3 +73,42 @@ parameters.
   behavior is specified as diagnostics, warnings, or raw preservation.
 - Revisit whether group 15 should become unit-type-aware only as a separate
   unit-list behavior slice.
+
+## Group 15 Projection Candidate
+
+### Current Behavior
+
+- `Qj` / `Rq` wrappers do not expose `top1` to `top4`.
+- Unit-list group 15 reads normalized raw `top1` to `top4` values for every
+  unit type.
+- If a QUEUE job definition contains raw `topN` values, group 15 can display
+  those transfer-operation values even though the QUEUE job manual section
+  does not define them.
+
+### Proposed Behavior
+
+After human approval:
+
+- keep displaying explicit `ts1` to `ts4` and `td1` to `td4` values for
+  `qj` / `rq`;
+- hide `top1` to `top4` group 15 transfer-operation values for `qj` / `rq`;
+- preserve non-QUEUE group 15 transfer-operation projection;
+- preserve raw parser output and normalized key/value storage.
+
+### Impact
+
+- User-visible table output changes only for QUEUE jobs that contain raw
+  `top1` to `top4` values.
+- The projection behavior becomes aligned with the existing `Qj` / `Rq`
+  wrapper boundary and the JP1/AJS3 version 13 QUEUE job definition.
+- Parser grammar, generated artifacts, diagnostics, and command generation are
+  unchanged.
+
+### Projection Alternatives
+
+- Keep group 15 raw by design and leave the matrix gap visible.
+- Add `topN` getters to `Qj` / `Rq`, rejected because the QUEUE job definition
+  does not define `top1` to `top4`.
+- Add diagnostics for raw `topN` on QUEUE jobs instead of changing projection,
+  deferred until editor-feedback behavior explicitly owns invalid JP1/AJS
+  parameter handling.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -54,6 +54,12 @@ JP1/AJS3 version 13 reference documents.
   UNIX/PC custom job definitions also define `top1` to `top4`. The QUEUE job
   slice must preserve that distinction and must not broaden `topN` default
   derivation to wrappers whose manual section does not define `topN`.
+- QUEUE job unit-list group 15 projection is a separate approval-sensitive
+  boundary from wrapper behavior because it is user-visible table output. If
+  approved, it should preserve `ts1` to `ts4` and `td1` to `td4` projection
+  for `qj` / `rq`, but hide `top1` to `top4` transfer-operation projection
+  for those unit types because the JP1/AJS3 version 13 QUEUE job definition
+  does not define `topN`.
 - Job end-judgment `wth` alignment is approval-sensitive because the current
   factory preserves a legacy lookup from `wth` to the schedule-rule `wt`
   parameter. Correct alignment should read explicit `wth` values without

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -113,6 +113,14 @@
 - [x] Add focused execution-interval control job regression evidence for
       omitted defaults, explicit value preservation, and non-target jobs
 - [x] Run required code-change validation after implementation
+- [x] Investigate unit-list group 15 projection for QUEUE job transfer-file
+      operations as a separate behavior slice
+- [x] Record human approval before changing QUEUE job group 15 projection
+- [x] Implement QUEUE job group 15 unit-type-aware projection only after
+      approval
+- [x] Add focused group 15 regression evidence for QUEUE `tsN` / `tdN`
+      preservation, QUEUE `topN` hiding, and non-QUEUE `topN` preservation
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -260,27 +268,46 @@
   projection consumes those defaults for `tmwj` / `rtmwj`, explicit normalized
   values remain visible, non-execution-interval-control jobs do not synthesize
   those defaults, and raw parser/normalized values remain unchanged.
+- 2026-05-01: QUEUE job group 15 projection is the next approval-gated
+  behavior candidate. The proposed scope is limited to hiding `top1` to
+  `top4` transfer-operation projection for `qj` / `rq`, preserving explicit
+  `ts1` to `ts4` and `td1` to `td4`, and preserving non-QUEUE `topN`
+  projection. Parser grammar, normalized raw parameter storage, diagnostics,
+  generated artifacts, configuration, dependency versions, and
+  `engines.vscode` remain out of scope.
+- 2026-05-01: QUEUE job group 15 projection now hides `top1` to `top4`
+  transfer-operation values for `qj` / `rq`. Explicit `ts1` to `ts4` and
+  `td1` to `td4` remain visible, non-QUEUE `topN` projection remains visible,
+  and raw parser/normalized values remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-01
-- Approved scope: User replied "OK. Proceed." after the execution-interval
+- Approved scope: User replied "OK. Proceed." after the QUEUE job unit-list
+  group 15 projection approval request. Approved changes are limited to
+  hiding `top1` to `top4` transfer-operation projection for `qj` / `rq`,
+  preserving explicit `ts1` to `ts4` and `td1` to `td4`, preserving non-QUEUE
+  `topN` projection, adding focused regression evidence, updating SDD and
+  use-case tracking, and running validation. Parser grammar, normalized raw
+  parameter storage, diagnostics, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` changes are out of scope.
+
+Current implementation gate: QUEUE job unit-list group 15 projection for
+`ts1` to `ts4`, `td1` to `td4`, and `top1` to `top4`.
+
+## Prior Approval Evidence
+
+- 2026-05-01: User replied "OK. Proceed." after the execution-interval
   control job defaults and unit-list group 13 projection approval request.
-  Approved changes are limited to aligning omitted `tmwj` / `rtmwj`
+  Approved changes were limited to aligning omitted `tmwj` / `rtmwj`
   `tmitv=10`, `etn=n`, and `ets=kl` behavior, making group 13 projection
   consume those defaults for execution-interval control jobs, preserving
   explicit values and non-target job behavior, adding focused regression
   evidence, updating SDD tracking, and running validation. Parser grammar,
   normalized raw parameter storage, diagnostics, generated artifacts,
-  configuration, dependency versions, and `engines.vscode` changes are out of
+  configuration, dependency versions, and `engines.vscode` changes were out of
   scope.
-
-Current implementation gate: execution-interval control job defaults and
-unit-list group 13 projection for `tmitv`, `etn`, and `ets`.
-
-## Prior Approval Evidence
-
 - 2026-05-01: User replied "OK.Proceed." after the unit-list group 13 file
   monitoring job default-aware projection approval request. Approved changes
   were limited to making group 13 `flwc`, `flwi`, `flco`, and `ets` columns
@@ -335,6 +362,17 @@ Only clear human approval can change Status to Approved.
 
 ## Validation
 
+- 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
+- 2026-05-01: `pnpm run test:compile`
+- 2026-05-01: `npm test`
+- 2026-05-01: `pnpm run qlty`
+- 2026-05-01: `npm run test:web` completed with exit code 0 and existing
+  localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-01: `pnpm run lint:md`
 - 2026-05-01: `pnpm run test:compile`
 - 2026-05-01: `pnpm run qlty`
 - 2026-05-01: `npm test`

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -31,8 +31,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Choose the next JP1/AJS3 v13 parameter-alignment slice after
-   execution-interval control job defaults.
+1. Prepare QUEUE job unit-list group 15 projection as the next focused
+   parameter-alignment behavior contract, then record approval before
+   implementation.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime
@@ -40,33 +41,28 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/interval-control-defaults`.
+- Branch: `codex/queue-group15-projection`.
 - Objective: continue the JP1/AJS3 v13 parameter alignment feature with a
-  focused implementation of execution-interval control job defaults and group
-  13 projection.
-- Status: unit-list group 13 file monitoring job projection is merged in
-  PR #225. The current slice is approved and implemented locally.
-- Scope: align omitted `tmitv`, `etn`, and `ets` behavior on
-  execution-interval control jobs (`tmwj` / `rtmwj`) and make unit-list group
-  13 projection default-aware for those values.
+  focused implementation of QUEUE job group 15 transfer-file projection.
+- Status: execution-interval control job defaults are merged in PR #226. The
+  current slice is approved and implemented locally.
+- Scope: hide `top1` to `top4` transfer-operation projection on QUEUE jobs
+  (`qj` / `rq`) while preserving explicit `ts1` to `ts4` and `td1` to `td4`
+  projection.
 - Out of scope: parser grammar changes, command generation, diagnostics,
-  generated artifacts, dependency changes, `engines.vscode`, numeric range
-  validation, invalid-combination diagnostics, and broader raw projection
-  policy changes.
+  generated artifacts, dependency changes, `engines.vscode`, byte-length
+  validation, macro-variable validation, invalid-combination diagnostics, and
+  broader raw projection policy changes.
 - Impact summary: the candidate affects
-  `src/domain/models/parameters/Defaults.ts`,
-  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`,
   `src/application/unit-list/buildUnitListRemainingGroups.ts`,
   `src/application/unit-list/buildUnitListView.ts` DTO fields only if helper
-  typing requires it, focused parameter factory and unit-list regression
-  tests, and the execution-interval control job SDD documents. Existing
-  domain default behavior in `ParamFactory.etn` and `ParamFactory.ets` is
-  reused; `ParamFactory.tmitv` now uses `DEFAULTS.Tmitv`.
+  typing requires it, focused unit-list regression tests, and the QUEUE job
+  SDD documents. Existing `Qj` / `Rq` wrapper behavior already avoids `topN`;
+  the approval-sensitive boundary is user-visible group 15 projection.
 - Risks and assumptions: behavior changes are user-visible in the table viewer
-  because omitted execution-interval control job group 13 fields would display
-  defaults instead of empty cells. Adding a `tmitv` domain default is also
-  observable through the `Tmwj.tmitv` wrapper. Raw parser output and
-  normalized parameter storage remain preserved.
+  because raw `topN` values on QUEUE jobs would no longer appear in group 15
+  transfer-operation columns. Raw parser output and normalized parameter
+  storage remain preserved.
 
 ## Build/Test Performance SDD
 
@@ -95,8 +91,7 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: execution-interval control job defaults and unit-list group 13
-  default-aware projection.
+  slice: QUEUE job unit-list group 15 unit-type-aware projection.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:
@@ -133,6 +128,14 @@ Current branch checks:
 - 2026-05-01: `npm run build` completed with existing webpack asset-size
   warnings
 - 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run test:compile`
+- 2026-05-01: `npm test`
+- 2026-05-01: `pnpm run qlty`
+- 2026-05-01: `npm run test:web` completed with exit code 0 and existing
+  localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-01: `pnpm run lint:md`
 - 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
   log-file permission failure
 - 2026-05-01: `pnpm run test:compile`
@@ -143,6 +146,9 @@ Current branch checks:
 - 2026-05-01: `npm run build` completed with existing webpack asset-size
   warnings
 - 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `pnpm run test:compile`
 - 2026-04-29: `pnpm run qlty` required an escalated rerun after a sandboxed

--- a/src/application/unit-list/buildUnitListRemainingGroups.ts
+++ b/src/application/unit-list/buildUnitListRemainingGroups.ts
@@ -32,6 +32,9 @@ const isFileMonitoringJob = (unit: AjsUnit): boolean =>
 const isExecutionIntervalControlJob = (unit: AjsUnit): boolean =>
   unit.unitType === "tmwj" || unit.unitType === "rtmwj";
 
+const isQueueJob = (unit: AjsUnit): boolean =>
+  unit.unitType === "qj" || unit.unitType === "rq";
+
 const findDefaultAwareParameterValue = (
   unit: AjsUnit,
   key: ParamSymbol,
@@ -85,6 +88,12 @@ const findGroup13EventTimeoutAction = (unit: AjsUnit): string | undefined =>
     DEFAULTS.Ets,
     isFileMonitoringJob(unit) || isExecutionIntervalControlJob(unit),
   );
+
+const findGroup15TransferOperation = (
+  unit: AjsUnit,
+  key: "top1" | "top2" | "top3" | "top4",
+): string | undefined =>
+  isQueueJob(unit) ? undefined : findAjsUnitParameterValue(unit, key);
 
 export const buildUnitListRemainingGroups = (
   unit: AjsUnit,
@@ -252,16 +261,16 @@ export const buildUnitListRemainingGroups = (
     jobType: findAjsUnitParameterValue(unit, "jty"),
     terminationStatus1: findAjsUnitParameterValue(unit, "ts1"),
     terminationDelay1: findAjsUnitParameterValue(unit, "td1"),
-    terminationOperation1: findAjsUnitParameterValue(unit, "top1"),
+    terminationOperation1: findGroup15TransferOperation(unit, "top1"),
     terminationStatus2: findAjsUnitParameterValue(unit, "ts2"),
     terminationDelay2: findAjsUnitParameterValue(unit, "td2"),
-    terminationOperation2: findAjsUnitParameterValue(unit, "top2"),
+    terminationOperation2: findGroup15TransferOperation(unit, "top2"),
     terminationStatus3: findAjsUnitParameterValue(unit, "ts3"),
     terminationDelay3: findAjsUnitParameterValue(unit, "td3"),
-    terminationOperation3: findAjsUnitParameterValue(unit, "top3"),
+    terminationOperation3: findGroup15TransferOperation(unit, "top3"),
     terminationStatus4: findAjsUnitParameterValue(unit, "ts4"),
     terminationDelay4: findAjsUnitParameterValue(unit, "td4"),
-    terminationOperation4: findAjsUnitParameterValue(unit, "top4"),
+    terminationOperation4: findGroup15TransferOperation(unit, "top4"),
   },
   group16: {
     endWaitUnitName: findAjsUnitParameterValue(unit, "eun"),

--- a/src/test/suite/buildUnitListRemainingGroups.test.ts
+++ b/src/test/suite/buildUnitListRemainingGroups.test.ts
@@ -114,6 +114,40 @@ unit=root,,jp1admin,;
 }
 `;
 
+const queueGroup15Definition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  unit=queue,,jp1admin,;
+  {
+    ty=qj;
+    ts1=queue-src-1;
+    td1=queue-dst-1;
+    top1=sav;
+    ts2=queue-src-2;
+    td2=queue-dst-2;
+    top2=del;
+  }
+  unit=recovery-queue,,jp1admin,;
+  {
+    ty=rq;
+    ts3=recovery-src-3;
+    td3=recovery-dst-3;
+    top3=sav;
+  }
+  unit=regular-job,,jp1admin,;
+  {
+    ty=j;
+    ts1=regular-src-1;
+    td1=regular-dst-1;
+    top1=del;
+    ts4=regular-src-4;
+    td4=regular-dst-4;
+    top4=sav;
+  }
+}
+`;
+
 suite("Build Unit List Remaining Groups", () => {
   test("projects all remaining group fields from unit parameters", () => {
     const result = parseAjs(definition);
@@ -277,5 +311,53 @@ suite("Build Unit List Remaining Groups", () => {
     assert.strictEqual(regularView.group13.timeoutInterval, undefined);
     assert.strictEqual(regularView.group13.eventTimeout, undefined);
     assert.strictEqual(regularView.group13.eventTimeoutAction, undefined);
+  });
+
+  test("hides QUEUE job transfer operations in group 15", () => {
+    const result = parseAjs(queueGroup15Definition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const queueJob = document.rootUnits[0]?.children[0];
+    const recoveryQueueJob = document.rootUnits[0]?.children[1];
+    const regularJob = document.rootUnits[0]?.children[2];
+
+    assert.ok(queueJob);
+    assert.ok(recoveryQueueJob);
+    assert.ok(regularJob);
+
+    const queueView = buildUnitListRemainingGroups(queueJob, [], []);
+    const recoveryQueueView = buildUnitListRemainingGroups(
+      recoveryQueueJob,
+      [],
+      [],
+    );
+    const regularView = buildUnitListRemainingGroups(regularJob, [], []);
+
+    assert.strictEqual(queueView.group15.terminationStatus1, "queue-src-1");
+    assert.strictEqual(queueView.group15.terminationDelay1, "queue-dst-1");
+    assert.strictEqual(queueView.group15.terminationOperation1, undefined);
+    assert.strictEqual(queueView.group15.terminationStatus2, "queue-src-2");
+    assert.strictEqual(queueView.group15.terminationDelay2, "queue-dst-2");
+    assert.strictEqual(queueView.group15.terminationOperation2, undefined);
+
+    assert.strictEqual(
+      recoveryQueueView.group15.terminationStatus3,
+      "recovery-src-3",
+    );
+    assert.strictEqual(
+      recoveryQueueView.group15.terminationDelay3,
+      "recovery-dst-3",
+    );
+    assert.strictEqual(
+      recoveryQueueView.group15.terminationOperation3,
+      undefined,
+    );
+
+    assert.strictEqual(regularView.group15.terminationStatus1, "regular-src-1");
+    assert.strictEqual(regularView.group15.terminationDelay1, "regular-dst-1");
+    assert.strictEqual(regularView.group15.terminationOperation1, "del");
+    assert.strictEqual(regularView.group15.terminationStatus4, "regular-src-4");
+    assert.strictEqual(regularView.group15.terminationDelay4, "regular-dst-4");
+    assert.strictEqual(regularView.group15.terminationOperation4, "sav");
   });
 });


### PR DESCRIPTION
## Summary
- hide group 15 top1-top4 transfer-operation projection for qj/rq QUEUE jobs
- preserve QUEUE ts1-ts4 and td1-td4 projection and non-QUEUE topN projection
- update focused SDD/use-case docs and regression coverage

## Validation
- pnpm run test:compile
- npm test
- pnpm run qlty
- npm run test:web
- npm run build
- pnpm run lint:md
- git diff --check

Notes: npm run test:web completed with the existing localhost dev-extension package.nls.json 404 noise. npm run build completed with existing webpack asset-size warnings.