### PR TITLE
[codex] Route agent CLI commands through rtk

### DIFF
--- a/.agent.md
+++ b/.agent.md
@@ -15,6 +15,8 @@ This file declares the AI agent configuration for this repository. Both
 
 - **Invoked via**: Terminal command (`copilot ...`)
 - **Best for**: Complex automation, git operations, CI/CD setup
+- **CLI execution**: Use `rtk` proxies by default for shell, git, GitHub,
+  package-script, test, and build commands
 - **Config**: `.github/copilot-instructions.md`
 
 ### Codex (VS Code Copilot)
@@ -75,7 +77,7 @@ This file declares the AI agent configuration for this repository. Both
 2. Follows link to `AGENTS.md` § "AI Agent Routing Guide"
 3. Looks up task type in routing matrix
 4. Reads relevant `docs/specs/` for context
-5. Executes with bash/git tools
+5. Executes CLI commands through `rtk` proxies by default
 
 ### Codex
 

--- a/.codex/skills/sdd-change/SKILL.md
+++ b/.codex/skills/sdd-change/SKILL.md
@@ -112,5 +112,5 @@ Keep the notes short and focused on impact, decisions, and validation.
 - keep KISS and YAGNI ahead of abstraction; avoid over-DRY process or code
 - use a `docs/...` branch name only when the slice stays within the docs-only
   file set used by `.github/workflows/verify.yml`
-- for docs-only changes, `pnpm run qlty` is required; add
-  `pnpm run lint:md` when useful
+- for docs-only changes, `rtk pnpm run qlty` is required; add
+  `rtk pnpm run lint:md` when useful

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,17 +52,25 @@ Check the routing matrix in `AGENTS.md` § "AI Agent Routing Guide":
 
 ## Build and Test Commands
 
+Run CLI commands through `rtk` by default when a matching proxy exists. Use a
+native command only when `rtk` has no suitable proxy, exact unfiltered output is
+required, the command is interactive, or an `rtk` proxy needs native-command
+confirmation.
+
 ```bash
-pnpm run qlty      # Lint and quality checks
-pnpm test          # Desktop extension tests
-pnpm run test:web  # Web extension tests
-pnpm run build     # Production build
+rtk pnpm run qlty      # Lint and quality checks
+rtk pnpm test          # Desktop extension tests
+rtk pnpm run test:web  # Web extension tests
+rtk pnpm run build     # Production build
 ```
 
-**Full validation sequence** (use before pushing):
+**Full validation sequence** (use before pushing; run serially):
 
 ```bash
-pnpm run qlty && pnpm test && pnpm run test:web && pnpm run build
+rtk pnpm run qlty
+rtk pnpm test
+rtk pnpm run test:web
+rtk pnpm run build
 ```
 
 ## Testing Policy
@@ -71,8 +79,9 @@ When touching parser, list view, flow view, CSV export, diagnostics, hover,
 or adapter boundaries:
 
 - Add or update unit/integration tests
-- Run `pnpm run qlty && pnpm test && pnpm run test:web`
-- For docs-only changes, `pnpm run lint:md` is sufficient
+- Run `rtk pnpm run qlty`, `rtk pnpm test`, and
+  `rtk pnpm run test:web`
+- For docs-only changes, `rtk pnpm run lint:md` is sufficient
 
 ## Key Constraints
 
@@ -121,7 +130,8 @@ routing matrix first.
 - For complex changes, follow the SDD workflow in `AGENTS.md` § "SDD Workflow"
 - Refer to `docs/specs/features/` for use-case examples
 - Keep assumptions and design decisions documented in feature `PLANS.md`
-- Run full validation (`pnpm run qlty && pnpm test && pnpm run test:web && pnpm run build`) before pushing
+- Run full validation (`rtk pnpm run qlty`, `rtk pnpm test`,
+  `rtk pnpm run test:web`, `rtk pnpm run build`) before pushing
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,36 @@ When finishing a task, provide:
 3. compatibility risks
 4. follow-up tasks if any
 
+## CLI Command Policy
+
+AI agents should run CLI commands through `rtk` by default when `rtk` provides
+an appropriate proxy. Prefer `rtk` for command output that can otherwise flood
+agent context, including file inspection, search, git/GitHub operations,
+package scripts, tests, builds, type checks, and browser test tooling.
+
+Examples:
+
+- `rtk ls`
+- `rtk read AGENTS.md`
+- `rtk grep "pattern" src`
+- `rtk git status --short --branch`
+- `rtk gh pr view`
+- `rtk pnpm run qlty`
+- `rtk pnpm test`
+- `rtk pnpm run test:web`
+- `rtk pnpm run build`
+
+Use the native command directly only when:
+
+- `rtk` has no suitable proxy for the command
+- exact, unfiltered output is required for diagnosis or user reporting
+- the command is interactive or relies on shell behavior that `rtk` should not
+  wrap
+- an `rtk` proxy fails and the native command is needed to confirm the issue
+
+When falling back to a native command, mention the reason in the task summary if
+it affects validation or reproducibility.
+
 ## Forbidden Changes
 
 Do not:
@@ -198,7 +228,8 @@ This repository is designed to work seamlessly with multiple AI agents, each wit
   - Git operations and branch management
   - CI/CD setup and scripting
   - Batch operations across files
-- **Capabilities**: Full bash/git/tool access, parallel execution
+- **Capabilities**: Full bash/git/tool access through `rtk` by default,
+  parallel execution
 - **Configuration**: `.github/copilot-instructions.md`
 
 #### Codex (VS Code Copilot)

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ For detailed task-to-agent assignment with Primary/Fallback options:
 - `.github/copilot-instructions.md` - Copilot CLI entry point
 - `.codex/skills/` - Codex-specific workflows
 
+AI agents should run CLI commands through `rtk` by default when a matching
+proxy exists, for example `rtk git status --short --branch`,
+`rtk pnpm run qlty`, or `rtk pnpm run build`. Use native commands only when
+`rtk` has no suitable proxy, exact unfiltered output is required, or the
+command is interactive.
+
 ## Telemetry
 
 This extension collects telemetry data to improve the experience of using this


### PR DESCRIPTION
## Summary
- add an AGENTS.md CLI command policy that tells AI agents to prefer rtk proxies
- update Copilot CLI, Codex SDD skill, .agent.md, and README guidance to use rtk examples
- document native-command fallback cases for exact output, interactivity, or unsupported commands

## Validation
- rtk pnpm run lint:md
- rtk pnpm run qlty (rerun with elevated permissions after qlty log-file sandbox failure)

## Compatibility
- Documentation/configuration guidance only; no runtime extension code or engines.vscode changes.