### PR TITLE
Release 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.14.0]
+
+- Added read-only JP1/AJS WebAPI import as a beta command.
+- Improved JP1/AJS3 version 13 parameter handling so table output and defaults
+  better match the official definition reference.
+
 ## [1.13.1]
 
 - Fixed flow-view nested expand/collapse layout so expanded panels stay

--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -26,7 +26,10 @@ embedding VS Code object construction inside parser-adjacent business logic.
 - domain and application layers must not construct `vscode.Diagnostic`,
   `vscode.Hover`, `vscode.Range`, or `vscode.MarkdownString`
 - VS Code adapters map DTOs into editor-specific objects
-- existing diagnostic messages and hover syntax content must remain unchanged
+- existing parser syntax diagnostic messages and hover syntax content must
+  remain unchanged
+- semantic parameter diagnostics must preserve raw parsed data and report
+  focused JP1/AJS3 version 13 rule violations without changing parser output
 
 ## Behavioral Scenarios (Gherkin)
 
@@ -47,6 +50,14 @@ Scenario: VS Code objects stay outside application output
   Given JP1/AJS editor feedback output
   When diagnostics and hover data are produced
   Then the application output does not construct VS Code API objects
+
+Scenario: Invalid parameter combinations produce semantic diagnostics
+  Given a syntactically valid JP1/AJS document
+  And the document contains a parameter combination that violates an explicit
+    JP1/AJS3 version 13 rule
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
@@ -75,7 +75,57 @@ This document covers the currently modeled end-judgment defaults for `jd`,
 
 ## Follow-up
 
-- Add range validation only after deciding whether invalid JP1/AJS parameter
-  values should become diagnostics, warnings, or preserved raw values.
-- Model `jd` / `abr` invalid combinations once the behavior contract is
-  explicit enough to test across domain and editor-feedback paths.
+- Add range validation only after the first semantic diagnostic slice proves
+  where source locations and parameter-rule checks belong.
+- Model additional retry diagnostics after `jd` / `abr` invalid-combination
+  behavior is implemented and validated across domain and editor-feedback
+  paths.
+
+## JD / ABR Diagnostic Candidate
+
+### Current Behavior
+
+- `ParamFactory.jd` resolves omitted `jd` to `cod`.
+- `ParamFactory.abr` resolves omitted `abr` to `n`.
+- Explicit invalid combinations, such as `jd=ab` with `abr=y`, are preserved
+  as raw values and do not currently produce semantic diagnostics.
+- `buildSyntaxDiagnostics` currently maps parser syntax errors only; it does
+  not inspect parsed units for JP1/AJS parameter-rule violations.
+- Parsed unit parameters preserve key, value, and definition order, but not
+  line and column source locations.
+
+### Proposed Behavior
+
+After human approval:
+
+- keep raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, and command generation unchanged;
+- add an application-level semantic diagnostic when an explicit UNIX/PC job or
+  UNIX/PC custom job has effective `abr=y` and effective `jd` is not `cod`;
+- report the diagnostic through the existing editor-feedback DTO and VS Code
+  adapter path so desktop and web hosts share the same rule;
+- keep omitted `jd=cod` and omitted `abr=n` behavior non-diagnostic;
+- add focused tests for syntax-only diagnostics, valid omitted defaults,
+  explicit valid `jd=cod` / `abr=y`, and explicit invalid `jd` / `abr`
+  combinations.
+
+### Impact
+
+- User-visible diagnostics change for syntactically valid JP1/AJS documents
+  containing the invalid combination.
+- The parser grammar should not change, but parsed parameter source locations
+  may need to be added to `Unit.parameters` so semantic diagnostics can point
+  at the explicit offending parameter instead of reporting a generic document
+  position.
+- The application diagnostics boundary broadens from syntax-only feedback to
+  syntax plus focused semantic parameter feedback.
+
+### Diagnostic Alternatives
+
+- Preserve invalid combinations silently and leave the matrix gap visible.
+- Change domain defaults or wrapper values to avoid the invalid combination,
+  rejected because raw manual-invalid input should remain inspectable.
+- Add broad parameter validation first, rejected because it is too large for
+  the next alignment slice.
+- Add diagnostics without source locations, possible as a fallback but less
+  useful for editor feedback and likely to weaken regression evidence.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -98,6 +98,12 @@ JP1/AJS3 version 13 reference documents.
   table output. If approved, it should consume execution-interval defaults for
   `tmitv`, `etn`, and `ets` while preserving explicit normalized values,
   parser output, and normalized raw parameter storage.
+- Job end-judgment `jd` / `abr` diagnostics are approval-sensitive because
+  existing behavior preserves explicit invalid combinations as raw parsed
+  values without editor feedback. A diagnostic slice must preserve raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  and command generation while adding application-level semantic diagnostics
+  through the existing editor-feedback boundary.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -121,6 +121,15 @@
 - [x] Add focused group 15 regression evidence for QUEUE `tsN` / `tdN`
       preservation, QUEUE `topN` hiding, and non-QUEUE `topN` preservation
 - [x] Run required code-change validation after implementation
+- [x] Investigate job end-judgment `jd` / `abr` invalid-combination diagnostics
+      as the next parameter semantic diagnostics slice
+- [ ] Record human approval before changing editor-feedback diagnostics,
+      parser source-location data, runtime code, tests, generated artifacts,
+      or configuration
+- [ ] Implement focused `jd` / `abr` semantic diagnostics only after approval
+- [ ] Add focused diagnostics regression evidence for valid omitted defaults,
+      explicit valid retry settings, and explicit invalid combinations
+- [ ] Run required code-change validation after implementation
 
 ## Notes
 
@@ -279,25 +288,35 @@
   transfer-operation values for `qj` / `rq`. Explicit `ts1` to `ts4` and
   `td1` to `td4` remain visible, non-QUEUE `topN` projection remains visible,
   and raw parser/normalized values remain unchanged.
+- 2026-05-01: job end-judgment `jd` / `abr` invalid-combination diagnostics
+  are the next approval-gated parameter semantic diagnostics candidate. The
+  proposed scope is limited to reporting explicit UNIX/PC job and UNIX/PC
+  custom job `abr=y` values when the effective `jd` value is not `cod`,
+  preserving raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, and command generation. Parser grammar, generated
+  artifacts, configuration, dependency versions, `engines.vscode`, retry range
+  diagnostics, byte-length validation, and broad range validation remain out of
+  scope.
 
 ## Human Approval
 
-- Status: Approved
-- Approved at: 2026-05-01
-- Approved scope: User replied "OK. Proceed." after the QUEUE job unit-list
-  group 15 projection approval request. Approved changes are limited to
-  hiding `top1` to `top4` transfer-operation projection for `qj` / `rq`,
-  preserving explicit `ts1` to `ts4` and `td1` to `td4`, preserving non-QUEUE
-  `topN` projection, adding focused regression evidence, updating SDD and
-  use-case tracking, and running validation. Parser grammar, normalized raw
-  parameter storage, diagnostics, generated artifacts, configuration,
-  dependency versions, and `engines.vscode` changes are out of scope.
+- Status: Pending
+- Approved at:
+- Approved scope:
 
-Current implementation gate: QUEUE job unit-list group 15 projection for
-`ts1` to `ts4`, `td1` to `td4`, and `top1` to `top4`.
+Current implementation gate: job end-judgment `jd` / `abr`
+invalid-combination diagnostics.
 
 ## Prior Approval Evidence
 
+- 2026-05-01: User replied "OK. Proceed." after the QUEUE job unit-list group
+  15 projection approval request. Approved changes were limited to hiding
+  `top1` to `top4` transfer-operation projection for `qj` / `rq`, preserving
+  explicit `ts1` to `ts4` and `td1` to `td4`, preserving non-QUEUE `topN`
+  projection, adding focused regression evidence, updating SDD and use-case
+  tracking, and running validation. Parser grammar, normalized raw parameter
+  storage, diagnostics, generated artifacts, configuration, dependency
+  versions, and `engines.vscode` changes were out of scope.
 - 2026-05-01: User replied "OK. Proceed." after the execution-interval
   control job defaults and unit-list group 13 projection approval request.
   Approved changes were limited to aligning omitted `tmwj` / `rtmwj`

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -31,9 +31,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Prepare QUEUE job unit-list group 15 projection as the next focused
-   parameter-alignment behavior contract, then record approval before
-   implementation.
+1. Prepare job end-judgment `jd` / `abr` invalid-combination diagnostics as
+   the next focused parameter-alignment behavior contract, then record approval
+   before implementation.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime
@@ -41,28 +41,28 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/queue-group15-projection`.
+- Branch: `codex/job-end-judgment-diagnostics`.
 - Objective: continue the JP1/AJS3 v13 parameter alignment feature with a
-  focused implementation of QUEUE job group 15 transfer-file projection.
-- Status: execution-interval control job defaults are merged in PR #226. The
-  current slice is approved and implemented locally.
-- Scope: hide `top1` to `top4` transfer-operation projection on QUEUE jobs
-  (`qj` / `rq`) while preserving explicit `ts1` to `ts4` and `td1` to `td4`
-  projection.
-- Out of scope: parser grammar changes, command generation, diagnostics,
-  generated artifacts, dependency changes, `engines.vscode`, byte-length
-  validation, macro-variable validation, invalid-combination diagnostics, and
-  broader raw projection policy changes.
+  focused diagnostic contract for job end-judgment invalid combinations.
+- Status: investigation recorded; implementation approval is pending.
+- Scope: add application-level semantic diagnostics for explicit UNIX/PC job
+  and UNIX/PC custom job `abr=y` values when the effective `jd` value is not
+  `cod`, while preserving raw parser output, domain wrapper values, unit-list
+  projection, and command generation.
+- Out of scope: parser grammar changes, generated artifacts, dependency
+  changes, `engines.vscode`, changing `jd` / `abr` default semantics, changing
+  list or flow projection, retry range diagnostics, byte-length validation, and
+  broad parameter range validation.
 - Impact summary: the candidate affects
-  `src/application/unit-list/buildUnitListRemainingGroups.ts`,
-  `src/application/unit-list/buildUnitListView.ts` DTO fields only if helper
-  typing requires it, focused unit-list regression tests, and the QUEUE job
-  SDD documents. Existing `Qj` / `Rq` wrapper behavior already avoids `topN`;
-  the approval-sensitive boundary is user-visible group 15 projection.
-- Risks and assumptions: behavior changes are user-visible in the table viewer
-  because raw `topN` values on QUEUE jobs would no longer appear in group 15
-  transfer-operation columns. Raw parser output and normalized parameter
-  storage remain preserved.
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts` or an adjacent
+  application diagnostic helper, `src/domain/services/parser/AjsEvaluator.ts`
+  and `src/domain/values/Unit.ts` only if parameter source locations are added,
+  focused diagnostics tests, VS Code diagnostic adapter behavior through the
+  existing DTO mapping, and the job end-judgment SDD documents.
+- Risks and assumptions: the diagnostic is user-visible in both desktop and
+  web extension hosts. Implementation should keep parser syntax diagnostics
+  unchanged and should report semantic diagnostics only when explicit
+  parameters make the invalid combination observable.
 
 ## Build/Test Performance SDD
 
@@ -109,6 +109,13 @@ contracts were compressed into `docs/requirements/use-cases/`.
 
 Current branch checks:
 
+- 2026-05-01: `pnpm run lint:md`
+- 2026-05-01: `pnpm run qlty`
+- 2026-05-01: `npm test`
+- 2026-05-01: `npm run test:web` completed with exit code 0 and existing
+  localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `npm run build` completed with existing webpack asset-size
+  warnings
 - 2026-04-29: `pnpm run qlty`
 - 2026-04-29: `pnpm run lint:md`
 - 2026-04-29: `pnpm run test:compile`

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -35,6 +35,8 @@
    - Unit-list group 10 projection now consumes effective schedule-rule
      `wc` / `wt` start-condition monitoring values after the domain-only
      pairing API was implemented.
+   - The next focused remaining gap is parameter semantic diagnostics, starting
+     with job end-judgment `jd` / `abr` invalid-combination reporting.
    - Keep behavior-preserving slices separate from behavior-changing manual
      alignment slices.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-ajsbutler",
   "displayName": "vscode-ajsbutler",
   "description": "Support tool for JP1/AJS3",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary

- Release vscode-ajsbutler 1.14.0.
- Add user-facing changelog entries for the beta JP1/AJS WebAPI import and JP1/AJS3 v13 parameter handling improvements.
- Include SDD planning for the next focused parameter semantic diagnostics slice.

## Validation

- pnpm run lint:md
- pnpm run qlty
- npm test
- npm run test:web
- npm run build
- vsce publish --no-dependencies

## Release

Published kittybbit.vscode-ajsbutler v1.14.0 to the Visual Studio Marketplace and pushed tag v1.14.0.

## Notes

The first vsce publish attempt failed during npm dependency detection against pnpm node_modules, so the successful publish used the official --no-dependencies option. The generated VSIX included .serena files, which should be excluded in a follow-up .vscodeignore cleanup.