### PR TITLE
[codex] Add job end judgment diagnostics

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
@@ -49,7 +49,8 @@ This document covers the currently modeled end-judgment defaults for `jd`,
   schedule-rule `wt` parameter.
 - `wth` and `jdf` are not synthesized when omitted.
 - Invalid combinations, such as `jd` values other than `cod` with `abr=y`,
-  remain preserved raw values until the diagnostics policy is explicit.
+  remain preserved raw values and are reported through focused semantic
+  diagnostics for UNIX/PC jobs and UNIX/PC custom jobs.
 
 ## WTH Key Mapping Follow-up
 
@@ -94,18 +95,17 @@ This document covers the currently modeled end-judgment defaults for `jd`,
 - Parsed unit parameters preserve key, value, and definition order, but not
   line and column source locations.
 
-### Proposed Behavior
+### Implemented Behavior
 
-After human approval:
-
-- keep raw parser output, domain wrapper values, normalized parameters,
-  unit-list projection, and command generation unchanged;
-- add an application-level semantic diagnostic when an explicit UNIX/PC job or
-  UNIX/PC custom job has effective `abr=y` and effective `jd` is not `cod`;
-- report the diagnostic through the existing editor-feedback DTO and VS Code
-  adapter path so desktop and web hosts share the same rule;
-- keep omitted `jd=cod` and omitted `abr=n` behavior non-diagnostic;
-- add focused tests for syntax-only diagnostics, valid omitted defaults,
+- Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, and command generation remain unchanged.
+- The application diagnostics boundary reports a semantic diagnostic when an
+  explicit UNIX/PC job or UNIX/PC custom job has effective `abr=y` and
+  effective `jd` is not `cod`.
+- The diagnostic is reported through the existing editor-feedback DTO and VS
+  Code adapter path so desktop and web hosts share the same rule.
+- Omitted `jd=cod` and omitted `abr=n` behavior remains non-diagnostic.
+- Focused tests cover syntax-only diagnostics, valid omitted defaults,
   explicit valid `jd=cod` / `abr=y`, and explicit invalid `jd` / `abr`
   combinations.
 
@@ -113,9 +113,9 @@ After human approval:
 
 - User-visible diagnostics change for syntactically valid JP1/AJS documents
   containing the invalid combination.
-- The parser grammar should not change, but parsed parameter source locations
-  may need to be added to `Unit.parameters` so semantic diagnostics can point
-  at the explicit offending parameter instead of reporting a generic document
+- The parser grammar did not change, but parsed parameter source locations
+  were added to `Unit.parameters` so semantic diagnostics can point at the
+  explicit offending parameter instead of reporting a generic document
   position.
 - The application diagnostics boundary broadens from syntax-only feedback to
   syntax plus focused semantic parameter feedback.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -123,13 +123,13 @@
 - [x] Run required code-change validation after implementation
 - [x] Investigate job end-judgment `jd` / `abr` invalid-combination diagnostics
       as the next parameter semantic diagnostics slice
-- [ ] Record human approval before changing editor-feedback diagnostics,
+- [x] Record human approval before changing editor-feedback diagnostics,
       parser source-location data, runtime code, tests, generated artifacts,
       or configuration
-- [ ] Implement focused `jd` / `abr` semantic diagnostics only after approval
-- [ ] Add focused diagnostics regression evidence for valid omitted defaults,
+- [x] Implement focused `jd` / `abr` semantic diagnostics only after approval
+- [x] Add focused diagnostics regression evidence for valid omitted defaults,
       explicit valid retry settings, and explicit invalid combinations
-- [ ] Run required code-change validation after implementation
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -297,12 +297,34 @@
   artifacts, configuration, dependency versions, `engines.vscode`, retry range
   diagnostics, byte-length validation, and broad range validation remain out of
   scope.
+- 2026-05-01: implementation approval was recorded for job end-judgment
+  `jd` / `abr` invalid-combination diagnostics. Complete reference impact
+  check before editing the application diagnostic boundary and parser
+  source-location data, then keep the implementation limited to the approved
+  semantic diagnostic and focused regression evidence.
+- 2026-05-01: job end-judgment `jd` / `abr` invalid-combination diagnostics
+  now report explicit UNIX/PC job and UNIX/PC custom job `abr=y` values when
+  the effective `jd` value is not `cod`. Parser grammar, raw parser values,
+  domain wrapper values, normalized parameters, unit-list projection, command
+  generation, generated artifacts, configuration, dependency versions, and
+  `engines.vscode` remain unchanged. Parameter source-location metadata was
+  added to support diagnostic ranges.
 
 ## Human Approval
 
-- Status: Pending
-- Approved at:
-- Approved scope:
+- Status: Approved
+- Approved at: 2026-05-01
+- Approved scope: User replied "OK.Proceed." after the job end-judgment
+  `jd` / `abr` invalid-combination diagnostics approval request. Approved
+  changes are limited to adding focused application-level semantic diagnostics
+  for explicit UNIX/PC job and UNIX/PC custom job `abr=y` values when the
+  effective `jd` value is not `cod`; adding source-location metadata only as
+  needed for diagnostic ranges; preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, and command generation;
+  adding focused regression evidence; updating SDD tracking; and running
+  validation. Parser grammar, generated artifacts, configuration, dependency
+  versions, `engines.vscode`, retry range diagnostics, byte-length validation,
+  and broad parameter range validation remain out of scope.
 
 Current implementation gate: job end-judgment `jd` / `abr`
 invalid-combination diagnostics.
@@ -335,9 +357,6 @@ invalid-combination diagnostics.
   running validation. Parser grammar, raw domain wrappers, normalized raw
   parameter storage, diagnostics, generated artifacts, configuration,
   dependency versions, and `engines.vscode` changes were out of scope.
-
-Implementation must not start while Status is Pending.
-Only clear human approval can change Status to Approved.
 
 - 2026-04-29: Approved unit-list group 14 default-aware projection for JP1
   event sending job arrival-check defaults. Approved changes were limited to
@@ -381,6 +400,16 @@ Only clear human approval can change Status to Approved.
 
 ## Validation
 
+- 2026-05-01: `pnpm run qlty` completed with exit code 0; final runs used an
+  escalated command because sandboxed qlty cannot create its log file
+- 2026-05-01: `pnpm test`
+- 2026-05-01: `pnpm run test:web` required an escalated rerun after Chromium
+  failed to launch in the sandbox with macOS Mach port permission errors; the
+  escalated rerun completed with exit code 0 and existing localhost
+  dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `pnpm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-01: `pnpm run lint:md`
 - 2026-05-01: `pnpm run lint:md`
 - 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
   log-file permission failure

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -31,9 +31,8 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Prepare job end-judgment `jd` / `abr` invalid-combination diagnostics as
-   the next focused parameter-alignment behavior contract, then record approval
-   before implementation.
+1. Select the next focused JP1/AJS3 v13 parameter-alignment gap from the
+   documented deferred diagnostics and range-validation candidates.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime
@@ -44,7 +43,7 @@ rules in `docs/specs/README.md`, not in this file.
 - Branch: `codex/job-end-judgment-diagnostics`.
 - Objective: continue the JP1/AJS3 v13 parameter alignment feature with a
   focused diagnostic contract for job end-judgment invalid combinations.
-- Status: investigation recorded; implementation approval is pending.
+- Status: implemented and validated on 2026-05-01.
 - Scope: add application-level semantic diagnostics for explicit UNIX/PC job
   and UNIX/PC custom job `abr=y` values when the effective `jd` value is not
   `cod`, while preserving raw parser output, domain wrapper values, unit-list
@@ -63,6 +62,12 @@ rules in `docs/specs/README.md`, not in this file.
   web extension hosts. Implementation should keep parser syntax diagnostics
   unchanged and should report semantic diagnostics only when explicit
   parameters make the invalid combination observable.
+- Outcome: explicit UNIX/PC job and UNIX/PC custom job `abr=y` values now
+  produce semantic diagnostics when the effective `jd` value is not `cod`.
+  Parameter source-location metadata supports diagnostic ranges; parser
+  grammar, raw parser values, domain wrapper values, normalized parameters,
+  unit-list projection, command generation, generated artifacts,
+  configuration, dependency versions, and `engines.vscode` remain unchanged.
 
 ## Build/Test Performance SDD
 
@@ -91,7 +96,7 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: QUEUE job unit-list group 15 unit-type-aware projection.
+  slice: job end-judgment semantic diagnostics.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:
@@ -109,6 +114,16 @@ contracts were compressed into `docs/requirements/use-cases/`.
 
 Current branch checks:
 
+- 2026-05-01: `pnpm run qlty` completed with exit code 0; final runs used an
+  escalated command because sandboxed qlty cannot create its log file
+- 2026-05-01: `pnpm test`
+- 2026-05-01: `pnpm run test:web` required an escalated rerun after Chromium
+  failed to launch in the sandbox with macOS Mach port permission errors; the
+  escalated rerun completed with exit code 0 and existing localhost
+  dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `pnpm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-01: `pnpm run lint:md`
 - 2026-05-01: `pnpm run lint:md`
 - 2026-05-01: `pnpm run qlty`
 - 2026-05-01: `npm test`

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -35,8 +35,11 @@
    - Unit-list group 10 projection now consumes effective schedule-rule
      `wc` / `wt` start-condition monitoring values after the domain-only
      pairing API was implemented.
-   - The next focused remaining gap is parameter semantic diagnostics, starting
-     with job end-judgment `jd` / `abr` invalid-combination reporting.
+   - The first focused parameter semantic diagnostic reports job end-judgment
+     `jd` / `abr` invalid combinations for UNIX/PC jobs and UNIX/PC custom
+     jobs while preserving raw parameter data.
+   - Continue with documented deferred diagnostics and range-validation gaps
+     only as focused, approval-gated slices.
    - Keep behavior-preserving slices separate from behavior-changing manual
      alignment slices.
 

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -1,4 +1,6 @@
 import { parseAjs } from "../../domain/services/parser/AjsParser";
+import { DEFAULTS } from "../../domain/models/parameters/Defaults";
+import type { Unit, UnitParameter } from "../../domain/values/Unit";
 
 export type SyntaxDiagnosticDto = {
   line: number;
@@ -8,15 +10,75 @@ export type SyntaxDiagnosticDto = {
   severity: "error";
 };
 
+const jobEndJudgmentDiagnosticTargetTypes = new Set([
+  "j",
+  "rj",
+  "pj",
+  "rp",
+  "cj",
+  "rcj",
+]);
+
+const flattenUnits = (units: Unit[]): Unit[] =>
+  units.reduce<Unit[]>(
+    (allUnits, unit) => [...allUnits, unit, ...flattenUnits(unit.children)],
+    [],
+  );
+
+const findParameter = (unit: Unit, key: string): UnitParameter | undefined =>
+  unit.parameters.find((parameter) => parameter.key === key);
+
+const buildJobEndJudgmentDiagnostics = (
+  rootUnits: Unit[],
+): SyntaxDiagnosticDto[] =>
+  flattenUnits(rootUnits)
+    .filter((unit) => {
+      const unitType = findParameter(unit, "ty")?.value;
+      return unitType
+        ? jobEndJudgmentDiagnosticTargetTypes.has(unitType)
+        : false;
+    })
+    .flatMap((unit) => {
+      const abrParameter = findParameter(unit, "abr");
+      if (abrParameter?.value !== "y") {
+        return [];
+      }
+
+      const effectiveJobEndJudgment =
+        findParameter(unit, "jd")?.value ?? DEFAULTS.Jd;
+      if (effectiveJobEndJudgment === DEFAULTS.Jd) {
+        return [];
+      }
+
+      return [
+        {
+          line: abrParameter.line ?? 1,
+          column: abrParameter.column ?? 0,
+          length: abrParameter.length ?? abrParameter.key.length,
+          message:
+            "Automatic retry (abr=y) requires end judgment (jd) to be cod.",
+          severity: "error" as const,
+        },
+      ];
+    });
+
 export const buildSyntaxDiagnostics = (
   content: string,
 ): SyntaxDiagnosticDto[] => {
   const result = parseAjs(content);
-  return result.errors.map((error) => ({
+  const syntaxDiagnostics = result.errors.map((error) => ({
     line: error.line,
     column: error.charPositionInLine,
     length: 1,
     message: error.msg,
-    severity: "error",
+    severity: "error" as const,
   }));
+  if (syntaxDiagnostics.length > 0) {
+    return syntaxDiagnostics;
+  }
+
+  return [
+    ...syntaxDiagnostics,
+    ...buildJobEndJudgmentDiagnostics(result.rootUnits),
+  ];
 };

--- a/src/application/unit-list/unitListDocument.ts
+++ b/src/application/unit-list/unitListDocument.ts
@@ -1,10 +1,10 @@
-import { AjsUnit } from "../../domain/models/ajs/AjsDocument";
+import { AjsParameter, AjsUnit } from "../../domain/models/ajs/AjsDocument";
 import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
 import { Unit } from "../../domain/values/Unit";
 
 export type UnitListRootDto = {
   unitAttribute: string;
-  parameters: Array<{ key: string; value: string; position?: number }>;
+  parameters: AjsParameter[];
   children: UnitListRootDto[];
 };
 

--- a/src/domain/models/ajs/AjsDocument.ts
+++ b/src/domain/models/ajs/AjsDocument.ts
@@ -1,8 +1,10 @@
 import { ParamSymbol, TySymbol } from "../../values/AjsType";
+import type { UnitParameter } from "../../values/Unit";
 
 export type AjsUnitType = TySymbol;
 export type AjsGroupType = "n" | "p";
 export type AjsRelationType = "seq" | "con";
+export type AjsParameter = Pick<UnitParameter, "key" | "value" | "position">;
 
 export type AjsRelation = {
   sourceUnitId: string;
@@ -38,7 +40,7 @@ export type AjsUnit = {
     h: number;
     v: number;
   };
-  parameters: Array<{ key: string; value: string; position?: number }>;
+  parameters: AjsParameter[];
   relations: AjsRelation[];
   children: AjsUnit[];
 };
@@ -47,8 +49,6 @@ export type AjsDocument = {
   rootUnits: AjsUnit[];
   warnings: AjsNormalizationWarning[];
 };
-
-export type AjsParameter = AjsUnit["parameters"][number];
 
 export const flattenAjsUnits = (units: AjsUnit[]): AjsUnit[] =>
   units.reduce<AjsUnit[]>(

--- a/src/domain/models/ajs/normalize/unitBuilder.ts
+++ b/src/domain/models/ajs/normalize/unitBuilder.ts
@@ -35,7 +35,11 @@ export const buildNormalizedUnit = (
   hasSchedule: resolveNormalizedHasSchedule(unit, unitType),
   hasWaitedFor: resolveNormalizedHasWaitedFor(unit),
   layout: resolveNormalizedLayout(unit),
-  parameters: unit.parameters.map((parameter) => ({ ...parameter })),
+  parameters: unit.parameters.map((parameter) => ({
+    key: parameter.key,
+    value: parameter.value,
+    position: parameter.position,
+  })),
   relations,
   children,
 });

--- a/src/domain/services/parser/AjsEvaluator.ts
+++ b/src/domain/services/parser/AjsEvaluator.ts
@@ -46,6 +46,9 @@ export class Ajs3v12Evaluator implements AjsParserListener {
       key: ctx._key.text as string,
       value: ctx._value.text as string,
       position: this.#currentUnit.parameters.length,
+      line: ctx._key.line,
+      column: ctx._key.charPositionInLine,
+      length: ctx._key.text?.length ?? 1,
     });
   };
 

--- a/src/domain/values/Unit.ts
+++ b/src/domain/values/Unit.ts
@@ -1,3 +1,12 @@
+export type UnitParameter = {
+  key: string;
+  value: string;
+  position?: number;
+  line?: number;
+  column?: number;
+  length?: number;
+};
+
 /**
  * raw object of unit
  */
@@ -6,7 +15,7 @@ export class Unit {
   unitAttribute: string;
 
   /** definition parameters */
-  parameters: Array<{ key: string; value: string; position?: number }>;
+  parameters: UnitParameter[];
 
   /** parent */
   parent?: Unit;

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -22,4 +22,100 @@ suite("Build Syntax Diagnostics", () => {
 
     assert.deepStrictEqual(diagnostics, []);
   });
+
+  test("does not report end-judgment diagnostics for omitted defaults", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("does not report end-judgment diagnostics for explicit valid retry settings", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    jd=cod;",
+        "    abr=y;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports end-judgment diagnostics for explicit invalid retry combinations", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=custom,cj,+160+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    jd=ab;",
+        "    abr=y;",
+        "  }",
+        "  unit=custom,,jp1admin,;",
+        "  {",
+        "    ty=cj;",
+        "    jd=nm;",
+        "    abr=y;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 2);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 10,
+          column: 4,
+          length: 3,
+          message:
+            "Automatic retry (abr=y) requires end judgment (jd) to be cod.",
+        },
+        {
+          line: 16,
+          column: 4,
+          length: 3,
+          message:
+            "Automatic retry (abr=y) requires end judgment (jd) to be cod.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error"],
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Add focused semantic diagnostics for invalid job end-judgment retry combinations.
- Report explicit UNIX/PC job and UNIX/PC custom job `abr=y` when the effective `jd` value is not `cod`.
- Preserve parser grammar, raw/domain/normalized parameter behavior, list/flow projection, and command generation.
- Sync SDD plans, roadmap, TASKS, and job end-judgment alignment docs.

## Validation

- `pnpm run qlty`
- `pnpm test`
- `pnpm run test:web` (required an escalated rerun because Chromium cannot launch in the sandbox; passed with existing dev-extension `package.nls.json` 404 noise)
- `pnpm run build` (passed with existing webpack asset-size warnings)
- `pnpm run lint:md`
- `pnpm run test:compile`

## Compatibility

- `engines.vscode` unchanged.
- Parser grammar and generated artifacts unchanged.
- Web extension test passed.
- User-visible change is limited to new Diagnostics/Problems errors for the approved invalid `jd` / `abr` combinations.