### PR TITLE
[codex] Add job retry diagnostics

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
@@ -84,7 +84,7 @@ This document covers the currently modeled end-judgment defaults for `jd`,
 
 ## JD / ABR Diagnostic Candidate
 
-### Current Behavior
+### JD / ABR Current Behavior
 
 - `ParamFactory.jd` resolves omitted `jd` to `cod`.
 - `ParamFactory.abr` resolves omitted `abr` to `n`.
@@ -109,7 +109,7 @@ This document covers the currently modeled end-judgment defaults for `jd`,
   explicit valid `jd=cod` / `abr=y`, and explicit invalid `jd` / `abr`
   combinations.
 
-### Impact
+### JD / ABR Diagnostic Impact
 
 - User-visible diagnostics change for syntactically valid JP1/AJS documents
   containing the invalid combination.
@@ -120,7 +120,7 @@ This document covers the currently modeled end-judgment defaults for `jd`,
 - The application diagnostics boundary broadens from syntax-only feedback to
   syntax plus focused semantic parameter feedback.
 
-### Diagnostic Alternatives
+### JD / ABR Diagnostic Alternatives
 
 - Preserve invalid combinations silently and leave the matrix gap visible.
 - Change domain defaults or wrapper values to avoid the invalid combination,
@@ -129,3 +129,48 @@ This document covers the currently modeled end-judgment defaults for `jd`,
   the next alignment slice.
 - Add diagnostics without source locations, possible as a fallback but less
   useful for editor feedback and likely to weaken regression evidence.
+
+## Retry Parameter Diagnostic Candidate
+
+### Current Behavior
+
+- `buildSyntaxDiagnostics` now reports the focused `jd` / `abr`
+  invalid-combination diagnostic after syntax parsing succeeds.
+- Explicit `rjs`, `rje`, `rec`, and `rei` values are preserved as raw values
+  and do not currently produce semantic diagnostics when effective `jd` is not
+  `cod`.
+- Unit-list group 11 projects retry parameters from normalized raw key/value
+  data, so invalid combinations remain visible in the table viewer.
+
+### Implemented Retry Behavior
+
+- keep raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation unchanged;
+- focused application-level semantic diagnostics report when an explicit UNIX/PC
+  job or UNIX/PC custom job has effective `jd` not equal to `cod` and also
+  specifies any of `rjs`, `rje`, `rec`, or `rei`;
+- each diagnostic is reported through the existing editor-feedback DTO and VS Code
+  adapter path so desktop and web hosts share the same rule;
+- keep omitted retry parameters non-diagnostic;
+- keep explicit `jd=cod` with retry parameters non-diagnostic for this slice;
+- focused tests cover valid `jd=cod` retry parameters and explicit invalid
+  `jd` / retry-parameter combinations.
+
+### Impact
+
+- User-visible diagnostics change for syntactically valid JP1/AJS documents
+  containing the invalid combination.
+- Existing parser source-location metadata can point diagnostics at the
+  explicit offending retry parameter.
+- The application diagnostics boundary remains the owner of semantic
+  parameter feedback; parser grammar and domain wrapper values remain raw.
+
+### Diagnostic Alternatives
+
+- Preserve invalid retry parameters silently and leave the matrix gap visible.
+- Remove or hide retry values from domain/list outputs when `jd` is not `cod`,
+  rejected because manual-invalid raw input should remain inspectable.
+- Add numeric range checks for `rjs`, `rje`, `rec`, and `rei` in the same
+  slice, rejected because this broadens the behavior and regression surface.
+- Implement a generic parameter-rule engine first, deferred because the next
+  slice can be covered by the existing small diagnostics boundary.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -73,8 +73,10 @@ coverage.
   `Defaults.ts`
 - Evidence: `parameterFactory.test.ts` and `jobEndJudgmentHelpers.test.ts`
 - Remaining gap:
-  range validation, `jd` / `abr` invalid-combination diagnostics, and retry
-  diagnostics remain deferred
+  `jd` / `abr` invalid-combination diagnostics are aligned through
+  editor-feedback. Retry-parameter diagnostics for effective non-`cod` end
+  judgment are aligned through editor-feedback. Numeric range validation and
+  retry threshold ordering remain deferred.
 
 ### HTTP Connection Job Defaults
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -104,6 +104,13 @@ JP1/AJS3 version 13 reference documents.
   output, domain wrapper values, normalized parameters, unit-list projection,
   and command generation while adding application-level semantic diagnostics
   through the existing editor-feedback boundary.
+- Job end-judgment retry-parameter diagnostics are approval-sensitive for the
+  same reason: existing behavior preserves explicit `rjs`, `rje`, `rec`, and
+  `rei` values even when effective `jd` is not `cod`. A focused diagnostic
+  slice should report these explicit invalid combinations through
+  editor-feedback while preserving raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -130,6 +130,15 @@
 - [x] Add focused diagnostics regression evidence for valid omitted defaults,
       explicit valid retry settings, and explicit invalid combinations
 - [x] Run required code-change validation after implementation
+- [x] Investigate job end-judgment retry-parameter diagnostics as the next
+      focused semantic diagnostics slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration
+- [x] Implement focused retry-parameter semantic diagnostics only after
+      approval
+- [x] Add focused diagnostics regression evidence for valid `jd=cod` retry
+      parameters and explicit invalid `jd` / retry-parameter combinations
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -309,28 +318,56 @@
   generation, generated artifacts, configuration, dependency versions, and
   `engines.vscode` remain unchanged. Parameter source-location metadata was
   added to support diagnostic ranges.
+- 2026-05-01: job end-judgment retry-parameter diagnostics are the next
+  approval-gated semantic diagnostics candidate. JP1/AJS3 version 13 UNIX/PC
+  job and UNIX/PC custom job definitions say `rjs`, `rje`, `rec`, and `rei`
+  cannot be specified when the effective `jd` value is not `cod`. The
+  proposed scope is limited to reporting explicit target job retry parameters
+  when effective `jd` is not `cod`, preserving raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow projection,
+  and command generation. Parser grammar, generated artifacts, configuration,
+  dependency versions, `engines.vscode`, numeric retry ranges, threshold
+  ordering, byte-length validation, and broad parameter validation remain out
+  of scope.
+- 2026-05-01: job end-judgment retry-parameter diagnostics now report explicit
+  UNIX/PC job and UNIX/PC custom job `rjs`, `rje`, `rec`, or `rei` values when
+  the effective `jd` value is not `cod`. Parser grammar, raw parser values,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, command generation, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` remain unchanged. Numeric retry
+  ranges and threshold ordering remain deferred.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-01
 - Approved scope: User replied "OK.Proceed." after the job end-judgment
-  `jd` / `abr` invalid-combination diagnostics approval request. Approved
-  changes are limited to adding focused application-level semantic diagnostics
-  for explicit UNIX/PC job and UNIX/PC custom job `abr=y` values when the
+  retry-parameter diagnostics approval request. Approved changes are limited
+  to adding focused application-level semantic diagnostics for explicit
+  UNIX/PC job and UNIX/PC custom job `rjs`, `rje`, `rec`, or `rei` values
+  when the effective `jd` value is not `cod`; preserving raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation; adding focused regression evidence;
+  updating SDD tracking; and running validation. Parser grammar, generated
+  artifacts, configuration, dependency versions, `engines.vscode`, numeric
+  retry ranges, retry threshold ordering, byte-length validation, and broad
+  parameter validation remain out of scope.
+
+Current implementation gate: job end-judgment retry-parameter diagnostics.
+
+## Prior Approval Evidence
+
+- 2026-05-01: User replied "OK.Proceed." after the job end-judgment `jd` /
+  `abr` invalid-combination diagnostics approval request. Approved changes
+  were limited to adding focused application-level semantic diagnostics for
+  explicit UNIX/PC job and UNIX/PC custom job `abr=y` values when the
   effective `jd` value is not `cod`; adding source-location metadata only as
   needed for diagnostic ranges; preserving raw parser output, domain wrapper
   values, normalized parameters, unit-list projection, and command generation;
   adding focused regression evidence; updating SDD tracking; and running
   validation. Parser grammar, generated artifacts, configuration, dependency
   versions, `engines.vscode`, retry range diagnostics, byte-length validation,
-  and broad parameter range validation remain out of scope.
-
-Current implementation gate: job end-judgment `jd` / `abr`
-invalid-combination diagnostics.
-
-## Prior Approval Evidence
-
+  and broad parameter range validation were out of scope.
 - 2026-05-01: User replied "OK. Proceed." after the QUEUE job unit-list group
   15 projection approval request. Approved changes were limited to hiding
   `top1` to `top4` transfer-operation projection for `qj` / `rq`, preserving
@@ -400,6 +437,16 @@ invalid-combination diagnostics.
 
 ## Validation
 
+- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
+- 2026-05-01: `pnpm test`
+- 2026-05-01: `pnpm run test:web` required an escalated rerun after Chromium
+  failed to launch in the sandbox with macOS Mach port permission errors; the
+  escalated rerun completed with exit code 0 and existing localhost
+  dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `pnpm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-01: `pnpm run lint:md`
 - 2026-05-01: `pnpm run qlty` completed with exit code 0; final runs used an
   escalated command because sandboxed qlty cannot create its log file
 - 2026-05-01: `pnpm test`

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -31,8 +31,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Select the next focused JP1/AJS3 v13 parameter-alignment gap from the
-   documented deferred diagnostics and range-validation candidates.
+1. Prepare job end-judgment retry-parameter diagnostics as the next focused
+   JP1/AJS3 v13 parameter-alignment behavior contract, then record approval
+   before implementation.
 2. Keep WebAPI import beta feedback and real-environment smoke evidence
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime
@@ -40,34 +41,40 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/job-end-judgment-diagnostics`.
+- Branch: `codex/job-end-judgment-retry-diagnostics`.
 - Objective: continue the JP1/AJS3 v13 parameter alignment feature with a
-  focused diagnostic contract for job end-judgment invalid combinations.
+  focused diagnostic contract for job end-judgment retry parameters.
 - Status: implemented and validated on 2026-05-01.
 - Scope: add application-level semantic diagnostics for explicit UNIX/PC job
-  and UNIX/PC custom job `abr=y` values when the effective `jd` value is not
-  `cod`, while preserving raw parser output, domain wrapper values, unit-list
+  and UNIX/PC custom job `rjs`, `rje`, `rec`, or `rei` values when the
+  effective `jd` value is not `cod`, while preserving raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
   projection, and command generation.
 - Out of scope: parser grammar changes, generated artifacts, dependency
-  changes, `engines.vscode`, changing `jd` / `abr` default semantics, changing
-  list or flow projection, retry range diagnostics, byte-length validation, and
-  broad parameter range validation.
+  changes, `engines.vscode`, changing `jd` / retry default semantics, changing
+  list or flow projection, numeric retry range validation, retry threshold
+  ordering, byte-length validation, and broad parameter range validation.
 - Impact summary: the candidate affects
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts` or an adjacent
-  application diagnostic helper, `src/domain/services/parser/AjsEvaluator.ts`
-  and `src/domain/values/Unit.ts` only if parameter source locations are added,
-  focused diagnostics tests, VS Code diagnostic adapter behavior through the
-  existing DTO mapping, and the job end-judgment SDD documents.
+  application diagnostic helper, focused diagnostics tests, VS Code diagnostic
+  adapter behavior through the existing DTO mapping, and the job end-judgment
+  SDD documents. Existing parser source-location metadata should be sufficient
+  for diagnostic ranges.
 - Risks and assumptions: the diagnostic is user-visible in both desktop and
   web extension hosts. Implementation should keep parser syntax diagnostics
   unchanged and should report semantic diagnostics only when explicit
   parameters make the invalid combination observable.
-- Outcome: explicit UNIX/PC job and UNIX/PC custom job `abr=y` values now
-  produce semantic diagnostics when the effective `jd` value is not `cod`.
-  Parameter source-location metadata supports diagnostic ranges; parser
-  grammar, raw parser values, domain wrapper values, normalized parameters,
-  unit-list projection, command generation, generated artifacts,
-  configuration, dependency versions, and `engines.vscode` remain unchanged.
+- Alternatives considered: keep invalid retry parameters silent and leave the
+  matrix gap visible; hide or alter retry values in domain/list outputs when
+  `jd` is not `cod`, rejected because raw manual-invalid input should remain
+  inspectable; add numeric range validation in the same slice, deferred because
+  it broadens the behavior and regression surface.
+- Outcome: explicit UNIX/PC job and UNIX/PC custom job `rjs`, `rje`, `rec`, or
+  `rei` values now produce semantic diagnostics when the effective `jd` value
+  is not `cod`. Parser grammar, raw parser values, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, command
+  generation, generated artifacts, configuration, dependency versions, and
+  `engines.vscode` remain unchanged.
 
 ## Build/Test Performance SDD
 
@@ -96,7 +103,7 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: job end-judgment semantic diagnostics.
+  slice: job end-judgment retry-parameter diagnostics.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:
@@ -114,6 +121,16 @@ contracts were compressed into `docs/requirements/use-cases/`.
 
 Current branch checks:
 
+- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
+  log-file permission failure
+- 2026-05-01: `pnpm test`
+- 2026-05-01: `pnpm run test:web` required an escalated rerun after Chromium
+  failed to launch in the sandbox with macOS Mach port permission errors; the
+  escalated rerun completed with exit code 0 and existing localhost
+  dev-extension `package.nls.json` 404 noise
+- 2026-05-01: `pnpm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-01: `pnpm run lint:md`
 - 2026-05-01: `pnpm run qlty` completed with exit code 0; final runs used an
   escalated command because sandboxed qlty cannot create its log file
 - 2026-05-01: `pnpm test`

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -38,6 +38,9 @@
    - The first focused parameter semantic diagnostic reports job end-judgment
      `jd` / `abr` invalid combinations for UNIX/PC jobs and UNIX/PC custom
      jobs while preserving raw parameter data.
+   - The next focused semantic diagnostic candidate is job end-judgment retry
+     parameter reporting for explicit `rjs`, `rje`, `rec`, or `rei` values
+     when effective `jd` is not `cod`.
    - Continue with documented deferred diagnostics and range-validation gaps
      only as focused, approval-gated slices.
    - Keep behavior-preserving slices separate from behavior-changing manual

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -18,6 +18,7 @@ const jobEndJudgmentDiagnosticTargetTypes = new Set([
   "cj",
   "rcj",
 ]);
+const jobEndJudgmentRetryParameterKeys = ["rjs", "rje", "rec", "rei"];
 
 const flattenUnits = (units: Unit[]): Unit[] =>
   units.reduce<Unit[]>(
@@ -39,27 +40,41 @@ const buildJobEndJudgmentDiagnostics = (
         : false;
     })
     .flatMap((unit) => {
+      const diagnostics: SyntaxDiagnosticDto[] = [];
       const abrParameter = findParameter(unit, "abr");
-      if (abrParameter?.value !== "y") {
-        return [];
-      }
-
       const effectiveJobEndJudgment =
         findParameter(unit, "jd")?.value ?? DEFAULTS.Jd;
       if (effectiveJobEndJudgment === DEFAULTS.Jd) {
         return [];
       }
 
-      return [
-        {
+      if (abrParameter?.value === "y") {
+        diagnostics.push({
           line: abrParameter.line ?? 1,
           column: abrParameter.column ?? 0,
           length: abrParameter.length ?? abrParameter.key.length,
           message:
             "Automatic retry (abr=y) requires end judgment (jd) to be cod.",
           severity: "error" as const,
-        },
-      ];
+        });
+      }
+
+      for (const retryParameterKey of jobEndJudgmentRetryParameterKeys) {
+        const retryParameter = findParameter(unit, retryParameterKey);
+        if (!retryParameter) {
+          continue;
+        }
+
+        diagnostics.push({
+          line: retryParameter.line ?? 1,
+          column: retryParameter.column ?? 0,
+          length: retryParameter.length ?? retryParameter.key.length,
+          message: `Retry parameter (${retryParameterKey}) requires end judgment (jd) to be cod.`,
+          severity: "error" as const,
+        });
+      }
+
+      return diagnostics;
     });
 
 export const buildSyntaxDiagnostics = (

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -54,6 +54,10 @@ suite("Build Syntax Diagnostics", () => {
         "    ty=j;",
         "    jd=cod;",
         "    abr=y;",
+        "    rjs=1;",
+        "    rje=9;",
+        "    rec=3;",
+        "    rei=1;",
         "  }",
         "}",
         "",
@@ -116,6 +120,78 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(
       diagnostics.map((diagnostic) => diagnostic.severity),
       ["error", "error"],
+    );
+  });
+
+  test("reports retry parameter diagnostics for explicit invalid end-judgment combinations", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=custom,cj,+160+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    jd=ab;",
+        "    rjs=1;",
+        "    rje=9;",
+        "  }",
+        "  unit=custom,,jp1admin,;",
+        "  {",
+        "    ty=cj;",
+        "    jd=nm;",
+        "    rec=3;",
+        "    rei=1;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 4);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 10,
+          column: 4,
+          length: 3,
+          message:
+            "Retry parameter (rjs) requires end judgment (jd) to be cod.",
+        },
+        {
+          line: 11,
+          column: 4,
+          length: 3,
+          message:
+            "Retry parameter (rje) requires end judgment (jd) to be cod.",
+        },
+        {
+          line: 17,
+          column: 4,
+          length: 3,
+          message:
+            "Retry parameter (rec) requires end judgment (jd) to be cod.",
+        },
+        {
+          line: 18,
+          column: 4,
+          length: 3,
+          message:
+            "Retry parameter (rei) requires end judgment (jd) to be cod.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error", "error"],
     );
   });
 });


### PR DESCRIPTION
## Summary

- Add focused semantic diagnostics for retry parameters on job end-judgment definitions.
- Report explicit UNIX/PC job and UNIX/PC custom job `rjs`, `rje`, `rec`, or `rei` values when the effective `jd` value is not `cod`.
- Preserve parser grammar, raw/domain/normalized parameter behavior, list/flow projection, and command generation.
- Sync SDD plans, roadmap, TASKS, coverage matrix, and job end-judgment alignment docs.

## Validation

- `pnpm run qlty` (required an escalated rerun because sandboxed qlty cannot create its log file)
- `pnpm test`
- `pnpm run test:web` (required an escalated rerun because Chromium cannot launch in the sandbox; passed with existing dev-extension `package.nls.json` 404 noise)
- `pnpm run build` (passed with existing webpack asset-size warnings)
- `pnpm run lint:md`

## Compatibility

- `engines.vscode` unchanged.
- Parser grammar, generated artifacts, configuration, and dependencies unchanged.
- Web extension test passed.
- User-visible change is limited to new Diagnostics/Problems errors for the approved invalid `jd` / retry-parameter combinations.