### PR TITLE
[codex] Update SDD agent usage guidance

### DIFF
--- a/.codex/skills/sdd-change/SKILL.md
+++ b/.codex/skills/sdd-change/SKILL.md
@@ -18,9 +18,14 @@ SDD investigation, approval, evidence, implementation, and validation flow.
 2. read `package.json`
 3. read the relevant files in `docs/specs/`
 4. run the investigation-only phase before implementation changes:
+   - use a high-accuracy model for planning, impact investigation, design
+     decisions, and pre-approval review when model selection is available
    - search affected functions, classes, components, and commands
    - follow `docs/specs/README.md` semantic code navigation guidance when
      Serena or an equivalent tool is available
+   - use Serena selectively: targeted symbol lookup, direct references,
+     call-site and dependency impact, then broad exploration only if
+     uncertainty remains
    - list affected files, features, tests, docs, and breaking-change risk
    - when behavior scenarios exist, list changed, added, or removed scenarios
      and affected tests
@@ -57,6 +62,7 @@ Keep the notes short and focused on impact, decisions, and validation.
 - identify direct VS Code API boundaries and adapter locations
 - apply semantic code navigation checks from `docs/specs/README.md` when
   available
+- avoid broad semantic exploration until target symbols or references are known
 - summarize architectural risks, test impact, and compatibility impact
 
 ### Planning
@@ -105,6 +111,20 @@ Keep the notes short and focused on impact, decisions, and validation.
   in `docs/specs/README.md` `Implementation Change Gate`
 - implementation phase starts only when `TASKS.md` records `Status: Approved`
   and the approval text
+- implementation inside the approved scope may use medium- or lower-cost models
+  when model selection is available
+- if implementation reveals a specification change, design decision, destructive
+  change, or out-of-scope edit, stop and return to high-accuracy investigation
+  and re-approval
+- Serena is a supplemental aid for impact and reference checks; it does not
+  replace manual analysis, SDD records, human approval, tests, or validation
+- do not treat Serena-only results as proof that a change is safe
+- do not repeat the same semantic search unless a new question requires it
+- Codex, GitHub Copilot, or other coding assistants may help, but changing the
+  agent or model never changes the SDD gate
+- Copilot suggestions must be checked against approved `SPECS.md`, `TASKS.md`,
+  and approved scope before adoption; reject suggestions outside scope unless
+  the work returns to investigation and re-approval
 - keep `engines.vscode` unchanged unless explicitly approved
 - preserve desktop and web extension behavior
 - prefer small vertical slices over broad rewrites
@@ -112,5 +132,7 @@ Keep the notes short and focused on impact, decisions, and validation.
 - keep KISS and YAGNI ahead of abstraction; avoid over-DRY process or code
 - use a `docs/...` branch name only when the slice stays within the docs-only
   file set used by `.github/workflows/verify.yml`
+- run validation through `rtk` by default
 - for docs-only changes, `rtk pnpm run qlty` is required; add
   `rtk pnpm run lint:md` when useful
+- `rtk` reduces cost and output volume; it is not a reason to skip validation

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -43,8 +43,9 @@ For non-trivial changes:
    branch priorities change materially
 9. refresh `docs/specs/roadmap.md` in the same commit if a completed slice
    changes repository-level ordering, remaining debt, or deferred work
-10. before `git push`, run local validation serially in this order for code
-    changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`, `pnpm run build`
+10. before `git push`, run local validation through `rtk` serially in this
+    order for code changes: `rtk pnpm run qlty`, `rtk pnpm test`,
+    `rtk pnpm run test:web`, `rtk pnpm run build`
 11. run any additional task-specific checks before finishing
 12. avoid anemic domain models: extract only cross-unit or cross-layer
     semantics into helpers/interfaces, and keep entity identity plus
@@ -54,10 +55,13 @@ For non-trivial changes:
 For docs-only changes:
 
 - `pnpm run build` is not required
-- `pnpm run qlty` is required
-- run `pnpm run lint:md` when the changed markdown scope benefits from
+- `rtk pnpm run qlty` is required
+- run `rtk pnpm run lint:md` when the changed markdown scope benefits from
   markdown-specific validation
 - repository `Verify` workflow should not be relied on as a required gate
+
+Run validation commands through `rtk` by default. `rtk` is a cost-control and
+execution-efficiency tool; it is not a reason to skip required validation.
 
 ## Semantic Code Navigation
 
@@ -71,6 +75,16 @@ reference and dependency impact, in:
 - Phase 1 impact investigation before requesting approval
 - Phase 3 reference impact verification after approval
 
+Use Serena selectively. Default order:
+
+1. targeted symbol lookup
+2. direct reference lookup
+3. call-site and dependency impact lookup
+4. broader repository exploration only when uncertainty remains
+
+Do not perform broad repository exploration before identifying target symbols.
+Do not repeat the same semantic search without a new question.
+
 Serena is supplemental tooling. It does not replace:
 
 - SDD artifacts
@@ -82,6 +96,10 @@ Serena is supplemental tooling. It does not replace:
 Manual impact analysis remains required. Do not treat Serena-only results as
 proof that a change is safe.
 
+Start with local, targeted lookup to reduce token use. Use broad exploration
+only when the targeted checks still leave uncertainty about impact or
+references.
+
 Minimal local setup:
 
 ```bash
@@ -92,6 +110,45 @@ serena setup codex
 
 If the MCP client cannot find `serena` on `PATH`, configure the Codex MCP
 server command with the absolute path to the installed `serena` executable.
+
+## Model and Agent Usage
+
+Use model and agent selection to control cost and precision without changing
+the SDD process. Do not define a separate abstract "intelligence" rule; choose
+the model based on whether the current phase requires judgment or execution.
+
+Recommended model use:
+
+- planning, impact investigation, design decisions, and pre-approval review:
+  use a high-accuracy model
+- destructive-change decisions, architecture decisions, and specification
+  decisions: use a high-accuracy model
+- implementation inside an already-approved scope: medium- or lower-cost
+  models may be used
+- simple fixes, lint follow-up, and approved test expectation updates:
+  lower-cost models may be used
+- if implementation reveals an out-of-scope change, specification change, or
+  design decision: stop and return to high-accuracy investigation and
+  re-approval
+
+Codex, GitHub Copilot, or another coding assistant may be used, but all agents
+must follow the same SDD gate. Changing the agent or model does not change the
+process.
+
+Every agent must preserve:
+
+- impact investigation
+- approval evidence
+- approved scope boundaries
+- required validation
+
+Copilot suggestions must be checked against the approved `SPECS.md`,
+`TASKS.md`, and approved scope before adoption. Do not accept Copilot
+suggestions outside the approved scope. If an out-of-scope change appears
+necessary, stop and return to investigation and re-approval.
+
+When Codex orchestrates work across agents, Codex owns consistency of the SDD
+documents, approval evidence, scope tracking, and validation record.
 
 ## Implementation Change Gate
 

--- a/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
+++ b/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
@@ -32,6 +32,7 @@ Implementation rules:
 12. Preserve VS Code compatibility declared in `package.json`.
 13. Add or update tests for every behavior change.
 14. Update documentation if implementation decisions differ from the spec.
+15. Changing the model or coding assistant does not change the SDD gate.
 
 Approval definition, approval evidence, and re-approval rules are centralized
 in `docs/specs/README.md` `Implementation Change Gate`.
@@ -41,6 +42,9 @@ Before editing:
 - Search affected functions, classes, components, commands, and DTOs.
 - Follow `docs/specs/README.md` semantic code navigation guidance when Serena
   or an equivalent tool is available.
+- Start Serena with targeted symbol lookup, then direct references, then
+  call-site and dependency impact. Use broad exploration only when uncertainty
+  remains.
 - List changed areas, affected features, affected tests, related docs, and
   breaking-change risk.
 - When behavior scenarios exist, list changed, added, or removed scenarios and
@@ -78,6 +82,10 @@ After approval:
   before implementation.
 - Do not implement if TASKS.md does not contain `Status: Approved` and
   `Approved scope`.
+- Medium- or lower-cost models may be used for simple implementation inside
+  the approved scope.
+- Keep Copilot or other supporting-agent suggestions inside the approved
+  `SPECS.md`, `TASKS.md`, and approval scope.
 - Inspect existing files and naming conventions.
 - Confirm every affected reference is either fixed or explicitly left
   unchanged in SPECS.md.
@@ -85,10 +93,12 @@ After approval:
 - Compile or run the closest fast check after meaningful changes.
 - If required changes exceed the approved scope, stop, update the impact
   record, and request additional clear approval before editing those areas.
+- If a specification decision, destructive change, or design judgment appears,
+  stop and return to high-accuracy investigation and re-approval.
 
 After editing:
 
-- Run available build/test commands.
+- Run available build/test commands through `rtk` by default.
 - Summarize changed files.
 - Summarize behavior compatibility.
 - List follow-up tasks.

--- a/docs/specs/features/_templates/PLANS.template.md
+++ b/docs/specs/features/_templates/PLANS.template.md
@@ -38,6 +38,7 @@
 
 ## Validation
 
-- code changes: `pnpm run qlty`, `pnpm test`, `pnpm run test:web`,
-  `pnpm run build`
-- docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when useful
+- code changes: `rtk pnpm run qlty`, `rtk pnpm test`,
+  `rtk pnpm run test:web`, `rtk pnpm run build`
+- docs-only changes: `rtk pnpm run qlty`; add `rtk pnpm run lint:md` when
+  useful

--- a/docs/specs/features/_templates/SPECS.template.md
+++ b/docs/specs/features/_templates/SPECS.template.md
@@ -68,6 +68,8 @@ Scenario: {{one observable behavior}}
 - VS Code compatibility follows `package.json` `engines.vscode`.
 - Web extension compatibility: {{impact}}
 - Desktop extension compatibility: {{impact}}
+- Model, Serena, or agent choice does not change this behavior contract or the
+  SDD approval gate.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

- Add lightweight SDD guidance for phase-based model selection without weakening approval gates.
- Clarify staged Serena usage for targeted semantic navigation before broader exploration.
- Document shared SDD gate expectations for Codex, GitHub Copilot, and other supporting agents.
- Keep validation guidance centered on `rtk` and remove the heavier Execution Budget template field.

## Impact

This is a docs-only SDD operations update. It does not change extension runtime behavior, tests, generated artifacts, configuration, or VS Code compatibility.

## Validation

- `rtk pnpm run qlty`
- `rtk pnpm run lint:md`