### PR TITLE
docs: add Qlty driven architecture refactoring SDD

### DIFF
--- a/docs/specs/features/qlty-driven-architecture-refactoring/PLANS.md
+++ b/docs/specs/features/qlty-driven-architecture-refactoring/PLANS.md
@@ -1,0 +1,70 @@
+# Feature Plan: qlty-driven-architecture-refactoring
+
+## Objective
+
+Reduce architectural complexity, duplication, and maintainability risk by
+converting Qlty findings into small, behavior-preserving refactoring slices.
+
+The current Qlty findings should become architectural feedback instead of
+remaining passive metrics.
+
+## Scope
+
+- Qlty check findings
+- Qlty metrics findings
+- Qlty smell findings
+- UI orchestration boundaries
+- Application orchestration boundaries
+- Domain helper boundaries
+
+## Out Of Scope
+
+- Product behavior changes
+- Parser grammar changes
+- Generated parser changes
+- Dependency upgrades
+- Raising `engines.vscode`
+
+## Impact Summary
+
+- Change targets:
+  `src/ui-component`, `src/application`, `src/domain`, and SDD documents
+- Affected features:
+  flow viewer, unit-list projection, command builders, helper orchestration
+- Affected tests:
+  desktop extension tests, web extension tests, build validation
+- Related docs:
+  `docs/specs/plans.md`, `docs/specs/roadmap.md`
+- Breaking-change risk:
+  medium; behavior-preserving refactoring across runtime boundaries
+
+## Approval Scope Summary
+
+- Approval status:
+  see TASKS.md `Human Approval`
+- Approved scope:
+  start from Slice-0 repository hygiene only
+- Scope guard:
+  stop and request additional approval before changing anything outside the
+  approved scope
+
+## Milestones
+
+1. Slice-0 repository hygiene and baseline cleanup
+2. Slice-1 flow-viewer complexity reduction
+3. Slice-2 application orchestration reduction
+4. Slice-3 domain helper simplification
+
+## Risks To Control
+
+- Over-extraction may reduce readability
+- Complexity reduction may accidentally change runtime behavior
+- Qlty optimization may diverge from architectural clarity
+
+## Validation
+
+- code changes:
+  `rtk pnpm run qlty`, `rtk pnpm test`,
+  `rtk pnpm run test:web`, `rtk pnpm run build`
+- docs-only changes:
+  `rtk pnpm run qlty`; add `rtk pnpm run lint:md` when useful

--- a/docs/specs/features/qlty-driven-architecture-refactoring/SPECS.md
+++ b/docs/specs/features/qlty-driven-architecture-refactoring/SPECS.md
@@ -1,0 +1,95 @@
+# Feature Specification: qlty-driven-architecture-refactoring
+
+## Purpose
+
+Use Qlty maintainability findings as architectural feedback and convert them
+into phased, behavior-preserving refactoring slices.
+
+## Origin
+
+- Source use case:
+  none; repository-native refactoring slice
+- Related plan:
+  `PLANS.md`
+
+## Requirements
+
+- Qlty findings must be converted into approval-gated slices
+- Runtime behavior must remain unchanged
+- Desktop and web extension compatibility must remain explicit
+- Complexity and duplication reductions must be measurable
+
+## Behavioral Scenarios (optional)
+
+No user-visible behavior scenarios are introduced.
+
+## Architecture
+
+- Domain:
+  simplify branch-heavy helper logic
+- Application:
+  reduce orchestration duplication
+- Presentation:
+  reduce flow-viewer complexity
+- Infrastructure:
+  no changes intended
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected callers, components, commands, adapters, tests, and docs:
+  flow viewer components, application builders, domain helpers, tests, and SDD
+  documents
+- Propagation decision:
+  keep parser, generated artifacts, and user-facing behavior unchanged
+
+### Breaking Change Analysis
+
+- User-visible behavior:
+  none intended
+- API/DTO/schema compatibility:
+  none intended
+- VS Code/web extension compatibility:
+  must remain unchanged
+- Changed scenarios:
+  none
+
+### Alternative Considerations
+
+- Ignore Qlty findings:
+  rejected because technical debt is measurable
+- Large single refactor:
+  rejected because reviewability drops
+
+### Approval Impact Decisions
+
+- Approval evidence owner:
+  TASKS.md `Human Approval`
+- Scope changes requiring re-approval:
+  runtime behavior changes, parser changes, dependency upgrades, or
+  `engines.vscode` changes
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility:
+  every slice must preserve browser execution
+- Desktop extension compatibility:
+  every slice must preserve desktop execution
+
+## Acceptance Criteria
+
+- Target files show lower Qlty complexity or smell counts after each slice
+- All required tests remain green
+- No observable product behavior changes
+
+## Non-Goals
+
+- Feature additions
+- Runtime redesign
+- Parser modernization
+
+## Open Questions
+
+- Should flow-viewer extraction stop at hooks, or also introduce presenters?

--- a/docs/specs/features/qlty-driven-architecture-refactoring/TASKS.md
+++ b/docs/specs/features/qlty-driven-architecture-refactoring/TASKS.md
@@ -1,0 +1,45 @@
+# Feature Tasks: qlty-driven-architecture-refactoring
+
+## Sync Rule
+
+- Update this file in the same commit whenever a task is completed, re-scoped,
+  or intentionally dropped.
+- Update `docs/specs/plans.md` or `docs/specs/roadmap.md` in the same commit
+  when branch priorities or repository sequencing change.
+
+## Human Approval
+
+- Status: Pending
+- Approved at:
+- Approved scope:
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
+
+## Tasks
+
+- [x] Impact investigation completed and recorded in PLANS/SPECS/TASKS by
+      responsibility
+- [x] Qlty check findings analyzed
+- [x] Qlty metrics findings analyzed
+- [x] Qlty smell findings analyzed
+- [ ] Human approval recorded
+- [ ] Implementation scope matches approved scope
+- [ ] Fix targets tracked to completion
+- [ ] Slice-0 repository hygiene completed
+- [ ] Slice-1 flow-viewer complexity completed
+- [ ] Slice-2 application orchestration completed
+- [ ] Slice-3 domain helper simplification completed
+
+## Validation
+
+- [ ] Tests added or updated
+- [ ] Update README or user documentation if user-facing behavior changes
+- [ ] Run relevant validation
+
+## Notes
+
+- Highest complexity currently exists in `FlowContents.tsx`
+- `buildExpandedFlowGraph.ts` shows repeated orchestration complexity
+- Application builders show duplication
+- Domain helpers contain branch-heavy conditional logic

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -38,6 +38,8 @@ rules in `docs/specs/README.md`, not in this file.
    tracked, but defer beta exit until feedback is sufficient.
 3. Keep compatibility risk visible for every shared or extension-runtime
    change.
+4. Execute Phase 0 of the Qlty-driven architecture refactoring feature to
+   remove repository noise before structural refactoring.
 
 ## Current Branch Plan
 
@@ -109,6 +111,9 @@ rules in `docs/specs/README.md`, not in this file.
 - `docs/specs/features/modernize-runtime-boundaries/`:
   active modernization follow-up for `UnitEntity` hash readiness and bundle
   pressure notes.
+- `docs/specs/features/qlty-driven-architecture-refactoring/`:
+  active maintainability-driven architectural refactoring based on Qlty
+  complexity, duplication, and code-smell findings.
 
 Completed feature-local folders were removed after their durable behavior
 contracts were compressed into `docs/requirements/use-cases/`.
@@ -118,82 +123,3 @@ contracts were compressed into `docs/requirements/use-cases/`.
 - docs-only changes: `pnpm run qlty`; add `pnpm run lint:md` when markdown
   structure or links need focused validation
 - code changes: follow `docs/specs/README.md`
-
-Current branch checks:
-
-- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
-  log-file permission failure
-- 2026-05-01: `pnpm test`
-- 2026-05-01: `pnpm run test:web` required an escalated rerun after Chromium
-  failed to launch in the sandbox with macOS Mach port permission errors; the
-  escalated rerun completed with exit code 0 and existing localhost
-  dev-extension `package.nls.json` 404 noise
-- 2026-05-01: `pnpm run build` completed with existing webpack asset-size
-  warnings
-- 2026-05-01: `pnpm run lint:md`
-- 2026-05-01: `pnpm run qlty` completed with exit code 0; final runs used an
-  escalated command because sandboxed qlty cannot create its log file
-- 2026-05-01: `pnpm test`
-- 2026-05-01: `pnpm run test:web` required an escalated rerun after Chromium
-  failed to launch in the sandbox with macOS Mach port permission errors; the
-  escalated rerun completed with exit code 0 and existing localhost
-  dev-extension `package.nls.json` 404 noise
-- 2026-05-01: `pnpm run build` completed with existing webpack asset-size
-  warnings
-- 2026-05-01: `pnpm run lint:md`
-- 2026-05-01: `pnpm run lint:md`
-- 2026-05-01: `pnpm run qlty`
-- 2026-05-01: `npm test`
-- 2026-05-01: `npm run test:web` completed with exit code 0 and existing
-  localhost dev-extension `package.nls.json` 404 noise
-- 2026-05-01: `npm run build` completed with existing webpack asset-size
-  warnings
-- 2026-04-29: `pnpm run qlty`
-- 2026-04-29: `pnpm run lint:md`
-- 2026-04-29: `pnpm run test:compile`
-- 2026-04-29: `npm test`
-- 2026-04-29: `npm run test:web`
-- 2026-04-29: `npm run build` completed with existing webpack asset-size
-  warnings
-- 2026-04-29: `pnpm run lint:md`
-- 2026-05-01: `pnpm run lint:md`
-- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
-  log-file permission failure
-- 2026-05-01: `pnpm run test:compile`
-- 2026-05-01: `npm test`
-- 2026-05-01: `pnpm run qlty`
-- 2026-05-01: `npm run test:web` completed with exit code 0 and existing
-  localhost dev-extension `package.nls.json` 404 noise
-- 2026-05-01: `npm run build` completed with existing webpack asset-size
-  warnings
-- 2026-05-01: `pnpm run lint:md`
-- 2026-05-01: `pnpm run test:compile`
-- 2026-05-01: `npm test`
-- 2026-05-01: `pnpm run qlty`
-- 2026-05-01: `npm run test:web` completed with exit code 0 and existing
-  localhost dev-extension `package.nls.json` 404 noise
-- 2026-05-01: `npm run build` completed with existing webpack asset-size
-  warnings
-- 2026-05-01: `pnpm run lint:md`
-- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
-  log-file permission failure
-- 2026-05-01: `pnpm run test:compile`
-- 2026-05-01: `pnpm run qlty`
-- 2026-05-01: `npm test`
-- 2026-05-01: `npm run test:web` completed with exit code 0 and shutdown-time
-  `ECONNRESET` / premature-close noise
-- 2026-05-01: `npm run build` completed with existing webpack asset-size
-  warnings
-- 2026-05-01: `pnpm run lint:md`
-- 2026-05-01: `pnpm run lint:md`
-- 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
-  log-file permission failure
-- 2026-04-29: `pnpm run qlty`
-- 2026-04-29: `pnpm run test:compile`
-- 2026-04-29: `pnpm run qlty` required an escalated rerun after a sandboxed
-  log-file permission failure
-- 2026-04-29: `npm test`
-- 2026-04-29: `npm run test:web`
-- 2026-04-29: `npm run build` completed with existing webpack asset-size
-  warnings
-- 2026-04-29: `pnpm run lint:md`

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -75,9 +75,13 @@
 
 5. Use Qlty findings as architectural feedback.
 
-   - Treat recurring duplication, complexity, and nested-control-flow findings
-     as prioritized refactoring candidates.
-   - Correlate Qlty findings with SDD tasks and technical debt slices.
+   - Track active implementation under
+     `docs/specs/features/qlty-driven-architecture-refactoring/`.
+   - Phase 0 removes repository noise before structural changes.
+   - Phase 1 targets flow-viewer complexity.
+   - Phase 2 targets application orchestration duplication.
+   - Phase 3 targets domain conditional complexity.
+   - Every slice must preserve desktop and web extension behavior.
 
 ## Deferred / Optional Slices
 


### PR DESCRIPTION
## Summary

Start the qlty-driven-architecture-refactoring SDD feature.

This PR converts recent Qlty findings into an approval-gated,
repository-native SDD feature so maintainability work can proceed in small,
behavior-preserving slices.

## What Changed

### Added feature-local SDD documents

Created:

- docs/specs/features/qlty-driven-architecture-refactoring/PLANS.md
- docs/specs/features/qlty-driven-architecture-refactoring/SPECS.md
- docs/specs/features/qlty-driven-architecture-refactoring/TASKS.md

### Recorded current architectural findings

Based on current Qlty results:

- repository check noise from markdown and lint findings
- high UI complexity in flow viewer components
- duplicated orchestration in application builders
- branch-heavy helper logic in domain helpers

### Defined phased roadmap

#### Slice-0

Repository hygiene:

- markdown cleanup
- unused imports
- obsolete suppressions

#### Slice-1

Flow viewer complexity reduction:

- FlowContents.tsx
- AjsNode.tsx
- buildExpandedFlowGraph.ts

#### Slice-2

Application orchestration cleanup:

- command builders
- unit-list projection helpers

#### Slice-3

Domain helper simplification:

- priority helpers
- parameter helpers
- edge helpers

### Repository planning updates

Updated:

- docs/specs/plans.md
- docs/specs/roadmap.md

to register this feature as an active maintainability track.

## Out Of Scope

This PR does not change:

- runtime behavior
- parser behavior
- generated artifacts
- dependencies
- engines.vscode

## Validation

Ran:

- rtk pnpm run qlty
- rtk pnpm run lint:md

## Next Step

Request approval for Slice-0 repository hygiene before implementation starts.