### PR TITLE
[codex] Add file monitoring diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -58,6 +58,21 @@ Scenario: Invalid parameter combinations produce semantic diagnostics
   When editor feedback is requested
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
+
+Scenario: Invalid file monitoring condition combinations produce diagnostics
+  Given a syntactically valid JP1/AJS document with a file monitoring job
+  And `flwc` specifies both size-change and modification-time monitoring
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
+Scenario: File existing-condition output requires creation monitoring
+  Given a syntactically valid JP1/AJS document with a file monitoring job
+  And `flco` is specified while the effective `flwc` value does not include
+    file-creation monitoring
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/FILE_MONITORING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/FILE_MONITORING_JOB_ALIGNMENT.md
@@ -59,6 +59,54 @@ This document focuses on the currently modeled file monitoring job parameters
 - Explicit normalized values remain preserved.
 - Omitted `flwf` remains empty because no monitored-file-name default exists.
 - Non-file-monitoring jobs do not synthesize these file monitoring defaults.
+- Editor feedback now reports focused semantic diagnostics for explicit
+  `flwj` / `rflwj` invalid combinations where `flwc` specifies both `s` and
+  `m`, or explicit `flco` is present when effective `flwc` does not include
+  `c`.
+
+## FLWC / FLCO Diagnostic Candidate
+
+### Current Behavior
+
+- `flwj` / `rflwj` raw parameters preserve explicit `flwc` and `flco` values
+  even when the combination is invalid according to JP1/AJS3 version 13.
+- `buildSyntaxDiagnostics` reports parser syntax errors and the focused job
+  end-judgment semantic diagnostics, but it does not inspect file monitoring
+  job parameter combinations.
+- Unit-list group 13 projects file monitoring values through the existing
+  default-aware projection boundary, so invalid raw combinations can remain
+  visible in table output.
+
+### Implemented Diagnostic Behavior
+
+- Report a semantic diagnostic when an explicit file monitoring job or
+  recovery file monitoring job `flwc` value specifies both `s` and `m`.
+- Report a semantic diagnostic when an explicit `flco` value is specified and
+  the effective `flwc` value does not include `c`.
+- Keep omitted `flwc` default `c` with omitted or explicit `flco` values
+  non-diagnostic for this slice.
+- Keep raw parser output, raw domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation unchanged.
+- Report diagnostics through the existing application editor-feedback DTO so
+  desktop and web hosts share the same rule.
+
+### Impact
+
+- User-visible diagnostics change for syntactically valid JP1/AJS documents
+  containing explicit invalid file monitoring parameter combinations.
+- Existing parsed parameter source-location metadata can point diagnostics at
+  the explicit offending `flwc` or `flco` parameter.
+- The application diagnostics boundary remains the owner of focused semantic
+  parameter feedback; parser grammar and domain wrapper values remain raw.
+
+### Diagnostic Alternatives
+
+- Preserve invalid file monitoring combinations silently and leave the matrix
+  gap visible.
+- Hide or rewrite invalid values in domain/list output, rejected because
+  manual-invalid raw input should remain inspectable.
+- Add wildcard, byte-length, `flwi` range, or timeout diagnostics in the same
+  slice, rejected because that broadens the behavior and regression surface.
 
 ## Expected Behavior If Approved
 
@@ -86,6 +134,6 @@ This document focuses on the currently modeled file monitoring job parameters
 
 ## Follow-up
 
-- Revisit `flwc` invalid combinations, `flwi` range validation, wildcard
-  restrictions, and `flco` pairing diagnostics only after editor-feedback
-  behavior explicitly owns invalid JP1/AJS parameter handling.
+- Revisit `flwi` range validation, wildcard restrictions, byte-length
+  validation, and timeout behavior only after the focused diagnostics slice is
+  completed or explicitly deferred.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -116,9 +116,10 @@ coverage.
   `parameterFactory.test.ts` for existing domain default seams and
   `buildUnitListRemainingGroups.test.ts` for group 13 projection
 - Remaining gap:
-  unit-list group 13 default-aware projection is aligned for these defaults;
-  `flwc` invalid-combination diagnostics, wildcard restrictions, byte-length
-  validation, and range validation are deferred
+  unit-list group 13 default-aware projection is aligned for these defaults,
+  and `flwc` / `flco` invalid-combination diagnostics are aligned through
+  editor-feedback. Wildcard restrictions, byte-length validation, and range
+  validation remain deferred.
 
 ### Execution-Interval Control Job Defaults
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PLANS.md
@@ -89,6 +89,10 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
 - Implemented QUEUE job unit-list group 15 projection so `qj` / `rq`
   transfer-operation values are hidden while transfer source/destination and
   non-QUEUE `topN` projection remain visible.
+- Investigated file monitoring job `flwc` / `flco` semantic diagnostics as
+  the next approval-gated parameter diagnostics candidate.
+- Implemented file monitoring job `flwc` / `flco` semantic diagnostics through
+  editor feedback while preserving raw parser/domain/list/flow/command output.
 
 ## Impact Investigation
 
@@ -456,6 +460,48 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   summary for execution-interval control job defaults and unit-list group 13
   projection.
 
+### File Monitoring Job FLWC / FLCO Diagnostic Candidate
+
+- Planned change:
+  add focused application-level semantic diagnostics for explicit file
+  monitoring job and recovery file monitoring job `flwc` / `flco`
+  combinations that violate JP1/AJS3 version 13 rules: `flwc` must not
+  specify both `s` and `m`, and explicit `flco` is valid only when effective
+  `flwc` includes `c`.
+- Affected files:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`,
+  `FILE_MONITORING_JOB_ALIGNMENT.md`, `PARAMETER_COVERAGE_MATRIX.md`,
+  `SPECS.md`, `TASKS.md`,
+  `docs/requirements/use-cases/uc-provide-editor-feedback.md`, and
+  branch-level `docs/specs/plans.md`.
+- Affected functions/classes/components:
+  `buildSyntaxDiagnostics`, the existing unit-flattening and parameter lookup
+  helpers in that file, the existing diagnostics VS Code adapter through its
+  DTO mapping, and focused diagnostics tests.
+- Affected features:
+  JP1/AJS editor feedback diagnostics for file monitoring jobs; JP1/AJS3 v13
+  parameter interpretation for file monitoring conditions.
+- Tests affected:
+  focused `buildSyntaxDiagnostics` tests for valid omitted defaults, valid
+  explicit `flwc` / `flco` combinations, invalid `flwc` containing both
+  `s` and `m`, and invalid explicit `flco` when effective `flwc` does not
+  include `c`.
+- Breaking-change risk:
+  medium. This intentionally adds user-visible diagnostics for syntactically
+  valid documents. Raw parser output, domain wrapper values, normalized
+  parameter storage, list/flow projection, and command generation should
+  remain unchanged.
+- Alternatives considered:
+  keep invalid combinations silent and leave the matrix gap visible; hide or
+  rewrite invalid values in domain/list output, rejected because raw
+  manual-invalid input should remain inspectable; add wildcard, byte-length,
+  `flwi` range, or timeout diagnostics in the same slice, deferred because it
+  expands the behavior and regression surface.
+- Approval:
+  human approval to proceed was given on 2026-05-06 after the investigation
+  summary for file monitoring job `flwc` / `flco` diagnostics.
+
 ## Follow-up
 
 - Apply the same value parsing audit/refactor workflow to other parameter
@@ -471,9 +517,8 @@ explicit JP1/AJS3 version 13 reference-driven contracts.
   behavior.
 - Revisit JP1 event sending job `evhst` requiredness when `evsrt=y` after the
   diagnostics behavior contract is explicit.
-- Revisit file monitoring job `flwc` invalid combinations, `flwi` range
-  validation, wildcard restrictions, and `flco` pairing diagnostics after the
-  editor-feedback behavior contract is explicit.
+- Keep `flwi` range validation, wildcard restrictions, byte-length validation,
+  and broader file monitoring validation deferred.
 - Revisit execution-interval control job `tmitv` range validation and broader
   wait-job default reconciliation after the focused default/projection slice.
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -88,6 +88,13 @@ JP1/AJS3 version 13 reference documents.
   table output. If approved, it should consume the existing wrapper/default
   semantics for `flwc`, `flwi`, `flco`, and `ets` while preserving parser
   output and normalized raw parameter storage.
+- File monitoring job `flwc` / `flco` diagnostics are approval-sensitive
+  because existing behavior preserves explicit invalid combinations as raw
+  parsed values without editor feedback. A focused diagnostic slice should
+  report `s` and `m` co-specification in `flwc`, and explicit `flco` when the
+  effective `flwc` value does not include `c`, while preserving raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation.
 - Execution-interval control job defaults are approval-sensitive because
   JP1/AJS3 version 13 defines omitted `tmitv`, `etn`, and `ets` behavior for
   `tmwj` / `rtmwj`, while current code only has generic defaults for `etn` and

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -139,6 +139,16 @@
 - [x] Add focused diagnostics regression evidence for valid `jd=cod` retry
       parameters and explicit invalid `jd` / retry-parameter combinations
 - [x] Run required code-change validation after implementation
+- [x] Investigate file monitoring job `flwc` / `flco` semantic diagnostics as
+      the next focused parameter diagnostics slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration
+- [x] Implement focused file monitoring semantic diagnostics only after
+      approval
+- [x] Add focused diagnostics regression evidence for valid omitted defaults,
+      valid explicit `flwc` / `flco` combinations, and explicit invalid
+      combinations
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -336,13 +346,51 @@
   projection, command generation, generated artifacts, configuration,
   dependency versions, and `engines.vscode` remain unchanged. Numeric retry
   ranges and threshold ordering remain deferred.
+- 2026-05-03: file monitoring job `flwc` / `flco` diagnostics are the next
+  approval-gated semantic diagnostics candidate. JP1/AJS3 version 13 file
+  monitoring job definitions say `flwc` can specify multiple monitoring
+  conditions but cannot specify `s` and `m` together, and `flco` can be
+  specified only when `flwc` includes `c`. The proposed scope is limited to
+  reporting explicit `flwj` / `rflwj` invalid combinations through the
+  existing editor-feedback boundary while preserving raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation. Parser grammar, generated artifacts,
+  configuration, dependency versions, `engines.vscode`, wildcard validation,
+  byte-length validation, numeric range validation, timeout behavior, and
+  broad parameter validation remain out of scope.
+- 2026-05-06: file monitoring job `flwc` / `flco` diagnostics now report
+  explicit `flwj` / `rflwj` invalid combinations when `flwc` specifies both
+  `s` and `m`, or when explicit `flco` is present and effective `flwc` does
+  not include `c`. Omitted `flwc=c` remains non-diagnostic with explicit
+  `flco`, valid explicit combinations remain non-diagnostic, and raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, command generation, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
-- Approved at: 2026-05-01
-- Approved scope: User replied "OK.Proceed." after the job end-judgment
-  retry-parameter diagnostics approval request. Approved changes are limited
+- Approved at: 2026-05-06
+- Approved scope: User replied "OK.Proceed." after the file monitoring job
+  `flwc` / `flco` diagnostics approval request. Approved changes are limited
+  to adding focused application-level semantic diagnostics for explicit
+  `flwj` / `rflwj` invalid combinations where `flwc` specifies both `s` and
+  `m`, or explicit `flco` is present when effective `flwc` does not include
+  `c`; preserving raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation;
+  adding focused regression evidence; updating SDD tracking; and running
+  validation. Parser grammar, generated artifacts, configuration, dependency
+  versions, `engines.vscode`, wildcard validation, byte-length validation,
+  numeric range validation, timeout behavior, and broad parameter validation
+  remain out of scope.
+
+Current implementation gate: file monitoring job `flwc` / `flco` semantic
+diagnostics.
+
+## Prior Approval Evidence
+
+- 2026-05-01: User replied "OK.Proceed." after the job end-judgment
+  retry-parameter diagnostics approval request. Approved changes were limited
   to adding focused application-level semantic diagnostics for explicit
   UNIX/PC job and UNIX/PC custom job `rjs`, `rje`, `rec`, or `rei` values
   when the effective `jd` value is not `cod`; preserving raw parser output,
@@ -351,12 +399,7 @@
   updating SDD tracking; and running validation. Parser grammar, generated
   artifacts, configuration, dependency versions, `engines.vscode`, numeric
   retry ranges, retry threshold ordering, byte-length validation, and broad
-  parameter validation remain out of scope.
-
-Current implementation gate: job end-judgment retry-parameter diagnostics.
-
-## Prior Approval Evidence
-
+  parameter validation were out of scope.
 - 2026-05-01: User replied "OK.Proceed." after the job end-judgment `jd` /
   `abr` invalid-combination diagnostics approval request. Approved changes
   were limited to adding focused application-level semantic diagnostics for
@@ -437,6 +480,16 @@ Current implementation gate: job end-judgment retry-parameter diagnostics.
 
 ## Validation
 
+- 2026-05-06: `pnpm run test:compile`
+- 2026-05-06: `pnpm test`
+- 2026-05-06: `pnpm run qlty` completed with exit code 0; final run used an
+  escalated command because sandboxed qlty cannot create its log file
+- 2026-05-06: `pnpm test`
+- 2026-05-06: `pnpm run test:web` failed in the sandbox because Chromium could
+  not access macOS Mach port APIs; escalated rerun completed with exit code 0
+  and existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-06: `pnpm run build` completed with existing webpack asset-size
+  warnings
 - 2026-05-01: `pnpm run qlty` required an escalated rerun after a sandboxed
   log-file permission failure
 - 2026-05-01: `pnpm test`

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -37,14 +37,12 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Select the next focused JP1/AJS3 v13 parameter-alignment gap from the
+1. Close the file monitoring job `flwc` / `flco` diagnostics slice with
+   validation evidence and SDD synchronization.
+2. Select the next focused JP1/AJS3 v13 parameter-alignment gap from the
    documented deferred diagnostics, range-validation, byte-length validation,
-   macro-variable validation, wildcard restriction, and requiredness candidates.
-2. Prepare that selected parameter-alignment slice as an approval-gated
-   behavior contract before implementation, keeping parser grammar, generated
-   artifacts, normalized raw storage, projections, command generation,
-   dependency versions, and `engines.vscode` out of scope unless explicitly
-   approved.
+   macro-variable validation, wildcard restriction, and requiredness
+   candidates.
 3. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -57,24 +55,35 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/prioritize-parameter-alignment-before-qlty`.
-- Objective: correct branch-level sequencing so JP1/AJS v13 parameter
-  alignment remains the active implementation priority before Qlty-driven
-  architecture refactoring.
-- Status: docs-only planning correction.
-- Scope: update `docs/specs/plans.md` to make the parameter-alignment-first
-  order explicit, preserve WebAPI beta tracking as deferred, and defer Qlty
-  Phase 0 until parameter alignment is complete or explicitly overridden.
-- Out of scope: runtime code changes, parser grammar changes, generated
-  artifacts, dependency changes, `engines.vscode`, test/build script changes,
-  and changing the roadmap content without a separate priority decision.
-- Impact summary: this change affects branch sequencing only. It does not alter
-  delivered job end-judgment retry diagnostics or any user-visible extension
-  behavior.
-- Risks and assumptions: JP1/AJS v13 parameter alignment still has documented
-  actionable gaps in the feature-local coverage matrix. Treat Qlty refactoring
-  as valuable but not the next implementation priority until alignment is
-  finished or explicitly re-prioritized.
+- Branch: `codex/file-monitoring-diagnostics`.
+- Objective: continue JP1/AJS v13 parameter alignment with the focused file
+  monitoring job `flwc` / `flco` semantic diagnostics slice before returning
+  to Qlty-driven architecture refactoring.
+- Status: implemented and validated on 2026-05-06.
+- Scope candidate: add application-level semantic diagnostics for explicit
+  `flwj` / `rflwj` invalid file monitoring combinations: `flwc` specifying
+  both `s` and `m`, and explicit `flco` when effective `flwc` does not include
+  `c`.
+- Out of scope: parser grammar changes, raw parser/domain/normalized value
+  changes, unit-list projection changes, flow projection changes, command
+  generation changes, generated artifacts, dependency changes,
+  `engines.vscode`, wildcard validation, byte-length validation, numeric range
+  validation, timeout behavior, and broad parameter validation.
+- Impact summary: the candidate affects
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
+  `buildSyntaxDiagnostics` tests, the existing VS Code diagnostics adapter
+  through DTO mapping, file monitoring alignment docs, the parameter coverage
+  matrix, and the editor-feedback use-case contract.
+- Risks and assumptions: the change is user-visible in desktop and web
+  diagnostics for syntactically valid documents. Existing parsed parameter
+  source-location metadata should be sufficient to point at the offending
+  explicit `flwc` or `flco` parameter. Raw values remain inspectable by
+  downstream consumers.
+- Alternatives considered: keep invalid combinations silent and leave the
+  matrix gap visible; hide or rewrite invalid values in domain/list output,
+  rejected because raw manual-invalid input should remain inspectable; broaden
+  to wildcard, byte-length, `flwi` range, or timeout diagnostics, deferred to
+  keep the slice small.
 
 ## Build/Test Performance SDD
 
@@ -103,8 +112,8 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  next slice: select the next unresolved diagnostics or validation gap before
-  implementation approval.
+  slice: file monitoring job `flwc` / `flco` semantic diagnostics completed;
+  next unresolved diagnostics or validation gap is not selected yet.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -19,6 +19,7 @@ const jobEndJudgmentDiagnosticTargetTypes = new Set([
   "rcj",
 ]);
 const jobEndJudgmentRetryParameterKeys = ["rjs", "rje", "rec", "rei"];
+const fileMonitoringDiagnosticTargetTypes = new Set(["flwj", "rflwj"]);
 
 const flattenUnits = (units: Unit[]): Unit[] =>
   units.reduce<Unit[]>(
@@ -28,6 +29,17 @@ const flattenUnits = (units: Unit[]): Unit[] =>
 
 const findParameter = (unit: Unit, key: string): UnitParameter | undefined =>
   unit.parameters.find((parameter) => parameter.key === key);
+
+const buildDiagnostic = (
+  parameter: UnitParameter,
+  message: string,
+): SyntaxDiagnosticDto => ({
+  line: parameter.line ?? 1,
+  column: parameter.column ?? 0,
+  length: parameter.length ?? parameter.key.length,
+  message,
+  severity: "error" as const,
+});
 
 const buildJobEndJudgmentDiagnostics = (
   rootUnits: Unit[],
@@ -49,14 +61,12 @@ const buildJobEndJudgmentDiagnostics = (
       }
 
       if (abrParameter?.value === "y") {
-        diagnostics.push({
-          line: abrParameter.line ?? 1,
-          column: abrParameter.column ?? 0,
-          length: abrParameter.length ?? abrParameter.key.length,
-          message:
+        diagnostics.push(
+          buildDiagnostic(
+            abrParameter,
             "Automatic retry (abr=y) requires end judgment (jd) to be cod.",
-          severity: "error" as const,
-        });
+          ),
+        );
       }
 
       for (const retryParameterKey of jobEndJudgmentRetryParameterKeys) {
@@ -65,13 +75,53 @@ const buildJobEndJudgmentDiagnostics = (
           continue;
         }
 
-        diagnostics.push({
-          line: retryParameter.line ?? 1,
-          column: retryParameter.column ?? 0,
-          length: retryParameter.length ?? retryParameter.key.length,
-          message: `Retry parameter (${retryParameterKey}) requires end judgment (jd) to be cod.`,
-          severity: "error" as const,
-        });
+        diagnostics.push(
+          buildDiagnostic(
+            retryParameter,
+            `Retry parameter (${retryParameterKey}) requires end judgment (jd) to be cod.`,
+          ),
+        );
+      }
+
+      return diagnostics;
+    });
+
+const splitFileMonitoringConditions = (value: string): Set<string> =>
+  new Set(value.split(":").filter((condition) => condition.length > 0));
+
+const buildFileMonitoringDiagnostics = (
+  rootUnits: Unit[],
+): SyntaxDiagnosticDto[] =>
+  flattenUnits(rootUnits)
+    .filter((unit) => {
+      const unitType = findParameter(unit, "ty")?.value;
+      return unitType
+        ? fileMonitoringDiagnosticTargetTypes.has(unitType)
+        : false;
+    })
+    .flatMap((unit) => {
+      const diagnostics: SyntaxDiagnosticDto[] = [];
+      const flwcParameter = findParameter(unit, "flwc");
+      const flcoParameter = findParameter(unit, "flco");
+      const effectiveFlwc = flwcParameter?.value ?? DEFAULTS.Flwc;
+      const flwcConditions = splitFileMonitoringConditions(effectiveFlwc);
+
+      if (flwcParameter && flwcConditions.has("s") && flwcConditions.has("m")) {
+        diagnostics.push(
+          buildDiagnostic(
+            flwcParameter,
+            "File monitoring condition (flwc) cannot specify both s and m.",
+          ),
+        );
+      }
+
+      if (flcoParameter && !flwcConditions.has("c")) {
+        diagnostics.push(
+          buildDiagnostic(
+            flcoParameter,
+            "File close option (flco) requires file creation monitoring (flwc=c).",
+          ),
+        );
       }
 
       return diagnostics;
@@ -95,5 +145,6 @@ export const buildSyntaxDiagnostics = (
   return [
     ...syntaxDiagnostics,
     ...buildJobEndJudgmentDiagnostics(result.rootUnits),
+    ...buildFileMonitoringDiagnostics(result.rootUnits),
   ];
 };

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -194,4 +194,86 @@ suite("Build Syntax Diagnostics", () => {
       ["error", "error", "error", "error"],
     );
   });
+
+  test("does not report file monitoring diagnostics for omitted defaults and valid explicit combinations", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=file1,flwj,+0+0;",
+        "  el=file2,rflwj,+160+0;",
+        "  unit=file1,,jp1admin,;",
+        "  {",
+        "    ty=flwj;",
+        "    flco=y;",
+        "  }",
+        "  unit=file2,,jp1admin,;",
+        "  {",
+        "    ty=rflwj;",
+        "    flwc=c:d:s;",
+        "    flco=n;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports file monitoring diagnostics for explicit invalid condition combinations", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=file1,flwj,+0+0;",
+        "  el=file2,rflwj,+160+0;",
+        "  unit=file1,,jp1admin,;",
+        "  {",
+        "    ty=flwj;",
+        "    flwc=d:s:m;",
+        "  }",
+        "  unit=file2,,jp1admin,;",
+        "  {",
+        "    ty=rflwj;",
+        "    flwc=d:s;",
+        "    flco=y;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 2);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 4,
+          message:
+            "File monitoring condition (flwc) cannot specify both s and m.",
+        },
+        {
+          line: 15,
+          column: 4,
+          length: 4,
+          message:
+            "File close option (flco) requires file creation monitoring (flwc=c).",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error"],
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Add focused JP1/AJS3 v13 semantic diagnostics for file monitoring job `flwc` / `flco` invalid combinations.
- Preserve raw parser output, domain wrapper values, normalized parameters, list/flow projection, and command generation.
- Update SDD/use-case tracking and parameter coverage records for the approved slice.

## Behavior

The editor feedback path now reports diagnostics for `flwj` / `rflwj` when:

- explicit `flwc` specifies both `s` and `m`
- explicit `flco` is present while effective `flwc` does not include `c`

Omitted `flwc=c` remains non-diagnostic with explicit `flco`, and valid explicit combinations remain non-diagnostic.

## Validation

- `rtk pnpm run test:compile`
- `rtk pnpm test`
- `rtk pnpm run qlty` (escalated because sandboxed qlty cannot create its log file)
- `rtk pnpm run test:web` (sandbox run failed on Chromium macOS Mach port permissions; escalated rerun passed with existing localhost dev-extension `package.nls.json` 404 noise)
- `rtk pnpm run build` (passed with existing webpack asset-size warnings)
- `rtk pnpm run lint:md`
- `rtk git diff --check`