### PR TITLE
[codex] Add event host requiredness diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -81,6 +81,14 @@ Scenario: Retry parameters require automatic retry
   When editor feedback is requested
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
+
+Scenario: Event arrival check requires an event destination host
+  Given a syntactically valid JP1/AJS document with a JP1 event sending job
+  And effective `evsrt` is event-arrival checking enabled
+  And `evhst` is omitted
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
@@ -32,8 +32,9 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
   evidence if a dedicated event sending job seam is introduced
 - Out of scope:
   parser grammar changes, command generation, byte-length validation, numeric
-  range validation, event arrival runtime behavior, event destination host
-  requiredness diagnostics, and broader event receiving job semantics
+  range validation, event arrival runtime behavior, broader event receiving
+  job semantics, and any validation beyond the focused `evsrt=y` / missing
+  `evhst` semantic diagnostic
 
 ## Investigation Notes
 
@@ -62,6 +63,46 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
   `evspl`, and `evsrc` values. Explicit normalized values remain preserved,
   and non-event-sending jobs do not synthesize these defaults.
 
+## EVHST Requiredness Diagnostics
+
+### Current Behavior
+
+- `Evsj` / `Revsj` expose `evhst` and `evsrt` through `ParamFactory`.
+- `ParamFactory.evsrt` resolves omitted `evsrt` to `n`.
+- Explicit `evsrt=y` without `evhst` is preserved as raw parsed data.
+- Unit-list group 14 projects `evhst` from normalized raw key/value data, so
+  missing `evhst` remains visible as an empty table value.
+
+### Delivered Behavior
+
+- Report a semantic diagnostic when an explicit JP1 event sending job or
+  recovery JP1 event sending job has effective `evsrt=y` and omits `evhst`.
+- Point the diagnostic at the explicit `evsrt` parameter because the required
+  `evhst` parameter has no source location when omitted.
+- Keep omitted `evsrt=n` without `evhst` non-diagnostic.
+- Keep raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation unchanged.
+- Report diagnostics through the existing application editor-feedback DTO so
+  desktop and web hosts share the same rule.
+
+### Impact
+
+- User-visible diagnostics change for syntactically valid JP1/AJS documents
+  containing explicit event-arrival checking without an event destination host.
+- Existing parsed parameter source-location metadata can point diagnostics at
+  explicit `evsrt`.
+- The application diagnostics boundary remains the owner of focused semantic
+  parameter feedback; parser grammar and domain wrapper values remain raw.
+
+### Diagnostic Alternatives
+
+- Preserve missing `evhst` silently and leave the matrix gap visible.
+- Synthesize or rewrite `evhst` in domain/list output, rejected because
+  manual-invalid raw input should remain inspectable.
+- Add `evhst` byte-length, macro-variable, or `evspl` / `evsrc` range
+  diagnostics in the same slice, rejected because that broadens the behavior
+  and regression surface.
+
 ## Alternatives
 
 - Leave `DEFAULTS.Evsrc` as `0` and record the event sending job check-count
@@ -74,7 +115,5 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 
 ## Follow-up
 
-- Revisit `evhst` requiredness when `evsrt=y` only after diagnostics behavior
-  is explicitly scoped.
 - Add range validation for `evspl` and `evsrc` only after invalid JP1/AJS
   parameter handling is defined across domain and diagnostics.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -104,7 +104,8 @@ coverage.
 - Evidence: `parameterFactory.test.ts` and `buildUnitListView.test.ts`
 - Remaining gap:
   unit-list group 14 default-aware projection is aligned for these defaults;
-  `evhst` requiredness and range validation are deferred
+  `evhst` requiredness diagnostics are aligned through editor-feedback; range
+  validation is deferred
 
 ### File Monitoring Job Defaults
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -124,6 +124,11 @@ JP1/AJS3 version 13 reference documents.
   report these explicit invalid combinations through editor-feedback while
   preserving raw parser output, domain wrapper values, normalized parameters,
   unit-list projection, flow projection, and command generation.
+- JP1 event sending job `evhst` requiredness diagnostics are aligned through
+  application editor-feedback. Explicit `evsrt=y` on `evsj` / `revsj` now
+  reports a semantic diagnostic when `evhst` is omitted, while raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation remain unchanged.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -159,6 +159,15 @@
       defaults, valid `abr=y` retry parameters, and explicit invalid `abr=n`
       / retry-parameter combinations
 - [x] Run required code-change validation after implementation
+- [x] Investigate JP1 event sending job `evhst` requiredness diagnostics as
+      the next focused parameter diagnostics slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration
+- [x] Implement focused `evhst` requiredness diagnostics only after approval
+- [x] Add focused diagnostics regression evidence for omitted `evsrt=n`,
+      valid explicit `evsrt=y` with `evhst`, and explicit invalid `evsrt=y`
+      without `evhst`
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -338,6 +347,11 @@
   generation, generated artifacts, configuration, dependency versions, and
   `engines.vscode` remain unchanged. Parameter source-location metadata was
   added to support diagnostic ranges.
+- 2026-05-06: JP1 event sending job `evhst` requiredness diagnostics now
+  report explicit `evsj` / `revsj` `evsrt=y` values when `evhst` is omitted.
+  Omitted `evsrt=n` remains non-diagnostic, explicit valid `evhst` values
+  remain accepted, and raw parser/domain/normalized values plus unit-list,
+  flow, and command output remain unchanged.
 - 2026-05-01: job end-judgment retry-parameter diagnostics are the next
   approval-gated semantic diagnostics candidate. JP1/AJS3 version 13 UNIX/PC
   job and UNIX/PC custom job definitions say `rjs`, `rje`, `rec`, and `rei`
@@ -396,14 +410,51 @@
   domain wrapper values, normalized parameters, unit-list projection, flow
   projection, command generation, generated artifacts, configuration,
   dependency versions, and `engines.vscode` remain unchanged.
+- 2026-05-06: JP1 event sending job `evhst` requiredness diagnostics are the
+  next approval-gated semantic diagnostics candidate. JP1/AJS3 version 13 JP1
+  event sending job definitions say `evhst` is required when `evsrt=y`.
+  Existing behavior preserves explicit `evsrt=y` without `evhst` as raw parsed
+  values without editor feedback. The proposed scope is limited to reporting
+  explicit `evsj` / `revsj` missing-host combinations through the existing
+  editor-feedback boundary while preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation. Parser grammar, generated artifacts, configuration,
+  dependency versions, `engines.vscode`, `evhst` byte-length validation,
+  macro-variable validation, `evspl` / `evsrc` range validation, and broad
+  parameter validation remain out of scope.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-06
-- Approved scope: User replied "OK.Proceed." after the job end-judgment
+- Approved scope: focused application-level semantic diagnostics for explicit
+  JP1 event sending jobs and recovery JP1 event sending jobs where effective
+  `evsrt=y` omits `evhst`; preserve raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation; add focused regression evidence; update SDD tracking; and run
+  validation.
+
+Current implementation gate: none; last completed slice was JP1 event sending
+job `evhst` requiredness diagnostics.
+
+## Prior Approval Evidence
+
+- 2026-05-06: User replied "OK.Proseed." after the JP1 event sending job
+  `evhst` requiredness diagnostics approval request. Approved changes were
+  limited to adding focused application-level semantic diagnostics for
+  explicit JP1 event sending jobs and recovery JP1 event sending jobs where
+  effective `evsrt=y` omits `evhst`; preserving raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation; adding focused regression evidence;
+  updating SDD tracking; and running validation. Parser grammar, generated
+  artifacts, configuration, dependency versions, `engines.vscode`, `evhst`
+  byte-length validation, host-name format validation, macro-variable
+  validation, `evspl` / `evsrc` range validation, and broad parameter
+  validation were out of scope.
+
+- 2026-05-06: User replied "OK.Proceed." after the job end-judgment
   automatic-retry enablement diagnostics approval request. Approved changes
-  are limited to adding focused application-level semantic diagnostics for
+  were limited to adding focused application-level semantic diagnostics for
   explicit UNIX/PC job and UNIX/PC custom job `rjs`, `rje`, `rec`, or `rei`
   values when effective `jd=cod` but effective `abr` is not `y`; preserving
   raw parser output, domain wrapper values, normalized parameters, unit-list
@@ -411,13 +462,7 @@
   regression evidence; updating SDD tracking; and running validation. Parser
   grammar, generated artifacts, configuration, dependency versions,
   `engines.vscode`, numeric retry ranges, retry threshold ordering,
-  byte-length validation, and broad parameter validation remain out of scope.
-
-Current implementation gate: no pending implementation gate for this feature;
-the automatic-retry enablement diagnostics slice completed on 2026-05-06.
-
-## Prior Approval Evidence
-
+  byte-length validation, and broad parameter validation were out of scope.
 - 2026-05-06: User replied "OK.Proceed." after the file monitoring job
   `flwc` / `flco` diagnostics approval request. Approved changes were limited
   to adding focused application-level semantic diagnostics for explicit
@@ -521,6 +566,15 @@ the automatic-retry enablement diagnostics slice completed on 2026-05-06.
 
 ## Validation
 
+- 2026-05-06: `pnpm run qlty` required an escalated rerun after a sandboxed
+  qlty log-file permission failure
+- 2026-05-06: `pnpm test`
+- 2026-05-06: `pnpm run test:web` failed in the sandbox because Chromium could
+  not access macOS Mach port APIs; escalated rerun completed with exit code 0
+  and existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-06: `pnpm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-06: `pnpm run lint:md`
 - 2026-05-06: `pnpm run test:compile`
 - 2026-05-06: `pnpm test`
 - 2026-05-06: `pnpm run test:web` failed in the sandbox because Chromium could

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -53,35 +53,35 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/job-end-retry-enable-diagnostics`.
-- Objective: continue JP1/AJS v13 parameter alignment with the focused job
-  end-judgment automatic-retry enablement diagnostics slice before returning
-  to Qlty-driven architecture refactoring.
-- Status: implemented and validated on 2026-05-06.
-- Scope candidate: add application-level semantic diagnostics for explicit
-  UNIX/PC job and UNIX/PC custom job retry parameters `rjs`, `rje`, `rec`, and
-  `rei` when effective `abr` is not `y`. Existing `jd != cod` diagnostics
-  remain the primary diagnostic for retry parameters in invalid end-judgment
-  combinations.
+- Branch: `codex/event-send-host-required-diagnostics` started from `main`.
+- Objective: continue JP1/AJS v13 parameter alignment with the focused JP1
+  event sending job `evhst` requiredness diagnostics slice before returning to
+  Qlty-driven architecture refactoring.
+- Status: approved, implemented, and validated.
+- Scope: add application-level semantic diagnostics for explicit
+  JP1 event sending jobs and recovery JP1 event sending jobs where effective
+  `evsrt=y` but explicit `evhst` is omitted.
 - Out of scope: parser grammar changes, raw parser/domain/normalized value
   changes, unit-list projection changes, flow projection changes, command
   generation changes, generated artifacts, dependency changes,
-  `engines.vscode`, numeric retry ranges, retry threshold ordering,
-  byte-length validation, and broad parameter validation.
-- Impact summary: the candidate affects
+  `engines.vscode`, `evhst` byte-length validation, host-name format
+  validation, macro-variable validation, `evspl` / `evsrc` range validation,
+  and broad parameter validation.
+- Impact summary: the slice affects
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
   `buildSyntaxDiagnostics` tests, the existing VS Code diagnostics adapter
-  through DTO mapping, job end-judgment alignment docs, the parameter coverage
-  matrix, and the editor-feedback use-case contract.
+  through DTO mapping, JP1 event sending job alignment docs, the parameter
+  coverage matrix, and the editor-feedback use-case contract.
 - Risks and assumptions: the change is user-visible in desktop and web
   diagnostics for syntactically valid documents. Existing parsed parameter
-  source-location metadata should be sufficient to point at each explicit
-  retry parameter. Raw values remain inspectable by downstream consumers.
-- Alternatives considered: keep retry parameters with `abr=n` silent and leave
-  the matrix gap visible; hide or rewrite retry values in domain/list output,
-  rejected because raw manual-invalid input should remain inspectable; broaden
-  to numeric ranges or retry threshold ordering, deferred to keep the slice
-  small.
+  source-location metadata can point at explicit `evsrt=y`; when `evsrt` is
+  omitted, the effective default is `n`, so no missing-host diagnostic is
+  needed. Raw values remain inspectable by downstream consumers.
+- Alternatives considered: keep missing `evhst` silent and leave the matrix
+  gap visible; synthesize or rewrite `evhst` in domain/list output, rejected
+  because manual-invalid input should remain inspectable; broaden to
+  byte-length, macro-variable, or range diagnostics, deferred to keep the
+  slice small.
 
 ## Build/Test Performance SDD
 
@@ -110,8 +110,8 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: job end-judgment automatic-retry enablement diagnostics completed;
-  next unresolved diagnostics or validation gap is not selected yet.
+  slice: JP1 event sending job `evsrt=y` / missing `evhst` diagnostics
+  implemented; next deferred gap to select remains open.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -41,9 +41,10 @@
    - The job end-judgment automatic-retry enablement diagnostic now reports
      explicit `rjs`, `rje`, `rec`, or `rei` values when effective `jd=cod`
      but effective `abr` is not `y`.
-   - The next focused semantic diagnostic candidate should be selected from the
-     remaining deferred validation gaps instead of broadening this family in
-     the same slice.
+   - JP1 event sending job `evhst` requiredness is now aligned through
+     editor-feedback when explicit `evsrt=y` omits `evhst`, while preserving
+     raw parameter data and avoiding broader event-job validation in the same
+     slice.
    - Continue with documented deferred diagnostics and range-validation gaps
      only as focused, approval-gated slices.
    - Keep behavior-preserving slices separate from behavior-changing manual

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -20,6 +20,7 @@ const jobEndJudgmentDiagnosticTargetTypes = new Set([
 ]);
 const jobEndJudgmentRetryParameterKeys = ["rjs", "rje", "rec", "rei"];
 const fileMonitoringDiagnosticTargetTypes = new Set(["flwj", "rflwj"]);
+const eventSendingDiagnosticTargetTypes = new Set(["evsj", "revsj"]);
 
 const flattenUnits = (units: Unit[]): Unit[] =>
   units.reduce<Unit[]>(
@@ -147,6 +148,31 @@ const buildFileMonitoringDiagnostics = (
       return diagnostics;
     });
 
+const buildEventSendingDiagnostics = (
+  rootUnits: Unit[],
+): SyntaxDiagnosticDto[] =>
+  flattenUnits(rootUnits)
+    .filter((unit) => {
+      const unitType = findParameter(unit, "ty")?.value;
+      return unitType ? eventSendingDiagnosticTargetTypes.has(unitType) : false;
+    })
+    .flatMap((unit) => {
+      const evsrtParameter = findParameter(unit, "evsrt");
+      const evhstParameter = findParameter(unit, "evhst");
+      const effectiveEvsrt = evsrtParameter?.value ?? DEFAULTS.Evsrt;
+
+      if (!evsrtParameter || effectiveEvsrt !== "y" || evhstParameter) {
+        return [];
+      }
+
+      return [
+        buildDiagnostic(
+          evsrtParameter,
+          "Event arrival check (evsrt=y) requires an event destination host (evhst).",
+        ),
+      ];
+    });
+
 export const buildSyntaxDiagnostics = (
   content: string,
 ): SyntaxDiagnosticDto[] => {
@@ -166,5 +192,6 @@ export const buildSyntaxDiagnostics = (
     ...syntaxDiagnostics,
     ...buildJobEndJudgmentDiagnostics(result.rootUnits),
     ...buildFileMonitoringDiagnostics(result.rootUnits),
+    ...buildEventSendingDiagnostics(result.rootUnits),
   ];
 };

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -349,4 +349,104 @@ suite("Build Syntax Diagnostics", () => {
       ["error", "error"],
     );
   });
+
+  test("does not report event sending diagnostics for omitted evsrt defaults", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=event1,evsj,+0+0;",
+        "  unit=event1,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("does not report event sending diagnostics for valid explicit arrival-check settings", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=event1,evsj,+0+0;",
+        "  el=event2,revsj,+160+0;",
+        "  unit=event1,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        "    evsrt=y;",
+        "    evhst=server-a;",
+        "  }",
+        "  unit=event2,,jp1admin,;",
+        "  {",
+        "    ty=revsj;",
+        "    evsrt=n;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports event sending diagnostics when arrival checking omits evhst", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=event1,evsj,+0+0;",
+        "  el=event2,revsj,+160+0;",
+        "  unit=event1,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        "    evsrt=y;",
+        "  }",
+        "  unit=event2,,jp1admin,;",
+        "  {",
+        "    ty=revsj;",
+        "    evsrt=y;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 2);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 5,
+          message:
+            "Event arrival check (evsrt=y) requires an event destination host (evhst).",
+        },
+        {
+          line: 14,
+          column: 4,
+          length: 5,
+          message:
+            "Event arrival check (evsrt=y) requires an event destination host (evhst).",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error"],
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- add editor-feedback diagnostics for explicit `evsj` / `revsj` `evsrt=y` entries that omit `evhst`
- add focused regression coverage for omitted defaults, valid explicit settings, and invalid missing-host combinations
- update SDD planning, approval, coverage-matrix, and use-case records for the completed JP1/AJS v13 slice

## Why

JP1/AJS3 v13 requires an event destination host when event-arrival checking is enabled. The extension previously preserved that invalid combination as raw data without surfacing any editor feedback.

## Impact

- desktop and web diagnostics now flag the missing-host semantic violation
- parser output, domain wrappers, normalized parameters, unit-list projection, flow projection, and command generation stay unchanged

## Validation

- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`
