### PR TITLE
[codex] Add event sending range diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -89,6 +89,14 @@ Scenario: Event arrival check requires an event destination host
   When editor feedback is requested
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
+
+Scenario: Event arrival check values must stay within documented ranges
+  Given a syntactically valid JP1/AJS document with a JP1 event sending job
+  And explicit `evspl` is outside the JP1/AJS3 v13 range `3..600`
+  Or explicit `evsrc` is outside the JP1/AJS3 v13 range `0..999`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
@@ -65,7 +65,7 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 
 ## EVHST Requiredness Diagnostics
 
-### Current Behavior
+### Current Range Behavior
 
 - `Evsj` / `Revsj` expose `evhst` and `evsrt` through `ParamFactory`.
 - `ParamFactory.evsrt` resolves omitted `evsrt` to `n`.
@@ -85,7 +85,7 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 - Report diagnostics through the existing application editor-feedback DTO so
   desktop and web hosts share the same rule.
 
-### Impact
+### Range Impact
 
 - User-visible diagnostics change for syntactically valid JP1/AJS documents
   containing explicit event-arrival checking without an event destination host.
@@ -94,7 +94,7 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 - The application diagnostics boundary remains the owner of focused semantic
   parameter feedback; parser grammar and domain wrapper values remain raw.
 
-### Diagnostic Alternatives
+### Range Diagnostic Alternatives
 
 - Preserve missing `evhst` silently and leave the matrix gap visible.
 - Synthesize or rewrite `evhst` in domain/list output, rejected because
@@ -113,7 +113,72 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 - Build a full parameter coverage matrix before changing this default; deferred
   because the roadmap favors small category-level slices with focused evidence.
 
+## EVSPL / EVSRC Range Diagnostics
+
+### Current Behavior
+
+- `Evsj` / `Revsj` expose `evspl` and `evsrc` through `ParamFactory`.
+- `ParamFactory.evspl` and `ParamFactory.evsrc` preserve explicit values as raw
+  strings and apply the existing aligned default `10` only when the parameter
+  is omitted.
+- `buildSyntaxDiagnostics.ts` already owns focused semantic diagnostics for
+  JP1 event sending jobs, but it currently checks only the `evsrt=y` /
+  missing-`evhst` rule.
+- Explicit out-of-range `evspl` / `evsrc` values are currently preserved
+  without editor feedback.
+
+### Proposed Next Slice
+
+- Report a semantic diagnostic when an explicit JP1 event sending job or
+  recovery JP1 event sending job sets `evspl` outside the JP1/AJS3 v13 range
+  `3..600` seconds.
+- Report a semantic diagnostic when an explicit JP1 event sending job or
+  recovery JP1 event sending job sets `evsrc` outside the JP1/AJS3 v13 range
+  `0..999` checks.
+- Keep omitted `evspl` / `evsrc` values non-diagnostic because the existing
+  defaults already align to `10`.
+- Point diagnostics at the explicit out-of-range parameter so parser output,
+  domain wrappers, normalized parameters, and downstream consumers remain
+  unchanged.
+- Report diagnostics through the existing application editor-feedback DTO so
+  desktop and web hosts continue to share the same rule.
+
+### Delivered Range Behavior
+
+- Explicit JP1 event sending job and recovery JP1 event sending job `evspl`
+  values now report a semantic diagnostic when outside `3..600` seconds.
+- Explicit JP1 event sending job and recovery JP1 event sending job `evsrc`
+  values now report a semantic diagnostic when outside `0..999` checks.
+- Omitted `evspl` / `evsrc` values remain non-diagnostic because the existing
+  defaults already align to `10`.
+- Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.
+
+### Impact
+
+- User-visible diagnostics would change for syntactically valid JP1/AJS
+  documents containing explicit out-of-range event-arrival interval or
+  check-count values.
+- Existing parsed parameter source-location metadata should be enough to point
+  diagnostics at explicit `evspl` / `evsrc` parameters, so no parser or DTO
+  shape change is expected.
+- The application diagnostics boundary remains the owner of focused semantic
+  parameter feedback; parser grammar and domain wrapper values remain raw.
+
+### Diagnostic Alternatives
+
+- Preserve out-of-range `evspl` / `evsrc` silently and leave the matrix gap
+  visible.
+- Move numeric validation into domain wrappers, rejected for this slice
+  because the current diagnostics policy preserves raw manual-invalid values.
+- Add `evhst` byte-length, macro-variable, or host-name validation in the
+  same slice, rejected because that broadens the behavior and regression
+  surface.
+
 ## Follow-up
 
-- Add range validation for `evspl` and `evsrc` only after invalid JP1/AJS
-  parameter handling is defined across domain and diagnostics.
+- Investigate `evspl` / `evsrc` range diagnostics as the next approval-gated
+  event sending job slice.
+- Revisit `evhst` byte-length, macro-variable, or host-name validation only
+  after the focused range-diagnostics slice is completed or explicitly
+  deferred.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -104,8 +104,9 @@ coverage.
 - Evidence: `parameterFactory.test.ts` and `buildUnitListView.test.ts`
 - Remaining gap:
   unit-list group 14 default-aware projection is aligned for these defaults;
-  `evhst` requiredness diagnostics are aligned through editor-feedback; range
-  validation is deferred
+  `evhst` requiredness diagnostics are aligned through editor-feedback;
+  `evspl` / `evsrc` range diagnostics are aligned through editor-feedback;
+  other event-job validation remains deferred
 
 ### File Monitoring Job Defaults
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -129,6 +129,13 @@ JP1/AJS3 version 13 reference documents.
   reports a semantic diagnostic when `evhst` is omitted, while raw parser
   output, domain wrapper values, normalized parameters, unit-list projection,
   flow projection, and command generation remain unchanged.
+- JP1 event sending job `evspl` / `evsrc` range diagnostics are approval-
+  sensitive because existing behavior preserves explicit out-of-range values as
+  raw parsed data without editor feedback. A focused diagnostic slice should
+  report explicit `evspl` values outside `3..600` seconds and explicit
+  `evsrc` values outside `0..999` checks through editor-feedback while
+  preserving raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -168,6 +168,16 @@
       valid explicit `evsrt=y` with `evhst`, and explicit invalid `evsrt=y`
       without `evhst`
 - [x] Run required code-change validation after implementation
+- [x] Investigate JP1 event sending job `evspl` / `evsrc` range diagnostics as
+      the next focused parameter diagnostics slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration
+- [x] Implement focused `evspl` / `evsrc` range diagnostics only after
+      approval
+- [x] Add focused diagnostics regression evidence for omitted defaults, valid
+      explicit in-range values, and explicit out-of-range `evspl` / `evsrc`
+      values
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -422,22 +432,55 @@
   dependency versions, `engines.vscode`, `evhst` byte-length validation,
   macro-variable validation, `evspl` / `evsrc` range validation, and broad
   parameter validation remain out of scope.
+- 2026-05-06: JP1 event sending job `evspl` / `evsrc` range diagnostics are
+  the next approval-gated semantic diagnostics candidate. JP1/AJS3 version 13
+  JP1 event sending job definitions say `evspl` accepts decimal values
+  `3..600` seconds and `evsrc` accepts decimal values `0..999`, while omitted
+  values default to `10`. Existing behavior preserves explicit out-of-range
+  values as raw parsed data without editor feedback. The proposed scope is
+  limited to reporting explicit out-of-range `evspl` / `evsrc` values through
+  the existing editor-feedback boundary while preserving raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation. Parser grammar, generated artifacts,
+  configuration, dependency versions, `engines.vscode`, `evhst` byte-length
+  validation, host-name validation, macro-variable validation, `evsid`
+  hexadecimal validation, and broad parameter validation remain out of scope.
+- 2026-05-06: JP1 event sending job `evspl` / `evsrc` range diagnostics now
+  report explicit out-of-range `evspl` and `evsrc` values through the
+  existing editor-feedback boundary. Omitted defaults remain non-diagnostic,
+  explicit in-range values remain accepted, and raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, command generation, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-06
 - Approved scope: focused application-level semantic diagnostics for explicit
-  JP1 event sending jobs and recovery JP1 event sending jobs where effective
-  `evsrt=y` omits `evhst`; preserve raw parser output, domain wrapper values,
-  normalized parameters, unit-list projection, flow projection, and command
-  generation; add focused regression evidence; update SDD tracking; and run
-  validation.
+  JP1 event sending jobs and recovery JP1 event sending jobs where `evspl` is
+  outside `3..600` seconds or `evsrc` is outside `0..999`; preserve raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation; add focused regression evidence;
+  update SDD tracking; and run validation.
 
 Current implementation gate: none; last completed slice was JP1 event sending
-job `evhst` requiredness diagnostics.
+job `evspl` / `evsrc` range diagnostics.
 
 ## Prior Approval Evidence
+
+- 2026-05-06: User replied "OK.Proceed." after the JP1 event sending job
+  `evspl` / `evsrc` range-diagnostics approval request. Approved changes were
+  limited to adding focused application-level semantic diagnostics for
+  explicit JP1 event sending jobs and recovery JP1 event sending jobs where
+  `evspl` is outside `3..600` seconds or `evsrc` is outside `0..999`;
+  preserving raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation; adding
+  focused regression evidence; updating SDD tracking; and running validation.
+  Parser grammar, generated artifacts, configuration, dependency versions,
+  `engines.vscode`, `evhst` byte-length validation, host-name validation,
+  macro-variable validation, `evsid` hexadecimal validation, and broad
+  parameter validation were out of scope.
 
 - 2026-05-06: User replied "OK.Proseed." after the JP1 event sending job
   `evhst` requiredness diagnostics approval request. Approved changes were

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -53,20 +53,26 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/event-send-host-required-diagnostics` started from `main`.
+- Branch: `codex/event-send-range-diagnostics` started after investigation on
+  `main`.
 - Objective: continue JP1/AJS v13 parameter alignment with the focused JP1
-  event sending job `evhst` requiredness diagnostics slice before returning to
-  Qlty-driven architecture refactoring.
-- Status: approved, implemented, and validated.
+  event sending job `evspl` / `evsrc` range-diagnostics slice before
+  returning to Qlty-driven architecture refactoring.
+- Status: approved, implemented, and validated on
+  `codex/event-send-range-diagnostics`.
 - Scope: add application-level semantic diagnostics for explicit
-  JP1 event sending jobs and recovery JP1 event sending jobs where effective
-  `evsrt=y` but explicit `evhst` is omitted.
+  JP1 event sending jobs and recovery JP1 event sending jobs where
+  `evspl` is outside the JP1/AJS3 v13 range `3..600` seconds or `evsrc`
+  is outside the JP1/AJS3 v13 range `0..999`; preserve raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation.
 - Out of scope: parser grammar changes, raw parser/domain/normalized value
   changes, unit-list projection changes, flow projection changes, command
   generation changes, generated artifacts, dependency changes,
   `engines.vscode`, `evhst` byte-length validation, host-name format
-  validation, macro-variable validation, `evspl` / `evsrc` range validation,
-  and broad parameter validation.
+  validation, macro-variable validation, `evsid` hexadecimal validation,
+  non-decimal numeric coercion policy beyond the focused range checks, and
+  broad parameter validation.
 - Impact summary: the slice affects
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
   `buildSyntaxDiagnostics` tests, the existing VS Code diagnostics adapter
@@ -74,14 +80,15 @@ rules in `docs/specs/README.md`, not in this file.
   coverage matrix, and the editor-feedback use-case contract.
 - Risks and assumptions: the change is user-visible in desktop and web
   diagnostics for syntactically valid documents. Existing parsed parameter
-  source-location metadata can point at explicit `evsrt=y`; when `evsrt` is
-  omitted, the effective default is `n`, so no missing-host diagnostic is
-  needed. Raw values remain inspectable by downstream consumers.
-- Alternatives considered: keep missing `evhst` silent and leave the matrix
-  gap visible; synthesize or rewrite `evhst` in domain/list output, rejected
-  because manual-invalid input should remain inspectable; broaden to
-  byte-length, macro-variable, or range diagnostics, deferred to keep the
-  slice small.
+  source-location metadata can point at explicit `evspl` / `evsrc`
+  parameters, so no parser or DTO shape change is expected. Omitted values
+  remain non-diagnostic because the existing defaults already align to `10`.
+  Raw values remain inspectable by downstream consumers.
+- Alternatives considered: keep out-of-range `evspl` / `evsrc` silent and
+  leave the matrix gap visible; move numeric validation into domain wrappers,
+  rejected for this slice because current diagnostics policy keeps raw manual-
+  invalid values inspectable; broaden to `evhst` byte-length, host-name, or
+  macro-variable validation, deferred to keep the slice small.
 
 ## Build/Test Performance SDD
 
@@ -110,7 +117,7 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: JP1 event sending job `evsrt=y` / missing `evhst` diagnostics
+  slice: JP1 event sending job `evspl` / `evsrc` range diagnostics
   implemented; next deferred gap to select remains open.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -45,6 +45,8 @@
      editor-feedback when explicit `evsrt=y` omits `evhst`, while preserving
      raw parameter data and avoiding broader event-job validation in the same
      slice.
+   - JP1 event sending job `evspl` / `evsrc` range diagnostics are now aligned
+     through editor-feedback while preserving raw parameter data.
    - Continue with documented deferred diagnostics and range-validation gaps
      only as focused, approval-gated slices.
    - Keep behavior-preserving slices separate from behavior-changing manual

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -42,6 +42,22 @@ const buildDiagnostic = (
   severity: "error" as const,
 });
 
+const parseExplicitDecimalInRange = (
+  parameter: UnitParameter | undefined,
+  minimum: number,
+  maximum: number,
+): number | undefined => {
+  const rawValue = parameter?.value;
+  if (!rawValue || !/^\d+$/.test(rawValue)) {
+    return undefined;
+  }
+
+  const numericValue = Number(rawValue);
+  return numericValue >= minimum && numericValue <= maximum
+    ? numericValue
+    : undefined;
+};
+
 const buildJobEndJudgmentDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
@@ -157,20 +173,46 @@ const buildEventSendingDiagnostics = (
       return unitType ? eventSendingDiagnosticTargetTypes.has(unitType) : false;
     })
     .flatMap((unit) => {
+      const diagnostics: SyntaxDiagnosticDto[] = [];
       const evsrtParameter = findParameter(unit, "evsrt");
       const evhstParameter = findParameter(unit, "evhst");
+      const evsplParameter = findParameter(unit, "evspl");
+      const evsrcParameter = findParameter(unit, "evsrc");
       const effectiveEvsrt = evsrtParameter?.value ?? DEFAULTS.Evsrt;
-
-      if (!evsrtParameter || effectiveEvsrt !== "y" || evhstParameter) {
-        return [];
+      if (
+        evsplParameter &&
+        parseExplicitDecimalInRange(evsplParameter, 3, 600) === undefined
+      ) {
+        diagnostics.push(
+          buildDiagnostic(
+            evsplParameter,
+            "Event arrival check interval (evspl) must be between 3 and 600.",
+          ),
+        );
       }
 
-      return [
-        buildDiagnostic(
-          evsrtParameter,
-          "Event arrival check (evsrt=y) requires an event destination host (evhst).",
-        ),
-      ];
+      if (
+        evsrcParameter &&
+        parseExplicitDecimalInRange(evsrcParameter, 0, 999) === undefined
+      ) {
+        diagnostics.push(
+          buildDiagnostic(
+            evsrcParameter,
+            "Event arrival check count (evsrc) must be between 0 and 999.",
+          ),
+        );
+      }
+
+      if (evsrtParameter && effectiveEvsrt === "y" && !evhstParameter) {
+        diagnostics.push(
+          buildDiagnostic(
+            evsrtParameter,
+            "Event arrival check (evsrt=y) requires an event destination host (evhst).",
+          ),
+        );
+      }
+
+      return diagnostics;
     });
 
 export const buildSyntaxDiagnostics = (

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -396,6 +396,86 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(diagnostics, []);
   });
 
+  test("does not report event sending range diagnostics for omitted defaults and valid explicit ranges", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=event1,evsj,+0+0;",
+        "  el=event2,revsj,+160+0;",
+        "  unit=event1,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        "  }",
+        "  unit=event2,,jp1admin,;",
+        "  {",
+        "    ty=revsj;",
+        "    evspl=600;",
+        "    evsrc=999;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports event sending range diagnostics for explicit out-of-range values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=event1,evsj,+0+0;",
+        "  el=event2,revsj,+160+0;",
+        "  unit=event1,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        "    evspl=2;",
+        "  }",
+        "  unit=event2,,jp1admin,;",
+        "  {",
+        "    ty=revsj;",
+        "    evsrc=1000;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 2);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 5,
+          message:
+            "Event arrival check interval (evspl) must be between 3 and 600.",
+        },
+        {
+          line: 14,
+          column: 4,
+          length: 5,
+          message:
+            "Event arrival check count (evsrc) must be between 0 and 999.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error"],
+    );
+  });
+
   test("reports event sending diagnostics when arrival checking omits evhst", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [


### PR DESCRIPTION
## Summary
- add editor-feedback diagnostics for explicit out-of-range `evspl` and `evsrc` values on `evsj` / `revsj`
- keep parser output and downstream projections unchanged while adding focused regression coverage
- update SDD artifacts and use-case coverage for the approved parameter-alignment slice

## Why
JP1/AJS3 v13 documents ranges for event arrival check interval and count, but the extension previously accepted explicit out-of-range values without semantic diagnostics.

## Validation
- `npm test`
- `rtk pnpm run qlty`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`