### PR TITLE
[codex] Add event sending evsid diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -97,6 +97,14 @@ Scenario: Event arrival check values must stay within documented ranges
   When editor feedback is requested
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
+
+Scenario: Event sending event IDs must stay within documented hexadecimal ranges
+  Given a syntactically valid JP1/AJS document with a JP1 event sending job
+  And explicit `evsid` is outside the JP1/AJS3 v13 hexadecimal ranges
+    `00000000..00001FFF` and `7FFF8000..7FFFFFFF`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
@@ -115,7 +115,7 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 
 ## EVSPL / EVSRC Range Diagnostics
 
-### Current Behavior
+### Current EVSID Behavior
 
 - `Evsj` / `Revsj` expose `evspl` and `evsrc` through `ParamFactory`.
 - `ParamFactory.evspl` and `ParamFactory.evsrc` preserve explicit values as raw
@@ -127,7 +127,7 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 - Explicit out-of-range `evspl` / `evsrc` values are currently preserved
   without editor feedback.
 
-### Proposed Next Slice
+### Proposed EVSID Slice
 
 - Report a semantic diagnostic when an explicit JP1 event sending job or
   recovery JP1 event sending job sets `evspl` outside the JP1/AJS3 v13 range
@@ -154,7 +154,7 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 - Raw parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation remain unchanged.
 
-### Impact
+### EVSID Impact
 
 - User-visible diagnostics would change for syntactically valid JP1/AJS
   documents containing explicit out-of-range event-arrival interval or
@@ -165,7 +165,7 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 - The application diagnostics boundary remains the owner of focused semantic
   parameter feedback; parser grammar and domain wrapper values remain raw.
 
-### Diagnostic Alternatives
+### EVSID Diagnostic Alternatives
 
 - Preserve out-of-range `evspl` / `evsrc` silently and leave the matrix gap
   visible.
@@ -175,10 +175,73 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
   same slice, rejected because that broadens the behavior and regression
   surface.
 
+## EVSID Hexadecimal Diagnostics
+
+### Current Behavior
+
+- `Evsj` / `Revsj` expose `evsid` through `ParamFactory`.
+- `ParamFactory.evsid` preserves explicit values as raw strings and does not
+  currently validate hexadecimal shape or numeric range.
+- `buildSyntaxDiagnostics.ts` already owns focused semantic diagnostics for
+  JP1 event sending jobs, so an `evsid` rule can stay within the existing
+  application editor-feedback boundary.
+- Explicit invalid `evsid` values are currently preserved without editor
+  feedback, and unit-list group 14 projects the same raw value through
+  `actionEventId`.
+
+### Proposed Next Slice
+
+- Report a semantic diagnostic when an explicit JP1 event sending job or
+  recovery JP1 event sending job sets `evsid` outside the JP1/AJS3 v13
+  hexadecimal ranges `00000000..00001FFF` and `7FFF8000..7FFFFFFF`.
+- Treat `evsid` as a hexadecimal value-shape check owned by
+  `buildSyntaxDiagnostics.ts`, preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation.
+- Keep omitted `evsid` non-diagnostic.
+- Point diagnostics at the explicit `evsid` parameter so parser and DTO
+  shapes remain unchanged.
+- Interpret hexadecimal digits case-insensitively unless implementation
+  investigation reveals a product-specific uppercase-only constraint.
+- Accept 1 to 8 hexadecimal digits when the numeric value falls inside one of
+  the documented JP1/AJS3 v13 ranges, because the manual lists allowable
+  hexadecimal values by range rather than as fixed-width tokens.
+
+### Delivered EVSID Behavior
+
+- Explicit JP1 event sending job and recovery JP1 event sending job `evsid`
+  values now report a semantic diagnostic when they are malformed or outside
+  the JP1/AJS3 v13 hexadecimal ranges `00000000..00001FFF` and
+  `7FFF8000..7FFFFFFF`.
+- Omitted `evsid` values remain non-diagnostic.
+- Shorter hexadecimal representations such as `1FFF` remain accepted when the
+  numeric value falls inside one of the documented ranges.
+- Lowercase hexadecimal input remains accepted when the numeric value falls
+  inside one of the documented ranges.
+- Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.
+
+### Impact
+
+- User-visible diagnostics would change for syntactically valid JP1/AJS
+  documents containing explicit invalid event IDs on `evsj` / `revsj`.
+- Existing parsed parameter source-location metadata should be enough to point
+  diagnostics at explicit `evsid`, so no parser or DTO shape change is
+  expected.
+- The application diagnostics boundary remains the owner of focused semantic
+  parameter feedback; parser grammar and domain wrapper values remain raw.
+
+### Diagnostic Alternatives
+
+- Preserve invalid `evsid` values silently and leave the matrix gap visible.
+- Move hexadecimal validation into domain wrappers, rejected for this slice
+  because the current diagnostics policy preserves raw manual-invalid values.
+- Broaden the slice to `evhst` byte-length, host-name, or macro-variable
+  validation, rejected because that would increase behavior and regression
+  surface.
+
 ## Follow-up
 
-- Investigate `evspl` / `evsrc` range diagnostics as the next approval-gated
-  event sending job slice.
 - Revisit `evhst` byte-length, macro-variable, or host-name validation only
-  after the focused range-diagnostics slice is completed or explicitly
+  after the focused `evsid` diagnostics slice is completed or explicitly
   deferred.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -106,7 +106,8 @@ coverage.
   unit-list group 14 default-aware projection is aligned for these defaults;
   `evhst` requiredness diagnostics are aligned through editor-feedback;
   `evspl` / `evsrc` range diagnostics are aligned through editor-feedback;
-  other event-job validation remains deferred
+  `evsid` hexadecimal diagnostics are aligned through editor-feedback; other
+  event-job validation remains deferred
 
 ### File Monitoring Job Defaults
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -136,6 +136,20 @@ JP1/AJS3 version 13 reference documents.
   `evsrc` values outside `0..999` checks through editor-feedback while
   preserving raw parser output, domain wrapper values, normalized parameters,
   unit-list projection, flow projection, and command generation.
+- JP1 event sending job `evsid` hexadecimal diagnostics are approval-sensitive
+  because existing behavior preserves explicit event IDs as raw parsed data
+  without editor feedback. A focused diagnostic slice should report explicit
+  `evsid` values outside the JP1/AJS3 v13 hexadecimal ranges
+  `00000000..00001FFF` and `7FFF8000..7FFFFFFF` through editor-feedback while
+  preserving raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
+- JP1 event sending job `evsid` hexadecimal diagnostics are aligned through
+  application editor-feedback. Explicit `evsid` values on `evsj` / `revsj`
+  now report a semantic diagnostic when they are malformed or fall outside the
+  JP1/AJS3 v13 hexadecimal ranges `00000000..00001FFF` and
+  `7FFF8000..7FFFFFFF`, while raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation remain unchanged.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -178,6 +178,15 @@
       explicit in-range values, and explicit out-of-range `evspl` / `evsrc`
       values
 - [x] Run required code-change validation after implementation
+- [x] Investigate JP1 event sending job `evsid` hexadecimal diagnostics as
+      the next focused parameter diagnostics slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration
+- [x] Implement focused `evsid` hexadecimal diagnostics only after approval
+- [x] Add focused diagnostics regression evidence for omitted `evsid`,
+      valid explicit in-range hexadecimal values, and explicit invalid
+      `evsid` values
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -452,22 +461,58 @@
   wrapper values, normalized parameters, unit-list projection, flow
   projection, command generation, generated artifacts, configuration,
   dependency versions, and `engines.vscode` remain unchanged.
+- 2026-05-06: JP1 event sending job `evsid` hexadecimal diagnostics are the
+  next approval-gated semantic diagnostics candidate. JP1/AJS3 version 13
+  JP1 event sending job definitions say `evsid` accepts hexadecimal values in
+  the disjoint ranges `00000000..00001FFF` and `7FFF8000..7FFFFFFF`.
+  Existing behavior preserves explicit invalid `evsid` values as raw parsed
+  data without editor feedback. The proposed scope is limited to reporting
+  explicit out-of-range or malformed `evsid` values through the existing
+  editor-feedback boundary while preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation. Parser grammar, generated artifacts, configuration,
+  dependency versions, `engines.vscode`, `evhst` byte-length validation,
+  host-name validation, macro-variable validation, event receiving job
+  `evwid` validation, and broad parameter validation remain out of scope.
+- 2026-05-06: JP1 event sending job `evsid` hexadecimal diagnostics now
+  report explicit malformed or out-of-range `evsid` values through the
+  existing editor-feedback boundary. Omitted `evsid` values remain
+  non-diagnostic, explicit valid in-range hexadecimal values remain accepted,
+  and raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, command generation, generated
+  artifacts, configuration, dependency versions, and `engines.vscode` remain
+  unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-06
 - Approved scope: focused application-level semantic diagnostics for explicit
-  JP1 event sending jobs and recovery JP1 event sending jobs where `evspl` is
-  outside `3..600` seconds or `evsrc` is outside `0..999`; preserve raw parser
-  output, domain wrapper values, normalized parameters, unit-list projection,
-  flow projection, and command generation; add focused regression evidence;
-  update SDD tracking; and run validation.
+  JP1 event sending jobs and recovery JP1 event sending jobs where `evsid`
+  falls outside the JP1/AJS3 v13 hexadecimal ranges
+  `00000000..00001FFF` and `7FFF8000..7FFFFFFF`; preserve raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation; add focused regression evidence; update
+  SDD tracking; and run validation.
 
 Current implementation gate: none; last completed slice was JP1 event sending
-job `evspl` / `evsrc` range diagnostics.
+job `evsid` hexadecimal diagnostics.
 
 ## Prior Approval Evidence
+
+- 2026-05-06: User replied "OK.Proceed." after the JP1 event sending job
+  `evsid` hexadecimal-diagnostics approval request. Approved changes were
+  limited to adding focused application-level semantic diagnostics for
+  explicit JP1 event sending jobs and recovery JP1 event sending jobs where
+  `evsid` falls outside the JP1/AJS3 v13 hexadecimal ranges
+  `00000000..00001FFF` and `7FFF8000..7FFFFFFF`; preserving raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation; adding focused regression
+  evidence; updating SDD tracking; and running validation. Parser grammar,
+  generated artifacts, configuration, dependency versions, `engines.vscode`,
+  `evhst` byte-length validation, host-name validation, macro-variable
+  validation, event receiving job `evwid` validation, and broad parameter
+  validation were out of scope.
 
 - 2026-05-06: User replied "OK.Proceed." after the JP1 event sending job
   `evspl` / `evsrc` range-diagnostics approval request. Approved changes were

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -53,26 +53,26 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/event-send-range-diagnostics` started after investigation on
+- Branch: `codex/event-send-evsid-diagnostics` started after approval on
   `main`.
 - Objective: continue JP1/AJS v13 parameter alignment with the focused JP1
-  event sending job `evspl` / `evsrc` range-diagnostics slice before
-  returning to Qlty-driven architecture refactoring.
+  event sending job `evsid` hexadecimal-diagnostics slice before returning
+  to Qlty-driven architecture refactoring.
 - Status: approved, implemented, and validated on
-  `codex/event-send-range-diagnostics`.
+  `codex/event-send-evsid-diagnostics`.
 - Scope: add application-level semantic diagnostics for explicit
-  JP1 event sending jobs and recovery JP1 event sending jobs where
-  `evspl` is outside the JP1/AJS3 v13 range `3..600` seconds or `evsrc`
-  is outside the JP1/AJS3 v13 range `0..999`; preserve raw parser output,
+  JP1 event sending jobs and recovery JP1 event sending jobs where `evsid`
+  falls outside the JP1/AJS3 v13 hexadecimal ranges
+  `00000000..00001FFF` and `7FFF8000..7FFFFFFF`; preserve raw parser output,
   domain wrapper values, normalized parameters, unit-list projection, flow
   projection, and command generation.
 - Out of scope: parser grammar changes, raw parser/domain/normalized value
   changes, unit-list projection changes, flow projection changes, command
   generation changes, generated artifacts, dependency changes,
   `engines.vscode`, `evhst` byte-length validation, host-name format
-  validation, macro-variable validation, `evsid` hexadecimal validation,
-  non-decimal numeric coercion policy beyond the focused range checks, and
-  broad parameter validation.
+  validation, macro-variable validation, event receiving job `evwid`
+  validation, lowercase/uppercase normalization of stored values, and broad
+  parameter validation.
 - Impact summary: the slice affects
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
   `buildSyntaxDiagnostics` tests, the existing VS Code diagnostics adapter
@@ -80,14 +80,14 @@ rules in `docs/specs/README.md`, not in this file.
   coverage matrix, and the editor-feedback use-case contract.
 - Risks and assumptions: the change is user-visible in desktop and web
   diagnostics for syntactically valid documents. Existing parsed parameter
-  source-location metadata can point at explicit `evspl` / `evsrc`
-  parameters, so no parser or DTO shape change is expected. Omitted values
-  remain non-diagnostic because the existing defaults already align to `10`.
-  Raw values remain inspectable by downstream consumers.
-- Alternatives considered: keep out-of-range `evspl` / `evsrc` silent and
-  leave the matrix gap visible; move numeric validation into domain wrappers,
-  rejected for this slice because current diagnostics policy keeps raw manual-
-  invalid values inspectable; broaden to `evhst` byte-length, host-name, or
+  source-location metadata can point at explicit `evsid`, so no parser or DTO
+  shape change is expected. Omitted `evsid` values remain non-diagnostic.
+  Lowercase hexadecimal values are accepted when they fall in-range. Raw
+  values remain inspectable by downstream consumers.
+- Alternatives considered: keep invalid `evsid` silent and leave the matrix
+  gap visible; move hexadecimal validation into domain wrappers, rejected for
+  this slice because current diagnostics policy keeps raw manual-invalid
+  values inspectable; broaden to `evhst` byte-length, host-name, or
   macro-variable validation, deferred to keep the slice small.
 
 ## Build/Test Performance SDD
@@ -117,8 +117,8 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: JP1 event sending job `evspl` / `evsrc` range diagnostics
-  implemented; next deferred gap to select remains open.
+  slice: JP1 event sending job `evsid` hexadecimal diagnostics implemented;
+  next deferred gap to select remains open.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -47,6 +47,8 @@
      slice.
    - JP1 event sending job `evspl` / `evsrc` range diagnostics are now aligned
      through editor-feedback while preserving raw parameter data.
+   - JP1 event sending job `evsid` hexadecimal diagnostics are now aligned
+     through editor-feedback while preserving raw parameter data.
    - Continue with documented deferred diagnostics and range-validation gaps
      only as focused, approval-gated slices.
    - Keep behavior-preserving slices separate from behavior-changing manual

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -58,6 +58,22 @@ const parseExplicitDecimalInRange = (
     : undefined;
 };
 
+const parseExplicitHexadecimalInRange = (
+  parameter: UnitParameter | undefined,
+  minimum: number,
+  maximum: number,
+): number | undefined => {
+  const rawValue = parameter?.value;
+  if (!rawValue || !/^[0-9a-fA-F]{1,8}$/.test(rawValue)) {
+    return undefined;
+  }
+
+  const numericValue = Number.parseInt(rawValue, 16);
+  return numericValue >= minimum && numericValue <= maximum
+    ? numericValue
+    : undefined;
+};
+
 const buildJobEndJudgmentDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
@@ -174,11 +190,34 @@ const buildEventSendingDiagnostics = (
     })
     .flatMap((unit) => {
       const diagnostics: SyntaxDiagnosticDto[] = [];
+      const evsidParameter = findParameter(unit, "evsid");
       const evsrtParameter = findParameter(unit, "evsrt");
       const evhstParameter = findParameter(unit, "evhst");
       const evsplParameter = findParameter(unit, "evspl");
       const evsrcParameter = findParameter(unit, "evsrc");
       const effectiveEvsrt = evsrtParameter?.value ?? DEFAULTS.Evsrt;
+
+      if (
+        evsidParameter &&
+        parseExplicitHexadecimalInRange(
+          evsidParameter,
+          0x00000000,
+          0x00001fff,
+        ) === undefined &&
+        parseExplicitHexadecimalInRange(
+          evsidParameter,
+          0x7fff8000,
+          0x7fffffff,
+        ) === undefined
+      ) {
+        diagnostics.push(
+          buildDiagnostic(
+            evsidParameter,
+            "Event ID (evsid) must be hexadecimal within 00000000-00001FFF or 7FFF8000-7FFFFFFF.",
+          ),
+        );
+      }
+
       if (
         evsplParameter &&
         parseExplicitDecimalInRange(evsplParameter, 3, 600) === undefined

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -377,6 +377,7 @@ suite("Build Syntax Diagnostics", () => {
         "  ty=g;",
         "  el=event1,evsj,+0+0;",
         "  el=event2,revsj,+160+0;",
+        "  el=event3,evsj,+320+0;",
         "  unit=event1,,jp1admin,;",
         "  {",
         "    ty=evsj;",
@@ -394,6 +395,90 @@ suite("Build Syntax Diagnostics", () => {
     );
 
     assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("does not report event sending evsid diagnostics for omitted and valid explicit hexadecimal values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=event1,evsj,+0+0;",
+        "  el=event2,revsj,+160+0;",
+        "  unit=event1,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        "    evsid=1fff;",
+        "  }",
+        "  unit=event2,,jp1admin,;",
+        "  {",
+        "    ty=revsj;",
+        "    evsid=7fff8000;",
+        "  }",
+        "  unit=event3,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports event sending evsid diagnostics for explicit invalid values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=event1,evsj,+0+0;",
+        "  el=event2,revsj,+160+0;",
+        "  unit=event1,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        "    evsid=ACT-1;",
+        "  }",
+        "  unit=event2,,jp1admin,;",
+        "  {",
+        "    ty=revsj;",
+        "    evsid=00002000;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 2);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 5,
+          message:
+            "Event ID (evsid) must be hexadecimal within 00000000-00001FFF or 7FFF8000-7FFFFFFF.",
+        },
+        {
+          line: 14,
+          column: 4,
+          length: 5,
+          message:
+            "Event ID (evsid) must be hexadecimal within 00000000-00001FFF or 7FFF8000-7FFFFFFF.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error"],
+    );
   });
 
   test("does not report event sending range diagnostics for omitted defaults and valid explicit ranges", () => {


### PR DESCRIPTION
## Summary
- add editor-feedback diagnostics for explicit invalid `evsid` values on `evsj` / `revsj`
- accept hexadecimal event IDs within the JP1/AJS3 v13 documented numeric ranges, including shorter representations such as `1FFF`
- add focused regression coverage and sync the approved SDD artifacts for this parameter-alignment slice

## Why
JP1/AJS3 v13 documents `evsid` as allowable hexadecimal value ranges, and the extension previously accepted malformed or out-of-range values without semantic diagnostics. During implementation, we also corrected an overly strict first pass that treated the value as fixed-width instead of range-based.

## Validation
- `rtk pnpm run qlty`
- `npm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`