### PR TITLE
[codex] add evesc diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -105,6 +105,16 @@ Scenario: Event sending event IDs must stay within documented hexadecimal ranges
   When editor feedback is requested
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
+
+Scenario: Event reception monitoring search scope must stay within documented
+  values
+  Given a syntactically valid JP1/AJS document with a JP1 event reception
+    monitoring job
+  And explicit `evesc` is neither `no` nor within the JP1/AJS3 v13 range
+    `1..720`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
@@ -1,0 +1,94 @@
+# JP1 Event Receiving Job Alignment
+
+## Purpose
+
+Record the next JP1/AJS3 version 13 alignment candidate for JP1 event
+reception monitoring job semantic diagnostics.
+
+This document focuses on the currently modeled JP1 event reception monitoring
+job parameter `evesc` for `Evwj` / `Revwj`.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual section:
+  Command Reference, `5.2.9 Job definition for monitoring JP1 event reception`
+- Source URL:
+  <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0224.HTM>
+
+## Slice Boundary
+
+- Application seam:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`
+- Existing consumers:
+  `src/domain/models/units/Evwj.ts` and `Revwj` via inheritance
+- Regression evidence:
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`; keep the existing raw list
+  projection evidence in `src/test/suite/buildUnitListView.test.ts`
+- Out of scope:
+  parser grammar changes, domain wrapper normalization, unit-list projection
+  changes, flow projection changes, command generation, generated artifacts,
+  dependency changes, `engines.vscode`, `evwid` format validation, `evhst`
+  byte-length validation, host-name validation, regular-expression
+  validation, macro-variable validation, `evipa` address validation, and
+  broad event-job validation
+
+## Investigation Notes
+
+- `Evwj` exposes `evesc` through `ParamFactory.evesc`, which currently uses
+  the generic optional scalar builder path and preserves explicit values as raw
+  strings.
+- `buildSyntaxDiagnostics.ts` already owns focused semantic diagnostics for
+  syntactically valid JP1/AJS documents and is shared by desktop and web
+  adapters through the existing editor-feedback boundary.
+- The JP1/AJS3 v13 manual states that `evesc` accepts either `no` or a
+  decimal value between `1` and `720` minutes, with omitted `evesc`
+  defaulting to `no`.
+
+## Proposed Next Slice
+
+- Report a semantic diagnostic when an explicit JP1 event reception monitoring
+  job or recovery JP1 event reception monitoring job sets `evesc` to a value
+  other than `no` or a decimal value between `1` and `720`.
+- Treat the rule as an application-level range validation owned by
+  `buildSyntaxDiagnostics.ts`, preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation.
+- Keep omitted `evesc` and explicit `evesc=no` non-diagnostic.
+- Point diagnostics at the explicit `evesc` parameter so parser and DTO shapes
+  remain unchanged.
+
+## Delivered Behavior
+
+- Explicit JP1 event reception monitoring job and recovery JP1 event reception
+  monitoring job `evesc` values now report a semantic diagnostic when they are
+  neither `no` nor decimal values in the range `1..720`.
+- Omitted `evesc` values and explicit `evesc=no` remain non-diagnostic.
+- Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.
+
+## Impact
+
+- User-visible diagnostics would change for syntactically valid JP1/AJS
+  documents containing explicit invalid event search conditions on
+  `evwj` / `revwj`.
+- Existing parsed parameter source-location metadata should be enough to point
+  diagnostics at explicit `evesc`, so no parser or DTO shape change is
+  expected.
+- The application diagnostics boundary remains the owner of focused semantic
+  parameter feedback; parser grammar and domain wrapper values remain raw.
+
+## Diagnostic Alternatives
+
+- Preserve invalid `evesc` values silently and leave the matrix gap visible.
+- Move `evesc` range validation into domain wrappers, rejected for this slice
+  because the current diagnostics policy preserves raw manual-invalid values.
+- Broaden the slice to `evwid`, `evhst`, `evipa`, or message/regular-
+  expression validation, rejected because that increases behavior and
+  regression surface.
+
+## Follow-up
+
+- Revisit event reception monitoring job host-name, address, regular-
+  expression, and event-ID validation only after the focused `evesc`
+  diagnostics slice is completed or explicitly deferred.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -142,6 +142,23 @@ coverage.
   are aligned for these values; range validation and broader wait-job default
   reconciliation are deferred
 
+### Event Reception Monitoring Job Search Scope
+
+- Keys: `evesc`
+- Unit scope:
+  JP1 event reception monitoring jobs and recovery JP1 event reception
+  monitoring jobs
+- Status: partial
+- Owning seam:
+  `Evwj.ts`, `optionalScalarParameterBuilders.ts`, and
+  `buildSyntaxDiagnostics.ts`
+- Evidence: `buildSyntaxDiagnostics.test.ts`
+- Remaining gap:
+  `evesc` range diagnostics are aligned through editor-feedback. `evwid`
+  format validation, `evhst` byte-length validation, host-name validation,
+  regular-expression validation, macro-variable validation, `evipa` address
+  validation, and broader event-job validation remain deferred.
+
 ## Boundary Decisions
 
 - This matrix covers only categories with feature-local investigation records.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -150,6 +150,20 @@ JP1/AJS3 version 13 reference documents.
   `7FFF8000..7FFFFFFF`, while raw parser output, domain wrapper values,
   normalized parameters, unit-list projection, flow projection, and command
   generation remain unchanged.
+- JP1 event reception monitoring job `evesc` range diagnostics are
+  approval-sensitive because existing behavior preserves explicit invalid event
+  search values as raw parsed data without editor feedback. A focused
+  diagnostic slice should report explicit `evesc` values that are neither `no`
+  nor decimal values in the JP1/AJS3 v13 range `1..720` through
+  editor-feedback while preserving raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation.
+- JP1 event reception monitoring job `evesc` range diagnostics are aligned
+  through application editor-feedback. Explicit `evesc` values on `evwj` /
+  `revwj` now report a semantic diagnostic when they are neither `no` nor
+  decimal values in the JP1/AJS3 v13 range `1..720`, while raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation remain unchanged.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -187,6 +187,15 @@
       valid explicit in-range hexadecimal values, and explicit invalid
       `evsid` values
 - [x] Run required code-change validation after implementation
+- [x] Investigate JP1 event reception monitoring job `evesc` range
+      diagnostics as the next focused parameter diagnostics slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration
+- [x] Implement focused `evesc` range diagnostics only after approval
+- [x] Add focused diagnostics regression evidence for omitted `evesc`,
+      valid explicit `evesc=no` or in-range decimal values, and explicit
+      invalid `evesc` values
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -482,23 +491,59 @@
   unit-list projection, flow projection, command generation, generated
   artifacts, configuration, dependency versions, and `engines.vscode` remain
   unchanged.
+- 2026-05-06: JP1 event reception monitoring job `evesc` range diagnostics
+  are the next approval-gated semantic diagnostics candidate. JP1/AJS3
+  version 13 job definitions for monitoring JP1 event reception say `evesc`
+  accepts either `no` or a decimal value in the range `1..720`, while omitted
+  values default to `no`. Existing behavior preserves explicit invalid
+  `evesc` values as raw parsed data without editor feedback. The proposed
+  scope is limited to reporting explicit malformed or out-of-range `evesc`
+  values through the existing editor-feedback boundary while preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation. Parser grammar,
+  generated artifacts, configuration, dependency versions, `engines.vscode`,
+  `evwid` format validation, `evhst` byte-length validation, host-name
+  validation, regular-expression validation, macro-variable validation,
+  `evipa` address validation, and broad parameter validation remain out of
+  scope.
+- 2026-05-06: JP1 event reception monitoring job `evesc` range diagnostics
+  now report explicit malformed or out-of-range `evesc` values through the
+  existing editor-feedback boundary. Omitted `evesc` values and explicit
+  `evesc=no` remain non-diagnostic, and raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection,
+  command generation, generated artifacts, configuration, dependency
+  versions, and `engines.vscode` remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-06
 - Approved scope: focused application-level semantic diagnostics for explicit
-  JP1 event sending jobs and recovery JP1 event sending jobs where `evsid`
-  falls outside the JP1/AJS3 v13 hexadecimal ranges
-  `00000000..00001FFF` and `7FFF8000..7FFFFFFF`; preserve raw parser output,
-  domain wrapper values, normalized parameters, unit-list projection, flow
-  projection, and command generation; add focused regression evidence; update
-  SDD tracking; and run validation.
+  JP1 event reception monitoring jobs and recovery JP1 event reception
+  monitoring jobs where `evesc` is neither `no` nor a decimal value in the
+  JP1/AJS3 v13 range `1..720`; preserve raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation; add focused regression evidence; update SDD tracking;
+  and run validation.
 
-Current implementation gate: none; last completed slice was JP1 event sending
-job `evsid` hexadecimal diagnostics.
+Current implementation gate: none; last completed slice was JP1 event
+reception monitoring job `evesc` range diagnostics.
 
 ## Prior Approval Evidence
+
+- 2026-05-06: User replied "OK.Proceed." after the JP1 event reception
+  monitoring job `evesc` range-diagnostics approval request. Approved changes
+  were limited to adding focused application-level semantic diagnostics for
+  explicit JP1 event reception monitoring jobs and recovery JP1 event
+  reception monitoring jobs where `evesc` is neither `no` nor a decimal value
+  in the JP1/AJS3 v13 range `1..720`; preserving raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation; adding focused regression evidence;
+  updating SDD tracking; and running validation. Parser grammar, generated
+  artifacts, configuration, dependency versions, `engines.vscode`, `evwid`
+  format validation, `evhst` byte-length validation, host-name validation,
+  regular-expression validation, macro-variable validation, `evipa` address
+  validation, and broad parameter validation were out of scope.
 
 - 2026-05-06: User replied "OK.Proceed." after the JP1 event sending job
   `evsid` hexadecimal-diagnostics approval request. Approved changes were
@@ -654,6 +699,16 @@ job `evsid` hexadecimal diagnostics.
 
 ## Validation
 
+- 2026-05-06: `pnpm run test:compile`
+- 2026-05-06: `pnpm run qlty` completed with exit code 0; run used an
+  escalated command because sandboxed qlty cannot create its log file
+- 2026-05-06: `pnpm test`
+- 2026-05-06: `pnpm run test:web` failed in the sandbox because Chromium could
+  not access macOS Mach port APIs; escalated rerun completed with exit code 0
+  and existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-06: `pnpm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-06: `pnpm run lint:md`
 - 2026-05-06: `pnpm run qlty` required an escalated rerun after a sandboxed
   qlty log-file permission failure
 - 2026-05-06: `pnpm test`

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -53,42 +53,42 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/event-send-evsid-diagnostics` started after approval on
-  `main`.
+- Branch: `main` during investigation-only work; create a non-`docs/...`
+  branch after approval and before implementation starts.
 - Objective: continue JP1/AJS v13 parameter alignment with the focused JP1
-  event sending job `evsid` hexadecimal-diagnostics slice before returning
-  to Qlty-driven architecture refactoring.
+  event reception monitoring job `evesc` range-diagnostics slice before
+  returning to broader deferred validation gaps.
 - Status: approved, implemented, and validated on
-  `codex/event-send-evsid-diagnostics`.
+  `codex/event-receiving-evesc-diagnostics`.
 - Scope: add application-level semantic diagnostics for explicit
-  JP1 event sending jobs and recovery JP1 event sending jobs where `evsid`
-  falls outside the JP1/AJS3 v13 hexadecimal ranges
-  `00000000..00001FFF` and `7FFF8000..7FFFFFFF`; preserve raw parser output,
-  domain wrapper values, normalized parameters, unit-list projection, flow
-  projection, and command generation.
+  JP1 event reception monitoring jobs and recovery JP1 event reception
+  monitoring jobs where `evesc` is neither `no` nor a decimal value between
+  `1` and `720`; preserve raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation.
 - Out of scope: parser grammar changes, raw parser/domain/normalized value
   changes, unit-list projection changes, flow projection changes, command
   generation changes, generated artifacts, dependency changes,
-  `engines.vscode`, `evhst` byte-length validation, host-name format
-  validation, macro-variable validation, event receiving job `evwid`
-  validation, lowercase/uppercase normalization of stored values, and broad
-  parameter validation.
-- Impact summary: the slice affects
+  `engines.vscode`, `evwid` format validation, `evhst` byte-length
+  validation, host-name validation, regular-expression validation,
+  macro-variable validation, `evipa` address validation, and broad parameter
+  validation.
+- Impact summary: the slice would affect
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
   `buildSyntaxDiagnostics` tests, the existing VS Code diagnostics adapter
-  through DTO mapping, JP1 event sending job alignment docs, the parameter
-  coverage matrix, and the editor-feedback use-case contract.
-- Risks and assumptions: the change is user-visible in desktop and web
+  through DTO mapping, the new JP1 event receiving job alignment record, and
+  the editor-feedback use-case contract.
+- Risks and assumptions: the change would be user-visible in desktop and web
   diagnostics for syntactically valid documents. Existing parsed parameter
-  source-location metadata can point at explicit `evsid`, so no parser or DTO
-  shape change is expected. Omitted `evsid` values remain non-diagnostic.
-  Lowercase hexadecimal values are accepted when they fall in-range. Raw
-  values remain inspectable by downstream consumers.
-- Alternatives considered: keep invalid `evsid` silent and leave the matrix
-  gap visible; move hexadecimal validation into domain wrappers, rejected for
-  this slice because current diagnostics policy keeps raw manual-invalid
-  values inspectable; broaden to `evhst` byte-length, host-name, or
-  macro-variable validation, deferred to keep the slice small.
+  source-location metadata should be enough to point at explicit `evesc`, so
+  no parser or DTO shape change is expected. Omitted `evesc` values and
+  explicit `evesc=no` remain non-diagnostic. Raw values remain inspectable by
+  downstream consumers.
+- Alternatives considered: keep invalid `evesc` silent and leave the gap
+  visible; move range validation into domain wrappers, rejected for this
+  slice because current diagnostics policy keeps raw manual-invalid values
+  inspectable; broaden to event-ID, host-name, address, or regular-expression
+  validation, deferred to keep the slice small.
 
 ## Build/Test Performance SDD
 
@@ -117,8 +117,8 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: JP1 event sending job `evsid` hexadecimal diagnostics implemented;
-  next deferred gap to select remains open.
+  slice: JP1 event reception monitoring job `evesc` range diagnostics
+  implemented; next deferred gap to select remains open.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -21,6 +21,7 @@ const jobEndJudgmentDiagnosticTargetTypes = new Set([
 const jobEndJudgmentRetryParameterKeys = ["rjs", "rje", "rec", "rei"];
 const fileMonitoringDiagnosticTargetTypes = new Set(["flwj", "rflwj"]);
 const eventSendingDiagnosticTargetTypes = new Set(["evsj", "revsj"]);
+const eventReceivingDiagnosticTargetTypes = new Set(["evwj", "revwj"]);
 
 const flattenUnits = (units: Unit[]): Unit[] =>
   units.reduce<Unit[]>(
@@ -254,6 +255,50 @@ const buildEventSendingDiagnostics = (
       return diagnostics;
     });
 
+const isValidExplicitEventSearchCondition = (
+  parameter: UnitParameter | undefined,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (!rawValue) {
+    return false;
+  }
+
+  if (rawValue === "no") {
+    return true;
+  }
+
+  return parseExplicitDecimalInRange(parameter, 1, 720) !== undefined;
+};
+
+const buildEventReceivingDiagnostics = (
+  rootUnits: Unit[],
+): SyntaxDiagnosticDto[] =>
+  flattenUnits(rootUnits)
+    .filter((unit) => {
+      const unitType = findParameter(unit, "ty")?.value;
+      return unitType
+        ? eventReceivingDiagnosticTargetTypes.has(unitType)
+        : false;
+    })
+    .flatMap((unit) => {
+      const diagnostics: SyntaxDiagnosticDto[] = [];
+      const evescParameter = findParameter(unit, "evesc");
+
+      if (
+        evescParameter &&
+        !isValidExplicitEventSearchCondition(evescParameter)
+      ) {
+        diagnostics.push(
+          buildDiagnostic(
+            evescParameter,
+            "Event search condition (evesc) must be no or between 1 and 720.",
+          ),
+        );
+      }
+
+      return diagnostics;
+    });
+
 export const buildSyntaxDiagnostics = (
   content: string,
 ): SyntaxDiagnosticDto[] => {
@@ -274,5 +319,6 @@ export const buildSyntaxDiagnostics = (
     ...buildJobEndJudgmentDiagnostics(result.rootUnits),
     ...buildFileMonitoringDiagnostics(result.rootUnits),
     ...buildEventSendingDiagnostics(result.rootUnits),
+    ...buildEventReceivingDiagnostics(result.rootUnits),
   ];
 };

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -614,4 +614,102 @@ suite("Build Syntax Diagnostics", () => {
       ["error", "error"],
     );
   });
+
+  test("does not report event receiving diagnostics for omitted defaults and valid explicit values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=wait1,evwj,+0+0;",
+        "  el=wait2,revwj,+160+0;",
+        "  el=wait3,evwj,+320+0;",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    evesc=no;",
+        "  }",
+        "  unit=wait3,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evesc=720;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports event receiving diagnostics for explicit invalid evesc values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=wait1,evwj,+0+0;",
+        "  el=wait2,revwj,+160+0;",
+        "  el=wait3,evwj,+320+0;",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evesc=0;",
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    evesc=721;",
+        "  }",
+        "  unit=wait3,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evesc=abc;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 3);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 5,
+          message:
+            "Event search condition (evesc) must be no or between 1 and 720.",
+        },
+        {
+          line: 14,
+          column: 4,
+          length: 5,
+          message:
+            "Event search condition (evesc) must be no or between 1 and 720.",
+        },
+        {
+          line: 19,
+          column: 4,
+          length: 5,
+          message:
+            "Event search condition (evesc) must be no or between 1 and 720.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error"],
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add semantic editor-feedback diagnostics for explicit invalid `evesc` values on `evwj` / `revwj`
- add focused regression tests for omitted, valid, and invalid `evesc` cases
- sync SDD artifacts and the editor-feedback use case for the approved slice

## Why
JP1/AJS v13 parameter alignment still had an open event reception monitoring gap. This closes the focused `evesc` range-diagnostics slice without changing parser output, domain wrappers, unit-list projection, flow projection, or command generation.

## Validation
- `pnpm run test:compile`
- `pnpm run qlty`
- `pnpm test`
- `pnpm run test:web`
- `pnpm run build`
- `pnpm run lint:md`

## Notes
- `pnpm run qlty` was rerun outside the sandbox because qlty could not create its log file inside the sandbox.
- `pnpm run test:web` was rerun outside the sandbox because Chromium could not launch inside the sandbox due to macOS Mach port restrictions.
- `pnpm run build` completed with the existing webpack asset-size warnings.