### PR TITLE
Add grouped event reception diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -115,6 +115,18 @@ Scenario: Event reception monitoring search scope must stay within documented
   When editor feedback is requested
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
+
+Scenario: Event reception monitoring identifiers must stay within documented
+  formats
+  Given a syntactically valid JP1/AJS document with a JP1 event reception
+    monitoring job
+  And explicit `evwid` is outside the JP1/AJS3 v13 hexadecimal event-ID
+    format and range `00000000:00000000` to `FFFFFFFF:FFFFFFFF`
+  Or explicit `evipa` is outside the JP1/AJS3 v13 IPv4 dotted-decimal range
+    `0.0.0.0` to `255.255.255.255`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-Record the next JP1/AJS3 version 13 alignment candidate for JP1 event
-reception monitoring job semantic diagnostics.
+Record the JP1/AJS3 version 13 alignment status and next grouped validation
+candidate for JP1 event reception monitoring job semantic diagnostics.
 
-This document focuses on the currently modeled JP1 event reception monitoring
-job parameter `evesc` for `Evwj` / `Revwj`.
+This document covers the delivered `evesc` diagnostic slice and the next
+grouped validation candidate for `Evwj` / `Revwj`.
 
 ## Normative Reference
 
@@ -28,10 +28,9 @@ job parameter `evesc` for `Evwj` / `Revwj`.
 - Out of scope:
   parser grammar changes, domain wrapper normalization, unit-list projection
   changes, flow projection changes, command generation, generated artifacts,
-  dependency changes, `engines.vscode`, `evwid` format validation, `evhst`
-  byte-length validation, host-name validation, regular-expression
-  validation, macro-variable validation, `evipa` address validation, and
-  broad event-job validation
+  dependency changes, `engines.vscode`, `evhst` byte-length validation,
+  host-name validation, regular-expression validation, macro-variable
+  validation, and broad event-job validation
 
 ## Investigation Notes
 
@@ -44,8 +43,15 @@ job parameter `evesc` for `Evwj` / `Revwj`.
 - The JP1/AJS3 v13 manual states that `evesc` accepts either `no` or a
   decimal value between `1` and `720` minutes, with omitted `evesc`
   defaulting to `no`.
+- The JP1/AJS3 v13 manual states that `evwid` accepts hexadecimal values in
+  the range `00000000:00000000` to `FFFFFFFF:FFFFFFFF`.
+- The JP1/AJS3 v13 manual states that `evipa` accepts IPv4 dotted-decimal
+  addresses in the range `0.0.0.0` to `255.255.255.255`.
+- Existing raw projection evidence includes `evwid=EV-1;` in
+  `buildUnitListView.test.ts`, which confirms that editor diagnostics can be
+  tightened without changing raw unit-list projection.
 
-## Proposed Next Slice
+## Delivered Slice Scope
 
 - Report a semantic diagnostic when an explicit JP1 event reception monitoring
   job or recovery JP1 event reception monitoring job sets `evesc` to a value
@@ -67,28 +73,55 @@ job parameter `evesc` for `Evwj` / `Revwj`.
 - Raw parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation remain unchanged.
 
+## Proposed Next Grouped Slice
+
+- Report a semantic diagnostic when an explicit JP1 event reception monitoring
+  job or recovery JP1 event reception monitoring job sets `evwid` to a value
+  outside the hexadecimal event-ID format and range
+  `00000000:00000000` to `FFFFFFFF:FFFFFFFF`.
+- Report a semantic diagnostic when an explicit JP1 event reception monitoring
+  job or recovery JP1 event reception monitoring job sets `evipa` to a value
+  outside the IPv4 dotted-decimal range `0.0.0.0` to `255.255.255.255`.
+- Treat both rules as application-level format validations owned by
+  `buildSyntaxDiagnostics.ts`, preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation.
+- Keep omitted `evwid` and `evipa` non-diagnostic.
+- Treat one to eight hexadecimal digits per `evwid` segment as valid when the
+  value stays within the documented range, because the manual defines a
+  hexadecimal range but does not explicitly require zero-padded eight-digit
+  segments.
+- Point diagnostics at the explicit `evwid` and `evipa` parameters so parser
+  and DTO shapes remain unchanged.
+
 ## Impact
 
 - User-visible diagnostics would change for syntactically valid JP1/AJS
-  documents containing explicit invalid event search conditions on
-  `evwj` / `revwj`.
+  documents containing explicit invalid event IDs or event source IP
+  addresses on `evwj` / `revwj`.
 - Existing parsed parameter source-location metadata should be enough to point
-  diagnostics at explicit `evesc`, so no parser or DTO shape change is
-  expected.
+  diagnostics at explicit `evwid` and `evipa`, so no parser or DTO shape
+  change is expected.
 - The application diagnostics boundary remains the owner of focused semantic
   parameter feedback; parser grammar and domain wrapper values remain raw.
 
 ## Diagnostic Alternatives
 
-- Preserve invalid `evesc` values silently and leave the matrix gap visible.
-- Move `evesc` range validation into domain wrappers, rejected for this slice
-  because the current diagnostics policy preserves raw manual-invalid values.
-- Broaden the slice to `evwid`, `evhst`, `evipa`, or message/regular-
-  expression validation, rejected because that increases behavior and
-  regression surface.
+- Preserve invalid `evwid` / `evipa` values silently and leave the matrix gap
+  visible.
+- Move `evwid` / `evipa` validation into domain wrappers, rejected for this
+  slice because the current diagnostics policy preserves raw manual-invalid
+  values.
+- Keep `evwid` and `evipa` as separate micro-slices, rejected because this
+  job type already has multiple related deferred validations and the user asked
+  for grouped fixes by job type or category where practical.
+- Broaden the slice further to `evhst` or message/regular-expression
+  validation, deferred because that increases behavior and regression surface
+  due to regex and macro-variable allowances.
 
 ## Follow-up
 
-- Revisit event reception monitoring job host-name, address, regular-
-  expression, and event-ID validation only after the focused `evesc`
-  diagnostics slice is completed or explicitly deferred.
+- Revisit event reception monitoring job host-name byte-length,
+  regular-expression, macro-variable, and broader string-filter validation
+  after the grouped `evwid` / `evipa` diagnostics slice is completed or
+  explicitly deferred.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -144,7 +144,7 @@ coverage.
 
 ### Event Reception Monitoring Job Search Scope
 
-- Keys: `evesc`
+- Keys: `evesc`, `evwid`, and `evipa`
 - Unit scope:
   JP1 event reception monitoring jobs and recovery JP1 event reception
   monitoring jobs
@@ -154,10 +154,11 @@ coverage.
   `buildSyntaxDiagnostics.ts`
 - Evidence: `buildSyntaxDiagnostics.test.ts`
 - Remaining gap:
-  `evesc` range diagnostics are aligned through editor-feedback. `evwid`
-  format validation, `evhst` byte-length validation, host-name validation,
-  regular-expression validation, macro-variable validation, `evipa` address
-  validation, and broader event-job validation remain deferred.
+  `evesc` range diagnostics plus grouped `evwid` event-ID and `evipa` IPv4
+  validation are aligned through editor-feedback. `evhst` byte-length
+  validation, host-name validation, regular-expression validation,
+  macro-variable validation, and broader event-job validation remain
+  deferred.
 
 ## Boundary Decisions
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -158,12 +158,32 @@ JP1/AJS3 version 13 reference documents.
   editor-feedback while preserving raw parser output, domain wrapper values,
   normalized parameters, unit-list projection, flow projection, and command
   generation.
+- JP1 event reception monitoring job `evwid` and `evipa` validation are
+  approval-sensitive because existing behavior preserves explicit event IDs
+  and source IP addresses as raw parsed data without editor feedback. A
+  grouped diagnostic slice should report explicit `evwid` values that fall
+  outside the JP1/AJS3 v13 hexadecimal event-ID format and range
+  `00000000:00000000` to `FFFFFFFF:FFFFFFFF`, plus explicit `evipa` values
+  that fall outside the JP1/AJS3 v13 IPv4 dotted-decimal range
+  `0.0.0.0` to `255.255.255.255`, through editor-feedback while preserving
+  raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation.
 - JP1 event reception monitoring job `evesc` range diagnostics are aligned
   through application editor-feedback. Explicit `evesc` values on `evwj` /
   `revwj` now report a semantic diagnostic when they are neither `no` nor
   decimal values in the JP1/AJS3 v13 range `1..720`, while raw parser output,
   domain wrapper values, normalized parameters, unit-list projection, flow
   projection, and command generation remain unchanged.
+- JP1 event reception monitoring job `evwid` and `evipa` validation are
+  aligned through application editor-feedback. Explicit `evwid` values on
+  `evwj` / `revwj` now report a semantic diagnostic when they are not
+  colon-separated hexadecimal event IDs within the
+  `00000000:00000000` to `FFFFFFFF:FFFFFFFF` range, and explicit `evipa`
+  values now report a semantic diagnostic when they are not IPv4
+  dotted-decimal values in `0.0.0.0` to
+  `255.255.255.255`, while raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation remain unchanged.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -196,6 +196,15 @@
       valid explicit `evesc=no` or in-range decimal values, and explicit
       invalid `evesc` values
 - [x] Run required code-change validation after implementation
+- [x] Investigate JP1 event reception monitoring job grouped `evwid` /
+      `evipa` validation as the next focused parameter diagnostics slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration
+- [x] Implement grouped `evwid` / `evipa` validation only after approval
+- [x] Add focused diagnostics regression evidence for omitted `evwid` and
+      `evipa`, valid explicit hexadecimal event IDs and IPv4 addresses, and
+      explicit invalid `evwid` / `evipa` values
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -513,6 +522,27 @@
   values, normalized parameters, unit-list projection, flow projection,
   command generation, generated artifacts, configuration, dependency
   versions, and `engines.vscode` remain unchanged.
+- 2026-05-06: JP1 event reception monitoring job grouped `evwid` / `evipa`
+  validation is the next approval-gated semantic diagnostics candidate.
+  JP1/AJS3 version 13 job definitions for monitoring JP1 event reception say
+  `evwid` accepts hexadecimal values in the range `00000000:00000000` to
+  `FFFFFFFF:FFFFFFFF`, and `evipa` accepts IPv4 dotted-decimal values in the
+  range `0.0.0.0` to `255.255.255.255`. The proposed scope is limited to
+  reporting explicit malformed `evwid` or `evipa` values through the existing
+  editor-feedback boundary while preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation. Parser grammar, generated artifacts, configuration,
+  dependency versions, `engines.vscode`, `evhst` byte-length validation,
+  host-name validation, regular-expression validation, macro-variable
+  validation, and broad parameter validation remain out of scope.
+- 2026-05-06: JP1 event reception monitoring job grouped `evwid` / `evipa`
+  validation now reports explicit malformed event IDs and invalid dotted-
+  decimal IPv4 source addresses through the existing editor-feedback
+  boundary. Omitted values remain non-diagnostic, valid explicit values remain
+  accepted, and raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, command generation,
+  generated artifacts, configuration, dependency versions, and
+  `engines.vscode` remain unchanged.
 
 ## Human Approval
 
@@ -520,16 +550,34 @@
 - Approved at: 2026-05-06
 - Approved scope: focused application-level semantic diagnostics for explicit
   JP1 event reception monitoring jobs and recovery JP1 event reception
-  monitoring jobs where `evesc` is neither `no` nor a decimal value in the
-  JP1/AJS3 v13 range `1..720`; preserve raw parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection, and
-  command generation; add focused regression evidence; update SDD tracking;
-  and run validation.
+  monitoring jobs where `evwid` is outside the JP1/AJS3 v13 hexadecimal
+  event-ID format and range `00000000:00000000` to `FFFFFFFF:FFFFFFFF`, or
+  where `evipa` is outside the IPv4 dotted-decimal range `0.0.0.0` to
+  `255.255.255.255`; preserve raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation; add focused regression evidence; update SDD tracking; and run
+  validation.
 
 Current implementation gate: none; last completed slice was JP1 event
-reception monitoring job `evesc` range diagnostics.
+reception monitoring job grouped `evwid` / `evipa` validation.
 
 ## Prior Approval Evidence
+
+- 2026-05-06: User replied "Approved. Proceed with implementation." after the
+  JP1 event reception monitoring job grouped `evwid` / `evipa` validation
+  approval request. Approved changes were limited to adding focused
+  application-level semantic diagnostics for explicit JP1 event reception
+  monitoring jobs and recovery JP1 event reception monitoring jobs where
+  `evwid` falls outside the JP1/AJS3 v13 hexadecimal event-ID format and
+  range `00000000:00000000` to `FFFFFFFF:FFFFFFFF`, or where `evipa` falls
+  outside the IPv4 dotted-decimal range `0.0.0.0` to `255.255.255.255`;
+  preserving raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation; adding
+  focused regression evidence; updating SDD tracking; and running validation.
+  Parser grammar, generated artifacts, configuration, dependency versions,
+  `engines.vscode`, `evhst` byte-length validation, host-name validation,
+  regular-expression validation, macro-variable validation, and broad
+  parameter validation were out of scope.
 
 - 2026-05-06: User replied "OK.Proceed." after the JP1 event reception
   monitoring job `evesc` range-diagnostics approval request. Approved changes
@@ -703,6 +751,17 @@ reception monitoring job `evesc` range diagnostics.
 - 2026-05-06: `pnpm run qlty` completed with exit code 0; run used an
   escalated command because sandboxed qlty cannot create its log file
 - 2026-05-06: `pnpm test`
+- 2026-05-06: `pnpm run qlty` completed with exit code 0 after grouped
+  `evwid` / `evipa` diagnostics implementation; run used an escalated command
+  because sandboxed qlty cannot create its log file
+- 2026-05-06: `pnpm run test:compile`
+- 2026-05-06: `pnpm test`
+- 2026-05-06: `pnpm run test:web` failed in the sandbox because Chromium could
+  not access macOS Mach port APIs; escalated rerun completed with exit code 0
+  and existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-06: `pnpm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-06: `pnpm run lint:md`
 - 2026-05-06: `pnpm run test:web` failed in the sandbox because Chromium could
   not access macOS Mach port APIs; escalated rerun completed with exit code 0
   and existing localhost dev-extension `package.nls.json` 404 noise

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -37,10 +37,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Select the next focused JP1/AJS3 v13 parameter-alignment gap from the
-   documented deferred diagnostics, range-validation, byte-length validation,
-   macro-variable validation, wildcard restriction, and requiredness
-   candidates.
+1. Select the next grouped JP1/AJS3 v13 parameter-alignment gap from the
+   remaining deferred validations after delivered event reception `evwid` /
+   `evipa` diagnostics.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -53,42 +52,43 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `main` during investigation-only work; create a non-`docs/...`
-  branch after approval and before implementation starts.
+- Branch: `codex/event-receiving-id-ip-diagnostics`
 - Objective: continue JP1/AJS v13 parameter alignment with the focused JP1
-  event reception monitoring job `evesc` range-diagnostics slice before
-  returning to broader deferred validation gaps.
+  event reception monitoring job grouped validation slice for `evwid` and
+  `evipa` before returning to broader deferred validation gaps.
 - Status: approved, implemented, and validated on
-  `codex/event-receiving-evesc-diagnostics`.
+  `codex/event-receiving-id-ip-diagnostics`.
 - Scope: add application-level semantic diagnostics for explicit
   JP1 event reception monitoring jobs and recovery JP1 event reception
-  monitoring jobs where `evesc` is neither `no` nor a decimal value between
-  `1` and `720`; preserve raw parser output, domain wrapper values,
-  normalized parameters, unit-list projection, flow projection, and command
-  generation.
+  monitoring jobs where `evwid` is outside the JP1/AJS3 v13 hexadecimal
+  event-ID format and range `00000000:00000000` to `FFFFFFFF:FFFFFFFF`, or
+  where `evipa` is outside the IPv4 dotted-decimal range
+  `0.0.0.0` to `255.255.255.255`; preserve raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation.
 - Out of scope: parser grammar changes, raw parser/domain/normalized value
   changes, unit-list projection changes, flow projection changes, command
   generation changes, generated artifacts, dependency changes,
-  `engines.vscode`, `evwid` format validation, `evhst` byte-length
-  validation, host-name validation, regular-expression validation,
-  macro-variable validation, `evipa` address validation, and broad parameter
-  validation.
+  `engines.vscode`, `evhst` byte-length validation, host-name validation,
+  regular-expression validation, macro-variable validation, and broad
+  parameter validation.
 - Impact summary: the slice would affect
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
   `buildSyntaxDiagnostics` tests, the existing VS Code diagnostics adapter
-  through DTO mapping, the new JP1 event receiving job alignment record, and
+  through DTO mapping, the JP1 event receiving job alignment record, and
   the editor-feedback use-case contract.
 - Risks and assumptions: the change would be user-visible in desktop and web
   diagnostics for syntactically valid documents. Existing parsed parameter
-  source-location metadata should be enough to point at explicit `evesc`, so
-  no parser or DTO shape change is expected. Omitted `evesc` values and
-  explicit `evesc=no` remain non-diagnostic. Raw values remain inspectable by
-  downstream consumers.
-- Alternatives considered: keep invalid `evesc` silent and leave the gap
-  visible; move range validation into domain wrappers, rejected for this
-  slice because current diagnostics policy keeps raw manual-invalid values
-  inspectable; broaden to event-ID, host-name, address, or regular-expression
-  validation, deferred to keep the slice small.
+  source-location metadata should be enough to point at explicit `evwid` and
+  `evipa`, so no parser or DTO shape change is expected. Omitted values remain
+  non-diagnostic. Raw values remain inspectable by downstream consumers, and
+  the existing unit-list raw projection evidence should stay unchanged outside
+  diagnostics.
+- Alternatives considered: keep invalid `evwid` / `evipa` silent and leave
+  the gap visible; move these validations into domain wrappers, rejected for
+  this slice because current diagnostics policy keeps raw manual-invalid
+  values inspectable; broaden immediately to `evhst` and regex-bearing string
+  parameters, deferred because that expands the approval and test surface.
 
 ## Build/Test Performance SDD
 
@@ -117,8 +117,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: JP1 event reception monitoring job `evesc` range diagnostics
-  implemented; next deferred gap to select remains open.
+  slice: JP1 event reception monitoring job grouped `evwid` / `evipa`
+  validation implemented after delivered `evesc` diagnostics; next deferred
+  grouped gap remains to be selected.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -32,6 +32,15 @@ const flattenUnits = (units: Unit[]): Unit[] =>
 const findParameter = (unit: Unit, key: string): UnitParameter | undefined =>
   unit.parameters.find((parameter) => parameter.key === key);
 
+const findUnitsByTypes = (
+  rootUnits: Unit[],
+  targetTypes: Set<string>,
+): Unit[] =>
+  flattenUnits(rootUnits).filter((unit) => {
+    const unitType = findParameter(unit, "ty")?.value;
+    return unitType ? targetTypes.has(unitType) : false;
+  });
+
 const buildDiagnostic = (
   parameter: UnitParameter,
   message: string,
@@ -60,32 +69,68 @@ const parseExplicitDecimalInRange = (
 };
 
 const parseExplicitHexadecimalInRange = (
-  parameter: UnitParameter | undefined,
+  value: string | undefined,
   minimum: number,
   maximum: number,
 ): number | undefined => {
-  const rawValue = parameter?.value;
-  if (!rawValue || !/^[0-9a-fA-F]{1,8}$/.test(rawValue)) {
+  if (!value || !/^[0-9a-fA-F]{1,8}$/.test(value)) {
     return undefined;
   }
 
-  const numericValue = Number.parseInt(rawValue, 16);
+  const numericValue = Number.parseInt(value, 16);
   return numericValue >= minimum && numericValue <= maximum
     ? numericValue
     : undefined;
 };
 
+const isValidExplicitColonSeparatedHexadecimalEventId = (
+  parameter: UnitParameter | undefined,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (!rawValue) {
+    return false;
+  }
+
+  const segments = rawValue.split(":");
+  if (segments.length !== 2) {
+    return false;
+  }
+
+  return segments.every(
+    (segment) =>
+      parseExplicitHexadecimalInRange(segment, 0x00000000, 0xffffffff) !==
+      undefined,
+  );
+};
+
+const isValidExplicitIpv4Address = (
+  parameter: UnitParameter | undefined,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (!rawValue) {
+    return false;
+  }
+
+  const octets = rawValue.split(".");
+  if (octets.length !== 4) {
+    return false;
+  }
+
+  return octets.every((octet) => {
+    if (!/^\d+$/.test(octet)) {
+      return false;
+    }
+
+    const numericValue = Number(octet);
+    return numericValue >= 0 && numericValue <= 255;
+  });
+};
+
 const buildJobEndJudgmentDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
-  flattenUnits(rootUnits)
-    .filter((unit) => {
-      const unitType = findParameter(unit, "ty")?.value;
-      return unitType
-        ? jobEndJudgmentDiagnosticTargetTypes.has(unitType)
-        : false;
-    })
-    .flatMap((unit) => {
+  findUnitsByTypes(rootUnits, jobEndJudgmentDiagnosticTargetTypes).flatMap(
+    (unit) => {
       const diagnostics: SyntaxDiagnosticDto[] = [];
       const abrParameter = findParameter(unit, "abr");
       const effectiveJobEndJudgment =
@@ -138,7 +183,8 @@ const buildJobEndJudgmentDiagnostics = (
       }
 
       return diagnostics;
-    });
+    },
+  );
 
 const splitFileMonitoringConditions = (value: string): Set<string> =>
   new Set(value.split(":").filter((condition) => condition.length > 0));
@@ -146,14 +192,8 @@ const splitFileMonitoringConditions = (value: string): Set<string> =>
 const buildFileMonitoringDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
-  flattenUnits(rootUnits)
-    .filter((unit) => {
-      const unitType = findParameter(unit, "ty")?.value;
-      return unitType
-        ? fileMonitoringDiagnosticTargetTypes.has(unitType)
-        : false;
-    })
-    .flatMap((unit) => {
+  findUnitsByTypes(rootUnits, fileMonitoringDiagnosticTargetTypes).flatMap(
+    (unit) => {
       const diagnostics: SyntaxDiagnosticDto[] = [];
       const flwcParameter = findParameter(unit, "flwc");
       const flcoParameter = findParameter(unit, "flco");
@@ -179,17 +219,14 @@ const buildFileMonitoringDiagnostics = (
       }
 
       return diagnostics;
-    });
+    },
+  );
 
 const buildEventSendingDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
-  flattenUnits(rootUnits)
-    .filter((unit) => {
-      const unitType = findParameter(unit, "ty")?.value;
-      return unitType ? eventSendingDiagnosticTargetTypes.has(unitType) : false;
-    })
-    .flatMap((unit) => {
+  findUnitsByTypes(rootUnits, eventSendingDiagnosticTargetTypes).flatMap(
+    (unit) => {
       const diagnostics: SyntaxDiagnosticDto[] = [];
       const evsidParameter = findParameter(unit, "evsid");
       const evsrtParameter = findParameter(unit, "evsrt");
@@ -201,12 +238,12 @@ const buildEventSendingDiagnostics = (
       if (
         evsidParameter &&
         parseExplicitHexadecimalInRange(
-          evsidParameter,
+          evsidParameter.value,
           0x00000000,
           0x00001fff,
         ) === undefined &&
         parseExplicitHexadecimalInRange(
-          evsidParameter,
+          evsidParameter.value,
           0x7fff8000,
           0x7fffffff,
         ) === undefined
@@ -253,7 +290,8 @@ const buildEventSendingDiagnostics = (
       }
 
       return diagnostics;
-    });
+    },
+  );
 
 const isValidExplicitEventSearchCondition = (
   parameter: UnitParameter | undefined,
@@ -273,16 +311,33 @@ const isValidExplicitEventSearchCondition = (
 const buildEventReceivingDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
-  flattenUnits(rootUnits)
-    .filter((unit) => {
-      const unitType = findParameter(unit, "ty")?.value;
-      return unitType
-        ? eventReceivingDiagnosticTargetTypes.has(unitType)
-        : false;
-    })
-    .flatMap((unit) => {
+  findUnitsByTypes(rootUnits, eventReceivingDiagnosticTargetTypes).flatMap(
+    (unit) => {
       const diagnostics: SyntaxDiagnosticDto[] = [];
+      const evwidParameter = findParameter(unit, "evwid");
+      const evipaParameter = findParameter(unit, "evipa");
       const evescParameter = findParameter(unit, "evesc");
+
+      if (
+        evwidParameter &&
+        !isValidExplicitColonSeparatedHexadecimalEventId(evwidParameter)
+      ) {
+        diagnostics.push(
+          buildDiagnostic(
+            evwidParameter,
+            "Event ID (evwid) must be hexadecimal in 00000000:00000000-FFFFFFFF:FFFFFFFF format.",
+          ),
+        );
+      }
+
+      if (evipaParameter && !isValidExplicitIpv4Address(evipaParameter)) {
+        diagnostics.push(
+          buildDiagnostic(
+            evipaParameter,
+            "Event source IP address (evipa) must be a dotted-decimal IPv4 address between 0.0.0.0 and 255.255.255.255.",
+          ),
+        );
+      }
 
       if (
         evescParameter &&
@@ -297,7 +352,8 @@ const buildEventReceivingDiagnostics = (
       }
 
       return diagnostics;
-    });
+    },
+  );
 
 export const buildSyntaxDiagnostics = (
   content: string,

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -624,6 +624,7 @@ suite("Build Syntax Diagnostics", () => {
         "  el=wait1,evwj,+0+0;",
         "  el=wait2,revwj,+160+0;",
         "  el=wait3,evwj,+320+0;",
+        "  el=wait4,revwj,+480+0;",
         "  unit=wait1,,jp1admin,;",
         "  {",
         "    ty=evwj;",
@@ -631,12 +632,20 @@ suite("Build Syntax Diagnostics", () => {
         "  unit=wait2,,jp1admin,;",
         "  {",
         "    ty=revwj;",
+        "    evwid=0123ABCD:89ABCDEF;",
         "    evesc=no;",
         "  }",
         "  unit=wait3,,jp1admin,;",
         "  {",
         "    ty=evwj;",
+        "    evipa=192.168.0.1;",
         "    evesc=720;",
+        "  }",
+        "  unit=wait4,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    evwid=A:1;",
+        "    evipa=255.255.255.255;",
         "  }",
         "}",
         "",
@@ -646,7 +655,7 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(diagnostics, []);
   });
 
-  test("reports event receiving diagnostics for explicit invalid evesc values", () => {
+  test("reports event receiving diagnostics for explicit invalid evesc, evwid, and evipa values", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [
         "unit=root,,jp1admin,;",
@@ -655,6 +664,8 @@ suite("Build Syntax Diagnostics", () => {
         "  el=wait1,evwj,+0+0;",
         "  el=wait2,revwj,+160+0;",
         "  el=wait3,evwj,+320+0;",
+        "  el=wait4,revwj,+480+0;",
+        "  el=wait5,evwj,+640+0;",
         "  unit=wait1,,jp1admin,;",
         "  {",
         "    ty=evwj;",
@@ -670,12 +681,22 @@ suite("Build Syntax Diagnostics", () => {
         "    ty=evwj;",
         "    evesc=abc;",
         "  }",
+        "  unit=wait4,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    evwid=123456789:1;",
+        "  }",
+        "  unit=wait5,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evipa=256.10.0.1;",
+        "  }",
         "}",
         "",
       ].join("\n"),
     );
 
-    assert.strictEqual(diagnostics.length, 3);
+    assert.strictEqual(diagnostics.length, 5);
     assert.deepStrictEqual(
       diagnostics.map((diagnostic) => ({
         line: diagnostic.line,
@@ -705,11 +726,25 @@ suite("Build Syntax Diagnostics", () => {
           message:
             "Event search condition (evesc) must be no or between 1 and 720.",
         },
+        {
+          line: 24,
+          column: 4,
+          length: 5,
+          message:
+            "Event ID (evwid) must be hexadecimal in 00000000:00000000-FFFFFFFF:FFFFFFFF format.",
+        },
+        {
+          line: 29,
+          column: 4,
+          length: 5,
+          message:
+            "Event source IP address (evipa) must be a dotted-decimal IPv4 address between 0.0.0.0 and 255.255.255.255.",
+        },
       ],
     );
     assert.deepStrictEqual(
       diagnostics.map((diagnostic) => diagnostic.severity),
-      ["error", "error", "error"],
+      ["error", "error", "error", "error", "error"],
     );
   });
 });


### PR DESCRIPTION
## Summary
- add grouped editor diagnostics for JP1 event reception monitoring job  and 
- keep raw parser/domain/projection behavior unchanged while tightening semantic validation
- sync SDD docs, coverage tracking, and approval evidence for the grouped slice

## Testing
- rtk pnpm run qlty
- rtk pnpm run test:compile
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
- rtk pnpm run lint:md