### PR TITLE
[codex] add grouped job-end diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -82,6 +82,18 @@ Scenario: Retry parameters require automatic retry
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Job end-judgment numeric values must stay within documented ranges
+  Given a syntactically valid JP1/AJS document with a UNIX/PC job
+  And explicit `wth` or `tho` is outside the JP1/AJS3 v13 range
+    `0..2147483647`
+  Or explicit `rjs` or `rje` is outside the JP1/AJS3 v13 range
+    `1..4294967295`
+  Or explicit `rec` is outside the JP1/AJS3 v13 range `1..12`
+  Or explicit `rei` is outside the JP1/AJS3 v13 range `1..10`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Event arrival check requires an event destination host
   Given a syntactically valid JP1/AJS document with a JP1 event sending job
   And effective `evsrt` is event-arrival checking enabled

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
@@ -99,9 +99,49 @@ This document covers the implemented behavior for `jd`, `wth`, `tho`, `jdf`,
 - Raw parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation remain unchanged.
 
+## Proposed Next Grouped Slice
+
+- Report semantic diagnostics when an explicit UNIX/PC job or UNIX/PC custom
+  job sets `wth` or `tho` outside the JP1/AJS3 v13 range
+  `0..2147483647`.
+- Report semantic diagnostics when an explicit UNIX/PC job or UNIX/PC custom
+  job sets `rjs` or `rje` outside the JP1/AJS3 v13 range
+  `1..4294967295`.
+- Report semantic diagnostics when an explicit UNIX/PC job or UNIX/PC custom
+  job sets `rec` outside the JP1/AJS3 v13 range `1..12` or `rei` outside the
+  range `1..10`.
+- Treat the rule as application-level numeric validation owned by
+  `buildSyntaxDiagnostics.ts`, preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation.
+- Keep omitted values non-diagnostic so the existing default-aware wrapper
+  semantics remain unchanged.
+- Point each diagnostic at the explicit out-of-range parameter so parser and
+  DTO shapes remain unchanged.
+
+## Impact
+
+- User-visible diagnostics would change for syntactically valid JP1/AJS
+  documents containing explicit out-of-range job end-judgment or automatic
+  retry values on `j` / `cj`.
+- Existing parsed parameter source-location metadata should be enough to point
+  diagnostics at explicit `wth`, `tho`, `rjs`, `rje`, `rec`, and `rei`, so no
+  parser or DTO shape change is expected.
+- The application diagnostics boundary remains the owner of focused semantic
+  parameter feedback; parser grammar and domain wrapper values remain raw.
+
+## Diagnostic Alternatives
+
+- Preserve out-of-range numeric values silently and leave the matrix gap
+  visible.
+- Move numeric validation into domain wrappers, rejected for this slice
+  because the current diagnostics policy preserves raw manual-invalid values.
+- Broaden the slice to retry threshold ordering in the same change, deferred
+  because cross-parameter ordering adds a second rule family and expands the
+  regression surface beyond a single numeric-range slice.
+
 ## Follow-up
 
-- Add range validation only after deciding whether invalid JP1/AJS parameter
-  values should become diagnostics, warnings, or preserved raw values.
-- Revisit numeric retry ranges and retry threshold ordering as a separate
-  approval-gated slice.
+- Implement grouped numeric range validation first, then revisit retry
+  threshold ordering as a separate approval-gated slice if the grouped numeric
+  diagnostics land cleanly.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -62,148 +62,14 @@
 
 ## Follow-up
 
-- [x] Extract `top1` to `top4` default resolution into a transfer-operation
-      helper seam while preserving explicit and derived values
-- [x] Align omitted UNIX/PC job and UNIX/PC custom job `jd` values to the
-      JP1/AJS3 v13 default `cod`
-- [x] Align omitted HTTP Connection job `eu` values to the JP1/AJS3 v13
-      `ajsprint -a` default values table value `def`
-- [x] Align omitted JP1 event sending job `evsrc` values to the JP1/AJS3 v13
-      default `10`, preserving explicit values and deciding whether normalized
-      unit-list projection should remain raw or become default-aware
-- [x] Add focused regression evidence that QUEUE job `ts1` to `ts4` and `td1`
-      to `td4` values are preserved while `top1` to `top4` are not exposed or
-      derived for `Qj` / `Rq`
-- [x] Align `wth` key mapping so job end-judgment threshold parsing reads
-      `wth` rather than the schedule-rule `wt` parameter
-- [x] Turn the audit notes into an explicit parameter-coverage matrix when
-      category-level status needs tracking beyond the current audit summary
-- [x] Investigate schedule-rule helper-boundary alignment with the remaining
-      grouped semantics, such as `wc` / `wt` pairing or range validation, when
-      the behavior contract is explicit enough to test across the family
-- [x] Implement schedule-rule `wc` / `wt` effective-value pairing after human
-      approval clarifies whether the slice is domain-only or includes
-      unit-list projection
-- [x] Investigate unit-list group 10 projection for schedule-rule `wc` / `wt`
-      effective values as a separate behavior slice after domain-only pairing
-- [x] Record human approval before changing unit-list projection behavior
-- [x] Implement group 10 effective `wc` / `wt` projection only after approval
-- [x] Add focused group 10 regression evidence for disabled and valid pairs
-- [x] Run required code-change validation after implementation
-- [x] Investigate unit-list group 14 projection for JP1 event sending job
-      arrival-check defaults as a separate behavior slice
-- [x] Record human approval before changing unit-list group 14 projection
-- [x] Implement group 14 default-aware projection only after approval
-- [x] Add focused group 14 regression evidence for omitted defaults and
-      explicit value preservation
-- [x] Run required code-change validation after implementation
-- [x] Investigate unit-list group 13 projection for file monitoring job
-      defaults as a separate behavior slice
-- [x] Record human approval before changing unit-list group 13 projection
-- [x] Implement group 13 file monitoring default-aware projection only after
-      approval
-- [x] Add focused group 13 regression evidence for omitted defaults and
-      explicit value preservation
-- [x] Run required code-change validation after implementation
-- [x] Investigate execution-interval control job defaults and unit-list group
-      13 projection as a separate behavior slice
-- [x] Record human approval before changing execution-interval control job
-      default or projection behavior
-- [x] Implement execution-interval control job defaults only after approval
-- [x] Add focused execution-interval control job regression evidence for
-      omitted defaults, explicit value preservation, and non-target jobs
-- [x] Run required code-change validation after implementation
-- [x] Investigate unit-list group 15 projection for QUEUE job transfer-file
-      operations as a separate behavior slice
-- [x] Record human approval before changing QUEUE job group 15 projection
-- [x] Implement QUEUE job group 15 unit-type-aware projection only after
-      approval
-- [x] Add focused group 15 regression evidence for QUEUE `tsN` / `tdN`
-      preservation, QUEUE `topN` hiding, and non-QUEUE `topN` preservation
-- [x] Run required code-change validation after implementation
-- [x] Investigate job end-judgment `jd` / `abr` invalid-combination diagnostics
-      as the next parameter semantic diagnostics slice
 - [x] Record human approval before changing editor-feedback diagnostics,
-      parser source-location data, runtime code, tests, generated artifacts,
-      or configuration
-- [x] Implement focused `jd` / `abr` semantic diagnostics only after approval
-- [x] Add focused diagnostics regression evidence for valid omitted defaults,
-      explicit valid retry settings, and explicit invalid combinations
-- [x] Run required code-change validation after implementation
-- [x] Investigate job end-judgment retry-parameter diagnostics as the next
-      focused semantic diagnostics slice
-- [x] Record human approval before changing editor-feedback diagnostics,
-      runtime code, tests, generated artifacts, or configuration
-- [x] Implement focused retry-parameter semantic diagnostics only after
-      approval
-- [x] Add focused diagnostics regression evidence for valid `jd=cod` retry
-      parameters and explicit invalid `jd` / retry-parameter combinations
-- [x] Run required code-change validation after implementation
-- [x] Investigate file monitoring job `flwc` / `flco` semantic diagnostics as
-      the next focused parameter diagnostics slice
-- [x] Record human approval before changing editor-feedback diagnostics,
-      runtime code, tests, generated artifacts, or configuration
-- [x] Implement focused file monitoring semantic diagnostics only after
-      approval
-- [x] Add focused diagnostics regression evidence for valid omitted defaults,
-      valid explicit `flwc` / `flco` combinations, and explicit invalid
-      combinations
-- [x] Run required code-change validation after implementation
-- [x] Investigate job end-judgment automatic-retry enablement diagnostics as
-      the next focused parameter diagnostics slice
-- [x] Record human approval before changing editor-feedback diagnostics,
-      runtime code, tests, generated artifacts, or configuration
-- [x] Implement focused automatic-retry enablement diagnostics only after
-      approval
-- [x] Add focused diagnostics regression evidence for omitted automatic retry
-      defaults, valid `abr=y` retry parameters, and explicit invalid `abr=n`
-      / retry-parameter combinations
-- [x] Run required code-change validation after implementation
-- [x] Investigate JP1 event sending job `evhst` requiredness diagnostics as
-      the next focused parameter diagnostics slice
-- [x] Record human approval before changing editor-feedback diagnostics,
-      runtime code, tests, generated artifacts, or configuration
-- [x] Implement focused `evhst` requiredness diagnostics only after approval
-- [x] Add focused diagnostics regression evidence for omitted `evsrt=n`,
-      valid explicit `evsrt=y` with `evhst`, and explicit invalid `evsrt=y`
-      without `evhst`
-- [x] Run required code-change validation after implementation
-- [x] Investigate JP1 event sending job `evspl` / `evsrc` range diagnostics as
-      the next focused parameter diagnostics slice
-- [x] Record human approval before changing editor-feedback diagnostics,
-      runtime code, tests, generated artifacts, or configuration
-- [x] Implement focused `evspl` / `evsrc` range diagnostics only after
+      runtime code, tests, generated artifacts, or configuration for grouped
+      job end-judgment numeric range validation
+- [x] Implement grouped job end-judgment numeric range validation only after
       approval
 - [x] Add focused diagnostics regression evidence for omitted defaults, valid
-      explicit in-range values, and explicit out-of-range `evspl` / `evsrc`
-      values
-- [x] Run required code-change validation after implementation
-- [x] Investigate JP1 event sending job `evsid` hexadecimal diagnostics as
-      the next focused parameter diagnostics slice
-- [x] Record human approval before changing editor-feedback diagnostics,
-      runtime code, tests, generated artifacts, or configuration
-- [x] Implement focused `evsid` hexadecimal diagnostics only after approval
-- [x] Add focused diagnostics regression evidence for omitted `evsid`,
-      valid explicit in-range hexadecimal values, and explicit invalid
-      `evsid` values
-- [x] Run required code-change validation after implementation
-- [x] Investigate JP1 event reception monitoring job `evesc` range
-      diagnostics as the next focused parameter diagnostics slice
-- [x] Record human approval before changing editor-feedback diagnostics,
-      runtime code, tests, generated artifacts, or configuration
-- [x] Implement focused `evesc` range diagnostics only after approval
-- [x] Add focused diagnostics regression evidence for omitted `evesc`,
-      valid explicit `evesc=no` or in-range decimal values, and explicit
-      invalid `evesc` values
-- [x] Run required code-change validation after implementation
-- [x] Investigate JP1 event reception monitoring job grouped `evwid` /
-      `evipa` validation as the next focused parameter diagnostics slice
-- [x] Record human approval before changing editor-feedback diagnostics,
-      runtime code, tests, generated artifacts, or configuration
-- [x] Implement grouped `evwid` / `evipa` validation only after approval
-- [x] Add focused diagnostics regression evidence for omitted `evwid` and
-      `evipa`, valid explicit hexadecimal event IDs and IPv4 addresses, and
-      explicit invalid `evwid` / `evipa` values
+      explicit in-range values, and explicit out-of-range `wth`, `tho`, `rjs`,
+      `rje`, `rec`, and `rei` values
 - [x] Run required code-change validation after implementation
 
 ## Notes
@@ -226,10 +92,6 @@
 - 2026-04-23: command-builder UI now resolves labels and descriptions through
   the existing message resources and switches `ajsshow` / `ajsprint` manual
   links between English and Japanese URLs from the active `lang` context.
-- 2026-04-26: the next parameter-alignment candidate is the schedule-rule
-  family because these keys already share helper seams, affect unit-list
-  behavior, and can be covered as a focused manual-alignment slice without
-  creating a full parameter matrix first.
 - 2026-04-27: schedule-rule alignment preparation is recorded in
   `SCHEDULE_RULE_ALIGNMENT.md`, keeping the matrix limited to the focused
   schedule-rule family instead of expanding to all parameters.
@@ -247,49 +109,22 @@
   and reused by unit-list projection. This is the first category-level parser
   alignment pattern; later parameter categories should follow the same audit,
   helper-boundary, and regression-test workflow.
-- 2026-04-27: transfer-operation alignment is the next helper-boundary slice.
-  It keeps the existing `topN` behavior but moves the paired `tsN` / `tdN`
-  default rule out of generic parameter helper code.
 - 2026-04-27: `topN` default resolution now lives in
   `transferOperationHelpers.ts`; regression evidence covers explicit `topN`,
   derived `sav`, derived `del`, and the no-default case.
-- 2026-04-27: job end-judgment alignment is the next non-schedule parameter
-  family. The manual-backed behavior change is limited to omitted `jd`
-  resolving to `cod`; invalid pairing diagnostics remain deferred.
 - 2026-04-27: omitted UNIX/PC job and UNIX/PC custom job `jd` values now
   resolve to `cod` through `jobEndJudgmentHelpers.ts`; explicit `jd` values
   remain preserved.
-- 2026-04-28: HTTP Connection job default alignment is the next small
-  parameter-default candidate. The proposed behavior change is limited to
-  omitted `eu` resolving to `def` for `Htpj` / `Rhtpj`, while other job
-  families continue to use generic `eu=ent`.
 - 2026-04-28: omitted HTTP Connection job `eu` values now resolve to `def`
   through `httpConnectionJobDefaultHelpers.ts`; explicit HTTP Connection job
   `eu` values and non-HTTP generic `eu=ent` behavior remain preserved.
-- 2026-04-28: JP1 event sending job arrival-check defaults are the next
-  category-level parameter candidate. The proposed behavior change is limited
-  to omitted `evsrc` resolving to `10` for `Evsj` / `Revsj`, while explicit
-  values remain preserved. Normalized unit-list projection is approval
-  sensitive because it currently reads raw normalized parameters by key.
 - 2026-04-28: omitted JP1 event sending job `evsrc` now resolves to `10`
   through `DEFAULTS.Evsrc`; explicit event sending job values remain preserved.
   Unit-list projection remains raw normalized key/value projection.
-- 2026-04-29: QUEUE job transfer-file alignment is the next non-schedule
-  parameter family. The proposed behavior-preserving change is limited to
-  focused regression evidence that `Qj` / `Rq` preserve explicit `ts1` to
-  `ts4` and `td1` to `td4` values without exposing or deriving `top1` to
-  `top4`, because JP1/AJS3 version 13 QUEUE job definitions do not define
-  `topN`.
 - 2026-04-29: QUEUE job transfer-file regression evidence now verifies `Qj`
   and `Rq` preserve explicit transfer source/destination values and do not
   expose transfer operation getters. Parser grammar, command generation,
   validation behavior, and unit-list group 15 raw projection remain unchanged.
-- 2026-04-29: job end-judgment `wth` key mapping is the next focused
-  non-schedule parameter correction. Current code maps `ParamFactory.wth` to
-  raw `wt`, and current regression evidence preserves that legacy behavior.
-  The proposed implementation changes only the builder/test seam so explicit
-  `wth` is preserved and schedule-rule `wt` no longer satisfies
-  end-judgment threshold lookup.
 - 2026-04-29: `ParamFactory.wth` now reads raw `wth`; focused regression
   evidence verifies explicit `wth` preservation and confirms raw `wt` no
   longer satisfies end-judgment threshold lookup. Parser grammar, command
@@ -299,84 +134,33 @@
   focused alignment records into an explicit category-level matrix. This is a
   docs-only status index and does not broaden parameter coverage or approve
   new runtime behavior.
-- 2026-04-29: schedule-rule `wc` / `wt` pairing is the next investigated
-  behavior candidate. The current code parses and defaults both parameters
-  independently, while the JP1/AJS3 v13 jobnet definition says they are
-  specified together and `no` in one parameter invalidates the paired
-  start-condition monitoring value. Implementation approval is pending.
 - 2026-04-29: schedule-rule `wc` / `wt` effective-value pairing is implemented
   as a domain-only helper/API. Raw `Wc.numberOfTimes`, `Wt.time`, `value()`,
   and normalized unit-list projection remain unchanged. Effective values are
   empty when either paired value is `no`, missing, or unparsable.
-- 2026-04-29: unit-list group 10 `wc` / `wt` projection is the next
-  approval-gated behavior candidate. The proposed scope is limited to table
-  DTO projection using the existing effective pairing semantics; parser
-  grammar, raw wrappers, normalized raw parameter storage, diagnostics,
-  generated artifacts, configuration, dependency versions, and
-  `engines.vscode` remain out of scope.
 - 2026-04-29: unit-list group 10 `wc` / `wt` projection now consumes the
   existing effective pairing semantics. Disabled pairs display empty
   start-condition monitoring values, valid pairs remain visible, and raw
   parser/domain/normalized values remain unchanged.
-- 2026-04-29: unit-list group 14 JP1 event sending job projection is the next
-  approval-gated behavior candidate. The proposed scope is limited to table
-  DTO projection using the existing domain defaults for omitted `evssv`,
-  `evsrt`, `evspl`, and `evsrc`; parser grammar, raw domain wrappers,
-  normalized raw parameter storage, diagnostics, generated artifacts,
-  configuration, dependency versions, and `engines.vscode` remain out of
-  scope.
 - 2026-04-29: unit-list group 14 JP1 event sending job projection now consumes
   existing defaults for omitted `evssv`, `evsrt`, `evspl`, and `evsrc`.
   Explicit normalized values remain visible, non-event-sending jobs do not
   synthesize these defaults, and raw parser/domain/normalized values remain
   unchanged.
-- 2026-05-01: unit-list group 13 file monitoring job projection is the next
-  approval-gated behavior candidate. The proposed scope is limited to table
-  DTO projection using the existing domain defaults for omitted `flwc`,
-  `flwi`, `flco`, and `ets`; parser grammar, raw domain wrappers, normalized
-  raw parameter storage, diagnostics, generated artifacts, configuration,
-  dependency versions, and `engines.vscode` remain out of scope.
 - 2026-05-01: unit-list group 13 file monitoring job projection now consumes
   existing defaults for omitted `flwc`, `flwi`, `flco`, and `ets`. Explicit
   normalized values remain visible, omitted `flwf` remains empty,
   non-file-monitoring jobs do not synthesize these defaults, and raw
   parser/domain/normalized values remain unchanged.
-- 2026-05-01: execution-interval control job defaults are the next
-  approval-gated behavior candidate. The proposed scope is limited to
-  `tmwj` / `rtmwj` omitted `tmitv=10`, `etn=n`, and `ets=kl` behavior plus
-  unit-list group 13 default-aware projection. Parser grammar, normalized raw
-  parameter storage, diagnostics, generated artifacts, configuration,
-  dependency versions, and `engines.vscode` remain out of scope.
 - 2026-05-01: execution-interval control job defaults now resolve omitted
   `tmitv`, `etn`, and `ets` values to `10`, `n`, and `kl`. Unit-list group 13
   projection consumes those defaults for `tmwj` / `rtmwj`, explicit normalized
   values remain visible, non-execution-interval-control jobs do not synthesize
   those defaults, and raw parser/normalized values remain unchanged.
-- 2026-05-01: QUEUE job group 15 projection is the next approval-gated
-  behavior candidate. The proposed scope is limited to hiding `top1` to
-  `top4` transfer-operation projection for `qj` / `rq`, preserving explicit
-  `ts1` to `ts4` and `td1` to `td4`, and preserving non-QUEUE `topN`
-  projection. Parser grammar, normalized raw parameter storage, diagnostics,
-  generated artifacts, configuration, dependency versions, and
-  `engines.vscode` remain out of scope.
 - 2026-05-01: QUEUE job group 15 projection now hides `top1` to `top4`
   transfer-operation values for `qj` / `rq`. Explicit `ts1` to `ts4` and
   `td1` to `td4` remain visible, non-QUEUE `topN` projection remains visible,
   and raw parser/normalized values remain unchanged.
-- 2026-05-01: job end-judgment `jd` / `abr` invalid-combination diagnostics
-  are the next approval-gated parameter semantic diagnostics candidate. The
-  proposed scope is limited to reporting explicit UNIX/PC job and UNIX/PC
-  custom job `abr=y` values when the effective `jd` value is not `cod`,
-  preserving raw parser output, domain wrapper values, normalized parameters,
-  unit-list projection, and command generation. Parser grammar, generated
-  artifacts, configuration, dependency versions, `engines.vscode`, retry range
-  diagnostics, byte-length validation, and broad range validation remain out of
-  scope.
-- 2026-05-01: implementation approval was recorded for job end-judgment
-  `jd` / `abr` invalid-combination diagnostics. Complete reference impact
-  check before editing the application diagnostic boundary and parser
-  source-location data, then keep the implementation limited to the approved
-  semantic diagnostic and focused regression evidence.
 - 2026-05-01: job end-judgment `jd` / `abr` invalid-combination diagnostics
   now report explicit UNIX/PC job and UNIX/PC custom job `abr=y` values when
   the effective `jd` value is not `cod`. Parser grammar, raw parser values,
@@ -389,17 +173,6 @@
   Omitted `evsrt=n` remains non-diagnostic, explicit valid `evhst` values
   remain accepted, and raw parser/domain/normalized values plus unit-list,
   flow, and command output remain unchanged.
-- 2026-05-01: job end-judgment retry-parameter diagnostics are the next
-  approval-gated semantic diagnostics candidate. JP1/AJS3 version 13 UNIX/PC
-  job and UNIX/PC custom job definitions say `rjs`, `rje`, `rec`, and `rei`
-  cannot be specified when the effective `jd` value is not `cod`. The
-  proposed scope is limited to reporting explicit target job retry parameters
-  when effective `jd` is not `cod`, preserving raw parser output, domain
-  wrapper values, normalized parameters, unit-list projection, flow projection,
-  and command generation. Parser grammar, generated artifacts, configuration,
-  dependency versions, `engines.vscode`, numeric retry ranges, threshold
-  ordering, byte-length validation, and broad parameter validation remain out
-  of scope.
 - 2026-05-01: job end-judgment retry-parameter diagnostics now report explicit
   UNIX/PC job and UNIX/PC custom job `rjs`, `rje`, `rec`, or `rei` values when
   the effective `jd` value is not `cod`. Parser grammar, raw parser values,
@@ -407,18 +180,6 @@
   projection, command generation, generated artifacts, configuration,
   dependency versions, and `engines.vscode` remain unchanged. Numeric retry
   ranges and threshold ordering remain deferred.
-- 2026-05-03: file monitoring job `flwc` / `flco` diagnostics are the next
-  approval-gated semantic diagnostics candidate. JP1/AJS3 version 13 file
-  monitoring job definitions say `flwc` can specify multiple monitoring
-  conditions but cannot specify `s` and `m` together, and `flco` can be
-  specified only when `flwc` includes `c`. The proposed scope is limited to
-  reporting explicit `flwj` / `rflwj` invalid combinations through the
-  existing editor-feedback boundary while preserving raw parser output, domain
-  wrapper values, normalized parameters, unit-list projection, flow
-  projection, and command generation. Parser grammar, generated artifacts,
-  configuration, dependency versions, `engines.vscode`, wildcard validation,
-  byte-length validation, numeric range validation, timeout behavior, and
-  broad parameter validation remain out of scope.
 - 2026-05-06: file monitoring job `flwc` / `flco` diagnostics now report
   explicit `flwj` / `rflwj` invalid combinations when `flwc` specifies both
   `s` and `m`, or when explicit `flco` is present and effective `flwc` does
@@ -427,18 +188,6 @@
   output, domain wrapper values, normalized parameters, unit-list projection,
   flow projection, command generation, generated artifacts, configuration,
   dependency versions, and `engines.vscode` remain unchanged.
-- 2026-05-06: job end-judgment automatic-retry enablement diagnostics are the
-  next approval-gated semantic diagnostics candidate. JP1/AJS3 version 13
-  UNIX/PC job and UNIX/PC custom job definitions say `rjs`, `rje`, `rec`, and
-  `rei` can be specified only when automatic retry is enabled with `abr=y`.
-  Existing diagnostics already report these retry parameters when effective
-  `jd` is not `cod`; the proposed scope is limited to reporting explicit
-  retry parameters when effective `jd=cod` but effective `abr` is not `y`,
-  preserving raw parser output, domain wrapper values, normalized parameters,
-  unit-list projection, flow projection, and command generation. Parser
-  grammar, generated artifacts, configuration, dependency versions,
-  `engines.vscode`, numeric retry ranges, retry threshold ordering,
-  byte-length validation, and broad parameter validation remain out of scope.
 - 2026-05-06: job end-judgment automatic-retry enablement diagnostics now
   report explicit UNIX/PC job and UNIX/PC custom job `rjs`, `rje`, `rec`, or
   `rei` values when effective `jd=cod` but effective `abr` is not `y`.
@@ -447,31 +196,6 @@
   domain wrapper values, normalized parameters, unit-list projection, flow
   projection, command generation, generated artifacts, configuration,
   dependency versions, and `engines.vscode` remain unchanged.
-- 2026-05-06: JP1 event sending job `evhst` requiredness diagnostics are the
-  next approval-gated semantic diagnostics candidate. JP1/AJS3 version 13 JP1
-  event sending job definitions say `evhst` is required when `evsrt=y`.
-  Existing behavior preserves explicit `evsrt=y` without `evhst` as raw parsed
-  values without editor feedback. The proposed scope is limited to reporting
-  explicit `evsj` / `revsj` missing-host combinations through the existing
-  editor-feedback boundary while preserving raw parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection, and
-  command generation. Parser grammar, generated artifacts, configuration,
-  dependency versions, `engines.vscode`, `evhst` byte-length validation,
-  macro-variable validation, `evspl` / `evsrc` range validation, and broad
-  parameter validation remain out of scope.
-- 2026-05-06: JP1 event sending job `evspl` / `evsrc` range diagnostics are
-  the next approval-gated semantic diagnostics candidate. JP1/AJS3 version 13
-  JP1 event sending job definitions say `evspl` accepts decimal values
-  `3..600` seconds and `evsrc` accepts decimal values `0..999`, while omitted
-  values default to `10`. Existing behavior preserves explicit out-of-range
-  values as raw parsed data without editor feedback. The proposed scope is
-  limited to reporting explicit out-of-range `evspl` / `evsrc` values through
-  the existing editor-feedback boundary while preserving raw parser output,
-  domain wrapper values, normalized parameters, unit-list projection, flow
-  projection, and command generation. Parser grammar, generated artifacts,
-  configuration, dependency versions, `engines.vscode`, `evhst` byte-length
-  validation, host-name validation, macro-variable validation, `evsid`
-  hexadecimal validation, and broad parameter validation remain out of scope.
 - 2026-05-06: JP1 event sending job `evspl` / `evsrc` range diagnostics now
   report explicit out-of-range `evspl` and `evsrc` values through the
   existing editor-feedback boundary. Omitted defaults remain non-diagnostic,
@@ -479,19 +203,6 @@
   wrapper values, normalized parameters, unit-list projection, flow
   projection, command generation, generated artifacts, configuration,
   dependency versions, and `engines.vscode` remain unchanged.
-- 2026-05-06: JP1 event sending job `evsid` hexadecimal diagnostics are the
-  next approval-gated semantic diagnostics candidate. JP1/AJS3 version 13
-  JP1 event sending job definitions say `evsid` accepts hexadecimal values in
-  the disjoint ranges `00000000..00001FFF` and `7FFF8000..7FFFFFFF`.
-  Existing behavior preserves explicit invalid `evsid` values as raw parsed
-  data without editor feedback. The proposed scope is limited to reporting
-  explicit out-of-range or malformed `evsid` values through the existing
-  editor-feedback boundary while preserving raw parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection, and
-  command generation. Parser grammar, generated artifacts, configuration,
-  dependency versions, `engines.vscode`, `evhst` byte-length validation,
-  host-name validation, macro-variable validation, event receiving job
-  `evwid` validation, and broad parameter validation remain out of scope.
 - 2026-05-06: JP1 event sending job `evsid` hexadecimal diagnostics now
   report explicit malformed or out-of-range `evsid` values through the
   existing editor-feedback boundary. Omitted `evsid` values remain
@@ -501,40 +212,12 @@
   artifacts, configuration, dependency versions, and `engines.vscode` remain
   unchanged.
 - 2026-05-06: JP1 event reception monitoring job `evesc` range diagnostics
-  are the next approval-gated semantic diagnostics candidate. JP1/AJS3
-  version 13 job definitions for monitoring JP1 event reception say `evesc`
-  accepts either `no` or a decimal value in the range `1..720`, while omitted
-  values default to `no`. Existing behavior preserves explicit invalid
-  `evesc` values as raw parsed data without editor feedback. The proposed
-  scope is limited to reporting explicit malformed or out-of-range `evesc`
-  values through the existing editor-feedback boundary while preserving raw
-  parser output, domain wrapper values, normalized parameters, unit-list
-  projection, flow projection, and command generation. Parser grammar,
-  generated artifacts, configuration, dependency versions, `engines.vscode`,
-  `evwid` format validation, `evhst` byte-length validation, host-name
-  validation, regular-expression validation, macro-variable validation,
-  `evipa` address validation, and broad parameter validation remain out of
-  scope.
-- 2026-05-06: JP1 event reception monitoring job `evesc` range diagnostics
   now report explicit malformed or out-of-range `evesc` values through the
   existing editor-feedback boundary. Omitted `evesc` values and explicit
   `evesc=no` remain non-diagnostic, and raw parser output, domain wrapper
   values, normalized parameters, unit-list projection, flow projection,
   command generation, generated artifacts, configuration, dependency
   versions, and `engines.vscode` remain unchanged.
-- 2026-05-06: JP1 event reception monitoring job grouped `evwid` / `evipa`
-  validation is the next approval-gated semantic diagnostics candidate.
-  JP1/AJS3 version 13 job definitions for monitoring JP1 event reception say
-  `evwid` accepts hexadecimal values in the range `00000000:00000000` to
-  `FFFFFFFF:FFFFFFFF`, and `evipa` accepts IPv4 dotted-decimal values in the
-  range `0.0.0.0` to `255.255.255.255`. The proposed scope is limited to
-  reporting explicit malformed `evwid` or `evipa` values through the existing
-  editor-feedback boundary while preserving raw parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection, and
-  command generation. Parser grammar, generated artifacts, configuration,
-  dependency versions, `engines.vscode`, `evhst` byte-length validation,
-  host-name validation, regular-expression validation, macro-variable
-  validation, and broad parameter validation remain out of scope.
 - 2026-05-06: JP1 event reception monitoring job grouped `evwid` / `evipa`
   validation now reports explicit malformed event IDs and invalid dotted-
   decimal IPv4 source addresses through the existing editor-feedback
@@ -543,25 +226,54 @@
   parameters, unit-list projection, flow projection, command generation,
   generated artifacts, configuration, dependency versions, and
   `engines.vscode` remain unchanged.
+- 2026-05-06: The next JP1/AJS v13 parameter-alignment slice was re-scoped by
+  user-visible size rather than by single-parameter granularity. The next
+  approval-gated candidate is grouped job end-judgment numeric range
+  diagnostics for UNIX/PC jobs and UNIX/PC custom jobs, covering explicit
+  `wth`, `tho`, `rjs`, `rje`, `rec`, and `rei` values through the existing
+  editor-feedback boundary while preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation. Parser grammar, generated artifacts, configuration,
+  dependency versions, `engines.vscode`, retry threshold ordering,
+  byte-length validation, and broad parameter validation remain out of scope.
+- 2026-05-06: Grouped job end-judgment numeric range diagnostics now report
+  explicit out-of-range `wth`, `tho`, `rjs`, `rje`, `rec`, and `rei` values
+  for UNIX/PC jobs and UNIX/PC custom jobs through the existing
+  editor-feedback boundary. Omitted values remain non-diagnostic, valid
+  explicit in-range values remain accepted, and raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, command generation, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-06
-- Approved scope: focused application-level semantic diagnostics for explicit
-  JP1 event reception monitoring jobs and recovery JP1 event reception
-  monitoring jobs where `evwid` is outside the JP1/AJS3 v13 hexadecimal
-  event-ID format and range `00000000:00000000` to `FFFFFFFF:FFFFFFFF`, or
-  where `evipa` is outside the IPv4 dotted-decimal range `0.0.0.0` to
-  `255.255.255.255`; preserve raw parser output, domain wrapper values,
-  normalized parameters, unit-list projection, flow projection, and command
-  generation; add focused regression evidence; update SDD tracking; and run
-  validation.
+- Approved scope: grouped application-level semantic diagnostics for explicit
+  UNIX/PC jobs and UNIX/PC custom jobs where `wth` or `tho` is outside
+  `0..2147483647`, `rjs` or `rje` is outside `1..4294967295`, `rec` is
+  outside `1..12`, or `rei` is outside `1..10`; preserve raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation; add focused regression evidence; update
+  SDD tracking; and run validation.
 
-Current implementation gate: none; last completed slice was JP1 event
-reception monitoring job grouped `evwid` / `evipa` validation.
+Current implementation gate: none; last completed slice was grouped job
+end-judgment numeric range validation.
 
 ## Prior Approval Evidence
+
+- 2026-05-06: User replied "Approved. Proceed with implementation." after the
+  grouped job end-judgment numeric range validation approval request.
+  Approved changes were limited to adding grouped application-level semantic
+  diagnostics for explicit UNIX/PC jobs and UNIX/PC custom jobs where `wth`
+  or `tho` falls outside `0..2147483647`, `rjs` or `rje` falls outside
+  `1..4294967295`, `rec` falls outside `1..12`, or `rei` falls outside
+  `1..10`; preserving raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation;
+  adding focused regression evidence; updating SDD tracking; and running
+  validation. Parser grammar, generated artifacts, configuration, dependency
+  versions, `engines.vscode`, retry threshold ordering, byte-length
+  validation, and broad parameter validation were out of scope.
 
 - 2026-05-06: User replied "Approved. Proceed with implementation." after the
   JP1 event reception monitoring job grouped `evwid` / `evipa` validation
@@ -747,6 +459,16 @@ reception monitoring job grouped `evwid` / `evipa` validation.
 
 ## Validation
 
+- 2026-05-06: `pnpm run qlty` required an escalated rerun after the sandboxed
+  qlty log-file permission failure; escalated rerun completed with exit code 0
+- 2026-05-06: `pnpm test` completed with exit code 0; the VS Code harness
+  emitted an existing macOS `task_name_for_pid` codesign noise line
+- 2026-05-06: `pnpm run test:web` failed in the sandbox because Chromium could
+  not access macOS Mach port APIs; escalated rerun completed with exit code 0
+  and existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-06: `pnpm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-06: `pnpm run lint:md`
 - 2026-05-06: `pnpm run test:compile`
 - 2026-05-06: `pnpm run qlty` completed with exit code 0; run used an
   escalated command because sandboxed qlty cannot create its log file

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -37,9 +37,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Select the next grouped JP1/AJS3 v13 parameter-alignment gap from the
-   remaining deferred validations after delivered event reception `evwid` /
-   `evipa` diagnostics.
+1. Request approval for the next grouped JP1/AJS3 v13 parameter-alignment
+   slice: job end-judgment numeric range diagnostics for `wth`, `tho`, `rjs`,
+   `rje`, `rec`, and `rei` on UNIX/PC jobs and UNIX/PC custom jobs.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -52,43 +52,39 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/event-receiving-id-ip-diagnostics`
-- Objective: continue JP1/AJS v13 parameter alignment with the focused JP1
-  event reception monitoring job grouped validation slice for `evwid` and
-  `evipa` before returning to broader deferred validation gaps.
+- Branch: `codex/job-end-judgment-range-diagnostics`
+- Objective: continue JP1/AJS v13 parameter alignment with a user-meaningful
+  grouped slice around job end-judgment numeric ranges for UNIX/PC jobs and
+  UNIX/PC custom jobs, instead of returning to one-parameter micro-slices.
 - Status: approved, implemented, and validated on
-  `codex/event-receiving-id-ip-diagnostics`.
-- Scope: add application-level semantic diagnostics for explicit
-  JP1 event reception monitoring jobs and recovery JP1 event reception
-  monitoring jobs where `evwid` is outside the JP1/AJS3 v13 hexadecimal
-  event-ID format and range `00000000:00000000` to `FFFFFFFF:FFFFFFFF`, or
-  where `evipa` is outside the IPv4 dotted-decimal range
-  `0.0.0.0` to `255.255.255.255`; preserve raw parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection, and
-  command generation.
+  `codex/job-end-judgment-range-diagnostics`.
+- Scope: add application-level semantic diagnostics for explicit `j` / `cj`
+  parameters where `wth` or `tho` is outside `0..2147483647`, `rjs` or `rje`
+  is outside `1..4294967295`, `rec` is outside `1..12`, or `rei` is outside
+  `1..10`; preserve raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation.
 - Out of scope: parser grammar changes, raw parser/domain/normalized value
   changes, unit-list projection changes, flow projection changes, command
   generation changes, generated artifacts, dependency changes,
-  `engines.vscode`, `evhst` byte-length validation, host-name validation,
-  regular-expression validation, macro-variable validation, and broad
-  parameter validation.
+  `engines.vscode`, retry threshold ordering, byte-length validation, and
+  broad parameter validation.
 - Impact summary: the slice would affect
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
   `buildSyntaxDiagnostics` tests, the existing VS Code diagnostics adapter
-  through DTO mapping, the JP1 event receiving job alignment record, and
-  the editor-feedback use-case contract.
+  through DTO mapping, the job end-judgment alignment record, and the
+  editor-feedback use-case contract.
 - Risks and assumptions: the change would be user-visible in desktop and web
   diagnostics for syntactically valid documents. Existing parsed parameter
-  source-location metadata should be enough to point at explicit `evwid` and
-  `evipa`, so no parser or DTO shape change is expected. Omitted values remain
-  non-diagnostic. Raw values remain inspectable by downstream consumers, and
-  the existing unit-list raw projection evidence should stay unchanged outside
-  diagnostics.
-- Alternatives considered: keep invalid `evwid` / `evipa` silent and leave
-  the gap visible; move these validations into domain wrappers, rejected for
-  this slice because current diagnostics policy keeps raw manual-invalid
-  values inspectable; broaden immediately to `evhst` and regex-bearing string
-  parameters, deferred because that expands the approval and test surface.
+  source-location metadata should be enough to point at explicit `wth`, `tho`,
+  `rjs`, `rje`, `rec`, and `rei`, so no parser or DTO shape change is
+  expected. Omitted values remain non-diagnostic. Raw values remain
+  inspectable by downstream consumers, and the existing unit-list raw
+  projection evidence should stay unchanged outside diagnostics.
+- Alternatives considered: keep invalid numeric values silent and leave the
+  gap visible; move these validations into domain wrappers, rejected for this
+  slice because current diagnostics policy keeps raw manual-invalid values
+  inspectable; include retry threshold ordering now, deferred because it adds
+  cross-parameter rule coupling beyond a single grouped numeric-range slice.
 
 ## Build/Test Performance SDD
 
@@ -117,9 +113,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: JP1 event reception monitoring job grouped `evwid` / `evipa`
-  validation implemented after delivered `evesc` diagnostics; next deferred
-  grouped gap remains to be selected.
+  slice: job end-judgment grouped numeric range diagnostics is implemented
+  after delivered event reception `evwid` / `evipa` validation; next step is
+  required validation.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -10,6 +10,12 @@ export type SyntaxDiagnosticDto = {
   severity: "error";
 };
 
+type UnitParameterDiagnosticRule = {
+  key: string;
+  message: string;
+  isInvalid: (parameter: UnitParameter, unit: Unit) => boolean;
+};
+
 const jobEndJudgmentDiagnosticTargetTypes = new Set([
   "j",
   "rj",
@@ -50,6 +56,18 @@ const buildDiagnostic = (
   length: parameter.length ?? parameter.key.length,
   message,
   severity: "error" as const,
+});
+
+const buildExplicitDecimalRangeRule = (
+  key: string,
+  minimum: number,
+  maximum: number,
+  message: string,
+): UnitParameterDiagnosticRule => ({
+  key,
+  message,
+  isInvalid: (parameter) =>
+    parseExplicitDecimalInRange(parameter, minimum, maximum) === undefined,
 });
 
 const parseExplicitDecimalInRange = (
@@ -126,12 +144,145 @@ const isValidExplicitIpv4Address = (
   });
 };
 
+const collectRuleDiagnostics = (
+  unit: Unit,
+  rules: readonly UnitParameterDiagnosticRule[],
+): SyntaxDiagnosticDto[] =>
+  rules.flatMap((rule) => {
+    const parameter = findParameter(unit, rule.key);
+    return parameter && rule.isInvalid(parameter, unit)
+      ? [buildDiagnostic(parameter, rule.message)]
+      : [];
+  });
+
+const jobEndJudgmentNumericRangeRules = [
+  buildExplicitDecimalRangeRule(
+    "wth",
+    0,
+    2147483647,
+    "Warning threshold (wth) must be between 0 and 2147483647.",
+  ),
+  buildExplicitDecimalRangeRule(
+    "tho",
+    0,
+    2147483647,
+    "Abnormal threshold (tho) must be between 0 and 2147483647.",
+  ),
+  buildExplicitDecimalRangeRule(
+    "rjs",
+    1,
+    4294967295,
+    "Retry start code (rjs) must be between 1 and 4294967295.",
+  ),
+  buildExplicitDecimalRangeRule(
+    "rje",
+    1,
+    4294967295,
+    "Retry end code (rje) must be between 1 and 4294967295.",
+  ),
+  buildExplicitDecimalRangeRule(
+    "rec",
+    1,
+    12,
+    "Retry count (rec) must be between 1 and 12.",
+  ),
+  buildExplicitDecimalRangeRule(
+    "rei",
+    1,
+    10,
+    "Retry interval (rei) must be between 1 and 10.",
+  ),
+] as const;
+
+const fileMonitoringDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
+  {
+    key: "flwc",
+    message: "File monitoring condition (flwc) cannot specify both s and m.",
+    isInvalid: (parameter) => {
+      const flwcConditions = splitFileMonitoringConditions(parameter.value);
+      return flwcConditions.has("s") && flwcConditions.has("m");
+    },
+  },
+  {
+    key: "flco",
+    message:
+      "File close option (flco) requires file creation monitoring (flwc=c).",
+    isInvalid: (_parameter, unit) => {
+      const effectiveFlwc = findParameter(unit, "flwc")?.value ?? DEFAULTS.Flwc;
+      return !splitFileMonitoringConditions(effectiveFlwc).has("c");
+    },
+  },
+];
+
+const eventSendingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
+  {
+    key: "evsid",
+    message:
+      "Event ID (evsid) must be hexadecimal within 00000000-00001FFF or 7FFF8000-7FFFFFFF.",
+    isInvalid: (parameter) =>
+      parseExplicitHexadecimalInRange(
+        parameter.value,
+        0x00000000,
+        0x00001fff,
+      ) === undefined &&
+      parseExplicitHexadecimalInRange(
+        parameter.value,
+        0x7fff8000,
+        0x7fffffff,
+      ) === undefined,
+  },
+  buildExplicitDecimalRangeRule(
+    "evspl",
+    3,
+    600,
+    "Event arrival check interval (evspl) must be between 3 and 600.",
+  ),
+  buildExplicitDecimalRangeRule(
+    "evsrc",
+    0,
+    999,
+    "Event arrival check count (evsrc) must be between 0 and 999.",
+  ),
+  {
+    key: "evsrt",
+    message:
+      "Event arrival check (evsrt=y) requires an event destination host (evhst).",
+    isInvalid: (parameter, unit) =>
+      (parameter.value ?? DEFAULTS.Evsrt) === "y" &&
+      !findParameter(unit, "evhst"),
+  },
+];
+
+const eventReceivingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
+  {
+    key: "evwid",
+    message:
+      "Event ID (evwid) must be hexadecimal in 00000000:00000000-FFFFFFFF:FFFFFFFF format.",
+    isInvalid: (parameter) =>
+      !isValidExplicitColonSeparatedHexadecimalEventId(parameter),
+  },
+  {
+    key: "evipa",
+    message:
+      "Event source IP address (evipa) must be a dotted-decimal IPv4 address between 0.0.0.0 and 255.255.255.255.",
+    isInvalid: (parameter) => !isValidExplicitIpv4Address(parameter),
+  },
+  {
+    key: "evesc",
+    message: "Event search condition (evesc) must be no or between 1 and 720.",
+    isInvalid: (parameter) => !isValidExplicitEventSearchCondition(parameter),
+  },
+];
+
 const buildJobEndJudgmentDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
   findUnitsByTypes(rootUnits, jobEndJudgmentDiagnosticTargetTypes).flatMap(
     (unit) => {
-      const diagnostics: SyntaxDiagnosticDto[] = [];
+      const diagnostics = collectRuleDiagnostics(
+        unit,
+        jobEndJudgmentNumericRangeRules,
+      );
       const abrParameter = findParameter(unit, "abr");
       const effectiveJobEndJudgment =
         findParameter(unit, "jd")?.value ?? DEFAULTS.Jd;
@@ -193,104 +344,14 @@ const buildFileMonitoringDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
   findUnitsByTypes(rootUnits, fileMonitoringDiagnosticTargetTypes).flatMap(
-    (unit) => {
-      const diagnostics: SyntaxDiagnosticDto[] = [];
-      const flwcParameter = findParameter(unit, "flwc");
-      const flcoParameter = findParameter(unit, "flco");
-      const effectiveFlwc = flwcParameter?.value ?? DEFAULTS.Flwc;
-      const flwcConditions = splitFileMonitoringConditions(effectiveFlwc);
-
-      if (flwcParameter && flwcConditions.has("s") && flwcConditions.has("m")) {
-        diagnostics.push(
-          buildDiagnostic(
-            flwcParameter,
-            "File monitoring condition (flwc) cannot specify both s and m.",
-          ),
-        );
-      }
-
-      if (flcoParameter && !flwcConditions.has("c")) {
-        diagnostics.push(
-          buildDiagnostic(
-            flcoParameter,
-            "File close option (flco) requires file creation monitoring (flwc=c).",
-          ),
-        );
-      }
-
-      return diagnostics;
-    },
+    (unit) => collectRuleDiagnostics(unit, fileMonitoringDiagnosticRules),
   );
 
 const buildEventSendingDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
   findUnitsByTypes(rootUnits, eventSendingDiagnosticTargetTypes).flatMap(
-    (unit) => {
-      const diagnostics: SyntaxDiagnosticDto[] = [];
-      const evsidParameter = findParameter(unit, "evsid");
-      const evsrtParameter = findParameter(unit, "evsrt");
-      const evhstParameter = findParameter(unit, "evhst");
-      const evsplParameter = findParameter(unit, "evspl");
-      const evsrcParameter = findParameter(unit, "evsrc");
-      const effectiveEvsrt = evsrtParameter?.value ?? DEFAULTS.Evsrt;
-
-      if (
-        evsidParameter &&
-        parseExplicitHexadecimalInRange(
-          evsidParameter.value,
-          0x00000000,
-          0x00001fff,
-        ) === undefined &&
-        parseExplicitHexadecimalInRange(
-          evsidParameter.value,
-          0x7fff8000,
-          0x7fffffff,
-        ) === undefined
-      ) {
-        diagnostics.push(
-          buildDiagnostic(
-            evsidParameter,
-            "Event ID (evsid) must be hexadecimal within 00000000-00001FFF or 7FFF8000-7FFFFFFF.",
-          ),
-        );
-      }
-
-      if (
-        evsplParameter &&
-        parseExplicitDecimalInRange(evsplParameter, 3, 600) === undefined
-      ) {
-        diagnostics.push(
-          buildDiagnostic(
-            evsplParameter,
-            "Event arrival check interval (evspl) must be between 3 and 600.",
-          ),
-        );
-      }
-
-      if (
-        evsrcParameter &&
-        parseExplicitDecimalInRange(evsrcParameter, 0, 999) === undefined
-      ) {
-        diagnostics.push(
-          buildDiagnostic(
-            evsrcParameter,
-            "Event arrival check count (evsrc) must be between 0 and 999.",
-          ),
-        );
-      }
-
-      if (evsrtParameter && effectiveEvsrt === "y" && !evhstParameter) {
-        diagnostics.push(
-          buildDiagnostic(
-            evsrtParameter,
-            "Event arrival check (evsrt=y) requires an event destination host (evhst).",
-          ),
-        );
-      }
-
-      return diagnostics;
-    },
+    (unit) => collectRuleDiagnostics(unit, eventSendingDiagnosticRules),
   );
 
 const isValidExplicitEventSearchCondition = (
@@ -312,47 +373,7 @@ const buildEventReceivingDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
   findUnitsByTypes(rootUnits, eventReceivingDiagnosticTargetTypes).flatMap(
-    (unit) => {
-      const diagnostics: SyntaxDiagnosticDto[] = [];
-      const evwidParameter = findParameter(unit, "evwid");
-      const evipaParameter = findParameter(unit, "evipa");
-      const evescParameter = findParameter(unit, "evesc");
-
-      if (
-        evwidParameter &&
-        !isValidExplicitColonSeparatedHexadecimalEventId(evwidParameter)
-      ) {
-        diagnostics.push(
-          buildDiagnostic(
-            evwidParameter,
-            "Event ID (evwid) must be hexadecimal in 00000000:00000000-FFFFFFFF:FFFFFFFF format.",
-          ),
-        );
-      }
-
-      if (evipaParameter && !isValidExplicitIpv4Address(evipaParameter)) {
-        diagnostics.push(
-          buildDiagnostic(
-            evipaParameter,
-            "Event source IP address (evipa) must be a dotted-decimal IPv4 address between 0.0.0.0 and 255.255.255.255.",
-          ),
-        );
-      }
-
-      if (
-        evescParameter &&
-        !isValidExplicitEventSearchCondition(evescParameter)
-      ) {
-        diagnostics.push(
-          buildDiagnostic(
-            evescParameter,
-            "Event search condition (evesc) must be no or between 1 and 720.",
-          ),
-        );
-      }
-
-      return diagnostics;
-    },
+    (unit) => collectRuleDiagnostics(unit, eventReceivingDiagnosticRules),
   );
 
 export const buildSyntaxDiagnostics = (

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -67,6 +67,87 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(diagnostics, []);
   });
 
+  test("reports end-judgment numeric range diagnostics for explicit out-of-range values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=custom,cj,+160+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    wth=2147483648;",
+        "    tho=-1;",
+        "    rjs=0;",
+        "    rje=4294967296;",
+        "  }",
+        "  unit=custom,,jp1admin,;",
+        "  {",
+        "    ty=cj;",
+        "    abr=y;",
+        "    rec=13;",
+        "    rei=0;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 6);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 3,
+          message: "Warning threshold (wth) must be between 0 and 2147483647.",
+        },
+        {
+          line: 10,
+          column: 4,
+          length: 3,
+          message: "Abnormal threshold (tho) must be between 0 and 2147483647.",
+        },
+        {
+          line: 11,
+          column: 4,
+          length: 3,
+          message: "Retry start code (rjs) must be between 1 and 4294967295.",
+        },
+        {
+          line: 12,
+          column: 4,
+          length: 3,
+          message: "Retry end code (rje) must be between 1 and 4294967295.",
+        },
+        {
+          line: 17,
+          column: 4,
+          length: 3,
+          message: "Retry count (rec) must be between 1 and 12.",
+        },
+        {
+          line: 18,
+          column: 4,
+          length: 3,
+          message: "Retry interval (rei) must be between 1 and 10.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error", "error", "error", "error"],
+    );
+  });
+
   test("reports end-judgment diagnostics for explicit invalid retry combinations", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [


### PR DESCRIPTION
## What changed
- added grouped job end-judgment numeric range diagnostics for `wth`, `tho`, `rjs`, `rje`, `rec`, and `rei`
- refactored `buildSyntaxDiagnostics.ts` so parameter diagnostics can be declared as rule objects and processed through shared logic
- updated the JP1/AJS v13 alignment SDD docs and editor-feedback use case to match the implemented slice

## Why
- the JP1/AJS v13 alignment work was moving in micro-slices; this groups a user-meaningful set of end-judgment and automatic-retry parameters into one behavior slice
- the diagnostics file had started to accumulate repeated `if`-based validation blocks, so formalizing rules makes the next parameter slices easier to add consistently

## Impact
- desktop and web editor diagnostics now report explicit out-of-range values for the grouped UNIX/PC job and UNIX/PC custom job parameters above
- parser output, domain wrapper values, normalized parameters, unit-list projection, flow projection, and command generation remain unchanged

## Validation
- `pnpm run qlty`
- `pnpm test`
- `pnpm run test:web`
- `pnpm run build`
- `pnpm run lint:md`
