### PR TITLE
[codex] Add schedule-rule range diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -94,6 +94,14 @@ Scenario: Job end-judgment numeric values must stay within documented ranges
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Schedule-rule values must stay within documented ranges
+  Given a syntactically valid JP1/AJS document with a jobnet
+  And explicit `ln`, `st`, `cy`, `shd`, `cftd`, `sy`, `ey`, `wc`, or `wt`
+    is outside the JP1/AJS3 v13 schedule-rule ranges
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Event arrival check requires an event destination host
   Given a syntactically valid JP1/AJS document with a JP1 event sending job
   And effective `evsrt` is event-arrival checking enabled

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -31,11 +31,14 @@ coverage.
   `Time.ts`
 - Evidence:
   `scheduleRuleHelpers.test.ts`, `parameterFactory.test.ts`,
-  `parameterHelpers.test.ts`, `buildUnitListGroup10View.test.ts`, and
-  `buildUnitListView.test.ts`
+  `parameterHelpers.test.ts`, `buildUnitListGroup10View.test.ts`,
+  `buildUnitListView.test.ts`, and `buildSyntaxDiagnostics.test.ts`
 - Remaining gap:
-  range validation remains deferred. `wc` / `wt` effective-value pairing is
-  aligned in the domain wrapper boundary and unit-list group 10 projection.
+  grouped range diagnostics are aligned for `ln`, `st`, `cy`, `shd`, `cftd`,
+  `sy`, `ey`, `wc`, and `wt` through editor-feedback. `sd` date/rule range
+  policy, `cy` open/closed-day restrictions, and any broader cross-parameter
+  invalidation remain deferred. `wc` / `wt` effective-value pairing is aligned
+  in the domain wrapper boundary and unit-list group 10 projection.
 
 ### Transfer Operation
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
@@ -148,9 +148,69 @@ and `wt`.
   `scheduleRuleHelpers.ts`, and unit-list projection no longer maintains a
   separate set of schedule-rule regular expressions.
 
+## Proposed Next Grouped Slice
+
+- Treat the next remaining schedule-rule work as one parameter-family slice for
+  jobnets, not as a return to one-key diagnostics.
+- Use the shared `scheduleRuleHelpers.ts` seam to verify already-modeled
+  explicit schedule-rule values before reporting user-visible range issues
+  through `buildSyntaxDiagnostics.ts`.
+- Keep raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation unchanged
+  unless a later approval explicitly broadens scope beyond diagnostics.
+- Focus the approval-gated investigation on the schedule-rule keys that still
+  have documented range gaps after value-shape alignment:
+  `ln`, `st`, `cy`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`.
+- Keep `sd` out of the first grouped follow-up unless the implementation
+  investigation resolves the separate product decision around `sd=0,ud`
+  handling and date-range policy.
+- Keep `sh` out of the follow-up because value-shape parsing for that key has
+  no remaining gap in this feature record.
+
+## Impact
+
+- User-visible diagnostics would change for syntactically valid JP1/AJS
+  documents containing explicit out-of-range schedule-rule values on jobnets.
+- The likely implementation surface spans
+  `src/domain/models/parameters/scheduleRuleHelpers.ts`,
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
+  `src/test/suite/scheduleRuleHelpers.test.ts`, and
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`.
+- Existing schedule-rule helper references in wrapper classes and unit-list
+  projection should not need projection changes if the slice stays inside
+  editor-feedback diagnostics.
+
+## Alternatives
+
+- Reopen the backlog as smaller single-parameter fixes, rejected because the
+  remaining gaps are already organized behind a shared schedule-rule seam and
+  shared regression evidence.
+- Switch to a different job type first, viable but deferred because schedule
+  rules are the clearest remaining parameter-family candidate.
+- Expand the slice to cross-parameter invalidation or UI redesign, rejected
+  because that broadens the behavior and regression surface beyond range
+  diagnostics.
+
+## Delivered Range Diagnostics
+
+- The editor-feedback boundary now reports semantic diagnostics for explicit
+  jobnet `ln`, `st`, `cy`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt` values
+  when they fall outside the grouped JP1/AJS3 v13 schedule-rule ranges covered
+  by this slice.
+- Root-jobnet `ln` remains ignored, matching the existing manual-aligned
+  boundary decision that root-jobnet parent-rule specification is ignored.
+- Diagnostics stay focused on explicit parameter values and preserve raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation.
+- This slice intentionally does not add cross-parameter invalidation such as
+  `sd` / `cy` open-closed-day coupling, and it keeps `sd` date-range policy
+  outside the grouped follow-up.
+
 ## Follow-up
 
-- Add range validation only after deciding whether invalid JP1/AJS parameter
-  values should become diagnostics, warnings, or preserved raw values.
+- Revisit `sd` date/rule range policy separately because `sd=0,ud` handling
+  still carries a product-decision note outside this grouped diagnostics slice.
+- Revisit `cy` open/closed-day restrictions and any other cross-parameter
+  invalidation separately from the delivered single-parameter range checks.
 - Apply this category-level parser alignment workflow to the next non-schedule
   parameter family before marking that category official-reference aligned.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -73,6 +73,13 @@ JP1/AJS3 version 13 reference documents.
   jobnet definition treats `no` in either parameter as invalidating the paired
   start-condition monitoring value. Any implementation must distinguish raw
   parameter preservation from effective-value interpretation.
+- Schedule-rule remaining range gaps are approval-sensitive because the
+  modeled jobnet parameters already share a parsing seam and regression
+  evidence set. Follow-up work should stay grouped by schedule-rule parameter
+  family where practical, rather than reopening the backlog as one-key
+  diagnostics, while still preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation unless a narrower approval explicitly broadens scope.
 - Unit-list group 10 `wc` / `wt` projection is a separate approval-sensitive
   boundary from domain interpretation because it is user-visible table output.
   If approved, it should consume the existing paired effective-value semantics

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -71,6 +71,13 @@
       explicit in-range values, and explicit out-of-range `wth`, `tho`, `rjs`,
       `rje`, `rec`, and `rei` values
 - [x] Run required code-change validation after implementation
+- [x] Record human approval before changing editor-feedback diagnostics,
+      shared schedule-rule helpers, runtime code, or tests for grouped
+      schedule-rule range diagnostics
+- [x] Implement grouped schedule-rule range diagnostics only after approval
+- [x] Add focused regression evidence for explicit valid and out-of-range
+      schedule-rule values in the approved key set
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -244,23 +251,55 @@
   wrapper values, normalized parameters, unit-list projection, flow
   projection, command generation, generated artifacts, configuration,
   dependency versions, and `engines.vscode` remain unchanged.
+- 2026-05-07: Remaining JP1/AJS v13 parameter-alignment gaps were re-grouped
+  around user-meaningful job types or parameter families instead of returning
+  to single-parameter micro-slices. The recommended next approval-gated
+  candidate is grouped schedule-rule range diagnostics for the already-modeled
+  jobnet parameter family, centered on `ln`, `st`, `cy`, `shd`, `cftd`,
+  `sy`, `ey`, `wc`, and `wt` through the existing editor-feedback boundary
+  while preserving raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation.
+  Parser grammar, schedule-rule value-shape parsing already delivered,
+  generated artifacts, configuration, dependency versions, `engines.vscode`,
+  and non-schedule parameter validation remain out of scope.
+- 2026-05-07: Grouped schedule-rule range diagnostics now report explicit
+  out-of-range `ln`, `st`, `cy`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`
+  values on jobnets through the existing editor-feedback boundary. Root-jobnet
+  `ln` remains ignored, explicit in-range values remain accepted, and raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, command generation, generated artifacts,
+  configuration, dependency versions, and `engines.vscode` remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
-- Approved at: 2026-05-06
-- Approved scope: grouped application-level semantic diagnostics for explicit
-  UNIX/PC jobs and UNIX/PC custom jobs where `wth` or `tho` is outside
-  `0..2147483647`, `rjs` or `rje` is outside `1..4294967295`, `rec` is
-  outside `1..12`, or `rei` is outside `1..10`; preserve raw parser output,
-  domain wrapper values, normalized parameters, unit-list projection, flow
-  projection, and command generation; add focused regression evidence; update
-  SDD tracking; and run validation.
+- Approved at: 2026-05-07
+- Approved scope: grouped schedule-rule range diagnostics for already-modeled
+  jobnet parameters through the existing editor-feedback boundary, reusing the
+  shared schedule-rule helper seam where practical, while preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation. Initial target keys:
+  `ln`, `st`, `cy`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`. Parser grammar
+  changes, schedule-rule value-shape parsing changes, generated artifacts,
+  configuration, dependency versions, `engines.vscode`, `sd` product-policy
+  changes, and non-schedule parameter validation remain out of scope.
 
-Current implementation gate: none; last completed slice was grouped job
-end-judgment numeric range validation.
+Current implementation gate: none; grouped schedule-rule range diagnostics are
+implemented and awaiting final validation sync.
 
 ## Prior Approval Evidence
+
+- 2026-05-07: User replied "Approved. Proceed with implementation." after the
+  grouped schedule-rule range-diagnostics approval request. Approved changes
+  were limited to adding grouped application-level semantic diagnostics for
+  already-modeled jobnet `ln`, `st`, `cy`, `shd`, `cftd`, `sy`, `ey`, `wc`,
+  and `wt` values through the existing editor-feedback boundary; preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation; adding focused
+  regression evidence; updating SDD tracking; and running validation. Parser
+  grammar, schedule-rule value-shape parsing changes, generated artifacts,
+  configuration, dependency versions, `engines.vscode`, `sd` product-policy
+  changes, and non-schedule parameter validation were out of scope.
 
 - 2026-05-06: User replied "Approved. Proceed with implementation." after the
   grouped job end-judgment numeric range validation approval request.
@@ -459,6 +498,18 @@ end-judgment numeric range validation.
 
 ## Validation
 
+- 2026-05-07: `pnpm run qlty` required an escalated rerun after the sandboxed
+  qlty log-file permission failure; escalated rerun completed with exit code 0
+- 2026-05-07: `pnpm test` completed with exit code 0; the VS Code harness
+  emitted an existing macOS `task_name_for_pid` codesign noise line
+- 2026-05-07: `pnpm run test:web` failed in the sandbox because Chromium could
+  not access macOS Mach port APIs; escalated rerun completed with exit code 0
+  and existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-07: `npm run build` completed with existing webpack asset-size
+  warnings
+- 2026-05-07: `pnpm run qlty` required an escalated rerun after the sandboxed
+  qlty log-file permission failure; escalated rerun completed with exit code 0
+- 2026-05-07: `pnpm run lint:md` completed with exit code 0
 - 2026-05-06: `pnpm run qlty` required an escalated rerun after the sandboxed
   qlty log-file permission failure; escalated rerun completed with exit code 0
 - 2026-05-06: `pnpm test` completed with exit code 0; the VS Code harness

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -20,6 +20,10 @@ rules in `docs/specs/README.md`, not in this file.
   categories without claiming repository-wide coverage. Schedule-rule
   `wc` / `wt` effective-value pairing is aligned in the domain boundary and
   unit-list projection.
+- Remaining JP1/AJS v13 parameter-alignment gaps should be grouped by
+  user-meaningful job type or parameter family where practical, instead of
+  returning to single-parameter micro-slices once a family has shared seams
+  and shared regression evidence.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -38,8 +42,9 @@ rules in `docs/specs/README.md`, not in this file.
 ## Next Priority Tasks
 
 1. Request approval for the next grouped JP1/AJS3 v13 parameter-alignment
-   slice: job end-judgment numeric range diagnostics for `wth`, `tho`, `rjs`,
-   `rje`, `rec`, and `rei` on UNIX/PC jobs and UNIX/PC custom jobs.
+   slice for the next user-meaningful remaining gap after the delivered
+   schedule-rule range diagnostics, keeping the grouping by job type or
+   parameter family.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -52,39 +57,37 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/job-end-judgment-range-diagnostics`
+- Branch: `codex/schedule-rule-range-diagnostics`
 - Objective: continue JP1/AJS v13 parameter alignment with a user-meaningful
-  grouped slice around job end-judgment numeric ranges for UNIX/PC jobs and
-  UNIX/PC custom jobs, instead of returning to one-parameter micro-slices.
+  grouped slice around the schedule-rule parameter family for jobnets, rather
+  than reopening the feature through another single-parameter fix.
 - Status: approved, implemented, and validated on
-  `codex/job-end-judgment-range-diagnostics`.
-- Scope: add application-level semantic diagnostics for explicit `j` / `cj`
-  parameters where `wth` or `tho` is outside `0..2147483647`, `rjs` or `rje`
-  is outside `1..4294967295`, `rec` is outside `1..12`, or `rei` is outside
-  `1..10`; preserve raw parser output, domain wrapper values, normalized
-  parameters, unit-list projection, flow projection, and command generation.
-- Out of scope: parser grammar changes, raw parser/domain/normalized value
-  changes, unit-list projection changes, flow projection changes, command
-  generation changes, generated artifacts, dependency changes,
-  `engines.vscode`, retry threshold ordering, byte-length validation, and
-  broad parameter validation.
-- Impact summary: the slice would affect
-  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
-  `buildSyntaxDiagnostics` tests, the existing VS Code diagnostics adapter
-  through DTO mapping, the job end-judgment alignment record, and the
-  editor-feedback use-case contract.
-- Risks and assumptions: the change would be user-visible in desktop and web
-  diagnostics for syntactically valid documents. Existing parsed parameter
-  source-location metadata should be enough to point at explicit `wth`, `tho`,
-  `rjs`, `rje`, `rec`, and `rei`, so no parser or DTO shape change is
-  expected. Omitted values remain non-diagnostic. Raw values remain
-  inspectable by downstream consumers, and the existing unit-list raw
-  projection evidence should stay unchanged outside diagnostics.
-- Alternatives considered: keep invalid numeric values silent and leave the
-  gap visible; move these validations into domain wrappers, rejected for this
-  slice because current diagnostics policy keeps raw manual-invalid values
-  inspectable; include retry threshold ordering now, deferred because it adds
-  cross-parameter rule coupling beyond a single grouped numeric-range slice.
+  `codex/schedule-rule-range-diagnostics`.
+- Scope: add focused schedule-rule range diagnostics for already-modeled
+  jobnet parameters through the existing editor-feedback boundary while
+  reusing the shared schedule-rule helper seam; preserve raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation.
+- Out of scope: parser grammar changes, schedule-rule value-shape parsing
+  changes already delivered, unrelated unit-list redesign, generated
+  artifacts, dependency changes, `engines.vscode`, and non-schedule parameter
+  validation.
+- Impact summary: the next slice is expected to affect
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
+  `src/domain/models/parameters/scheduleRuleHelpers.ts`, focused
+  schedule-rule helper and diagnostics tests, the schedule-rule alignment
+  record, and the editor-feedback behavior contract if new diagnostics are
+  approved.
+- Risks and assumptions: schedule-rule values already share a parsing seam, so
+  the remaining work can stay grouped by parameter family without duplicating
+  parsing rules in presentation code. The main open design point is whether
+  every documented out-of-range value should become an editor diagnostic or
+  whether some cases should remain documented as raw-only gaps.
+- Alternatives considered: reopen the backlog as smaller single-parameter
+  fixes, rejected because that hides the category-level nature of the
+  remaining schedule-rule work; switch to a different job type first, viable
+  but deferred because schedule rules already have the clearest shared seam
+  and evidence set for a grouped follow-up.
 
 ## Build/Test Performance SDD
 
@@ -113,9 +116,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: job end-judgment grouped numeric range diagnostics is implemented
-  after delivered event reception `evwid` / `evipa` validation; next step is
-  required validation.
+  slice: grouped schedule-rule range diagnostics is implemented; next
+  candidate should be selected from the remaining partial/deferred gaps using
+  the same user-meaningful grouping rule.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -28,6 +28,7 @@ const jobEndJudgmentRetryParameterKeys = ["rjs", "rje", "rec", "rei"];
 const fileMonitoringDiagnosticTargetTypes = new Set(["flwj", "rflwj"]);
 const eventSendingDiagnosticTargetTypes = new Set(["evsj", "revsj"]);
 const eventReceivingDiagnosticTargetTypes = new Set(["evwj", "revwj"]);
+const scheduleRuleDiagnosticTargetTypes = new Set(["g", "n"]);
 
 const flattenUnits = (units: Unit[]): Unit[] =>
   units.reduce<Unit[]>(
@@ -155,6 +156,227 @@ const collectRuleDiagnostics = (
       : [];
   });
 
+type ParsedExplicitScheduleRuleValue = {
+  hasExplicitRuleNumber: boolean;
+  ruleNumber: number;
+  value: string;
+};
+
+const parseExplicitScheduleRuleValue = (
+  rawValue: string | undefined,
+): ParsedExplicitScheduleRuleValue | undefined => {
+  const matched = /^((\d{1,3}),)?(.+)$/.exec(rawValue ?? "");
+  if (!matched) {
+    return undefined;
+  }
+
+  return {
+    hasExplicitRuleNumber: matched[2] !== undefined,
+    ruleNumber: matched[2] === undefined ? 1 : Number(matched[2]),
+    value: matched[3],
+  };
+};
+
+const isValidScheduleRuleNumber = (
+  parsedValue: ParsedExplicitScheduleRuleValue | undefined,
+): boolean =>
+  parsedValue !== undefined &&
+  (!parsedValue.hasExplicitRuleNumber ||
+    (parsedValue.ruleNumber >= 1 && parsedValue.ruleNumber <= 144));
+
+const parseHourMinuteValue = (
+  rawValue: string,
+): { hours: number; minutes: number } | undefined => {
+  const matched = /^\+?(\d{2}):(\d{2})$/.exec(rawValue);
+  if (!matched) {
+    return undefined;
+  }
+
+  return {
+    hours: Number(matched[1]),
+    minutes: Number(matched[2]),
+  };
+};
+
+const isValidHourMinuteRange = (rawValue: string): boolean => {
+  const parsed = parseHourMinuteValue(rawValue);
+  return (
+    parsed !== undefined &&
+    parsed.hours >= 0 &&
+    parsed.hours <= 47 &&
+    parsed.minutes >= 0 &&
+    parsed.minutes <= 59
+  );
+};
+
+const isValidDelayMinutesRange = (rawValue: string): boolean => {
+  const matched = /^[MCU](\d{1,4})$/.exec(rawValue);
+  if (!matched) {
+    return false;
+  }
+
+  const minutes = Number(matched[1]);
+  return minutes >= 1 && minutes <= 2879;
+};
+
+const isValidWaitMinutesRange = (rawValue: string): boolean => {
+  if (!/^\d{1,4}$/.test(rawValue)) {
+    return false;
+  }
+
+  const minutes = Number(rawValue);
+  return minutes >= 1 && minutes <= 2879;
+};
+
+const isValidExplicitParentScheduleRule = (
+  parameter: UnitParameter,
+  unit: Unit,
+  rootUnits: readonly Unit[],
+): boolean => {
+  if (rootUnits.includes(unit)) {
+    return true;
+  }
+
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
+    return false;
+  }
+
+  if (!/^\d{1,3}$/.test(parsed.value)) {
+    return false;
+  }
+
+  const parentRuleNumber = Number(parsed.value);
+  return parentRuleNumber >= 1 && parentRuleNumber <= 144;
+};
+
+const isValidExplicitStartTime = (parameter: UnitParameter): boolean => {
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  return (
+    isValidScheduleRuleNumber(parsed) &&
+    parsed !== undefined &&
+    isValidHourMinuteRange(parsed.value)
+  );
+};
+
+const isValidExplicitCycle = (parameter: UnitParameter): boolean => {
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
+    return false;
+  }
+
+  const matched = /^\((\d{1,3}),([ymwd])\)$/.exec(parsed.value);
+  if (!matched) {
+    return false;
+  }
+
+  const cycle = Number(matched[1]);
+  const unitType = matched[2];
+  const maximumByUnit = {
+    y: 10,
+    m: 12,
+    w: 5,
+    d: 31,
+  } as const;
+  return cycle >= 1 && cycle <= maximumByUnit[unitType];
+};
+
+const isValidExplicitShiftDays = (parameter: UnitParameter): boolean => {
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
+    return false;
+  }
+
+  if (!/^\d{1,3}$/.test(parsed.value)) {
+    return false;
+  }
+
+  const shiftDays = Number(parsed.value);
+  return shiftDays >= 1 && shiftDays <= 31;
+};
+
+const isValidOptionalOneToThirtyOne = (rawValue: string | undefined): boolean =>
+  rawValue === undefined ||
+  (/^\d{1,2}$/.test(rawValue) &&
+    Number(rawValue) >= 1 &&
+    Number(rawValue) <= 31);
+
+const isValidExplicitScheduleByDaysFromStart = (
+  parameter: UnitParameter,
+): boolean => {
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
+    return false;
+  }
+
+  const segments = parsed.value.split(",");
+  const scheduleType = segments[0];
+  if (
+    !["no", "be", "af", "db", "da"].includes(scheduleType) ||
+    segments.some((segment) => segment.length === 0)
+  ) {
+    return false;
+  }
+
+  if (scheduleType === "no") {
+    return segments.length === 1;
+  }
+
+  if (scheduleType === "db" || scheduleType === "da") {
+    return segments.length <= 2 && isValidOptionalOneToThirtyOne(segments[1]);
+  }
+
+  return (
+    segments.length <= 3 &&
+    isValidOptionalOneToThirtyOne(segments[1]) &&
+    isValidOptionalOneToThirtyOne(segments[2])
+  );
+};
+
+const isValidExplicitDelayTime = (parameter: UnitParameter): boolean => {
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
+    return false;
+  }
+
+  return (
+    isValidHourMinuteRange(parsed.value) ||
+    isValidDelayMinutesRange(parsed.value)
+  );
+};
+
+const isValidExplicitWaitCount = (parameter: UnitParameter): boolean => {
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
+    return false;
+  }
+
+  if (parsed.value === "no" || parsed.value === "un") {
+    return true;
+  }
+
+  if (!/^\d{1,3}$/.test(parsed.value)) {
+    return false;
+  }
+
+  const waitCount = Number(parsed.value);
+  return waitCount >= 1 && waitCount <= 999;
+};
+
+const isValidExplicitWaitTime = (parameter: UnitParameter): boolean => {
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
+    return false;
+  }
+
+  return (
+    parsed.value === "no" ||
+    parsed.value === "un" ||
+    isValidHourMinuteRange(parsed.value) ||
+    isValidWaitMinutesRange(parsed.value)
+  );
+};
+
 const jobEndJudgmentNumericRangeRules = [
   buildExplicitDecimalRangeRule(
     "wth",
@@ -273,6 +495,75 @@ const eventReceivingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
     isInvalid: (parameter) => !isValidExplicitEventSearchCondition(parameter),
   },
 ];
+
+const buildScheduleRuleDiagnostics = (
+  rootUnits: Unit[],
+): SyntaxDiagnosticDto[] =>
+  findUnitsByTypes(rootUnits, scheduleRuleDiagnosticTargetTypes).flatMap(
+    (unit) =>
+      collectRuleDiagnostics(unit, [
+        {
+          key: "ln",
+          message:
+            "Parent schedule rule (ln) must use schedule rule numbers between 1 and 144.",
+          isInvalid: (parameter, currentUnit) =>
+            !isValidExplicitParentScheduleRule(
+              parameter,
+              currentUnit,
+              rootUnits,
+            ),
+        },
+        {
+          key: "st",
+          message:
+            "Start time (st) must use schedule rule numbers 1..144 and times between 00:00 and 47:59.",
+          isInvalid: (parameter) => !isValidExplicitStartTime(parameter),
+        },
+        {
+          key: "cy",
+          message:
+            "Cycle value (cy) must use schedule rule numbers 1..144 and cycle ranges y=1..10, m=1..12, w=1..5, or d=1..31.",
+          isInvalid: (parameter) => !isValidExplicitCycle(parameter),
+        },
+        {
+          key: "shd",
+          message:
+            "Maximum shift days (shd) must use schedule rule numbers 1..144 and values between 1 and 31.",
+          isInvalid: (parameter) => !isValidExplicitShiftDays(parameter),
+        },
+        {
+          key: "cftd",
+          message:
+            "Days-from-start rule (cftd) must use schedule rule numbers 1..144 with valid no/be/af/db/da ranges.",
+          isInvalid: (parameter) =>
+            !isValidExplicitScheduleByDaysFromStart(parameter),
+        },
+        {
+          key: "sy",
+          message:
+            "Start delay time (sy) must use schedule rule numbers 1..144 and either 00:00-47:59 or M/C/U minutes between 1 and 2879.",
+          isInvalid: (parameter) => !isValidExplicitDelayTime(parameter),
+        },
+        {
+          key: "ey",
+          message:
+            "End delay time (ey) must use schedule rule numbers 1..144 and either 00:00-47:59 or M/C/U minutes between 1 and 2879.",
+          isInvalid: (parameter) => !isValidExplicitDelayTime(parameter),
+        },
+        {
+          key: "wc",
+          message:
+            "Start-condition count (wc) must use schedule rule numbers 1..144 and values no, un, or 1..999.",
+          isInvalid: (parameter) => !isValidExplicitWaitCount(parameter),
+        },
+        {
+          key: "wt",
+          message:
+            "Monitoring end time (wt) must use schedule rule numbers 1..144 and values no, un, 00:00-47:59, or 1..2879 minutes.",
+          isInvalid: (parameter) => !isValidExplicitWaitTime(parameter),
+        },
+      ]),
+  );
 
 const buildJobEndJudgmentDiagnostics = (
   rootUnits: Unit[],
@@ -393,6 +684,7 @@ export const buildSyntaxDiagnostics = (
 
   return [
     ...syntaxDiagnostics,
+    ...buildScheduleRuleDiagnostics(result.rootUnits),
     ...buildJobEndJudgmentDiagnostics(result.rootUnits),
     ...buildFileMonitoringDiagnostics(result.rootUnits),
     ...buildEventSendingDiagnostics(result.rootUnits),

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -23,6 +23,151 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(diagnostics, []);
   });
 
+  test("does not report schedule-rule diagnostics for valid explicit values and ignored root ln", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  ln=1,999;",
+        "  st=144,+47:59;",
+        "  cy=143,(12,m);",
+        "  shd=142,31;",
+        "  cftd=141,af,31,31;",
+        "  sy=140,U2879;",
+        "  ey=139,47:59;",
+        "  wc=138,999;",
+        "  wt=137,2879;",
+        "  el=jobnet,n,+0+0;",
+        "  unit=jobnet,,jp1admin,;",
+        "  {",
+        "    ty=n;",
+        "    ln=136,144;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports schedule-rule diagnostics for explicit out-of-range values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  ln=1,999;",
+        "  st=145,+48:00;",
+        "  cy=1,(13,m);",
+        "  shd=1,0;",
+        "  cftd=1,no,2;",
+        "  sy=1,C2880;",
+        "  ey=1,48:00;",
+        "  wc=1,1000;",
+        "  wt=1,2880;",
+        "  el=jobnet,n,+0+0;",
+        "  unit=jobnet,,jp1admin,;",
+        "  {",
+        "    ty=n;",
+        "    ln=0,145;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 9);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 5,
+          column: 2,
+          length: 2,
+          message:
+            "Start time (st) must use schedule rule numbers 1..144 and times between 00:00 and 47:59.",
+        },
+        {
+          line: 6,
+          column: 2,
+          length: 2,
+          message:
+            "Cycle value (cy) must use schedule rule numbers 1..144 and cycle ranges y=1..10, m=1..12, w=1..5, or d=1..31.",
+        },
+        {
+          line: 7,
+          column: 2,
+          length: 3,
+          message:
+            "Maximum shift days (shd) must use schedule rule numbers 1..144 and values between 1 and 31.",
+        },
+        {
+          line: 8,
+          column: 2,
+          length: 4,
+          message:
+            "Days-from-start rule (cftd) must use schedule rule numbers 1..144 with valid no/be/af/db/da ranges.",
+        },
+        {
+          line: 9,
+          column: 2,
+          length: 2,
+          message:
+            "Start delay time (sy) must use schedule rule numbers 1..144 and either 00:00-47:59 or M/C/U minutes between 1 and 2879.",
+        },
+        {
+          line: 10,
+          column: 2,
+          length: 2,
+          message:
+            "End delay time (ey) must use schedule rule numbers 1..144 and either 00:00-47:59 or M/C/U minutes between 1 and 2879.",
+        },
+        {
+          line: 11,
+          column: 2,
+          length: 2,
+          message:
+            "Start-condition count (wc) must use schedule rule numbers 1..144 and values no, un, or 1..999.",
+        },
+        {
+          line: 12,
+          column: 2,
+          length: 2,
+          message:
+            "Monitoring end time (wt) must use schedule rule numbers 1..144 and values no, un, 00:00-47:59, or 1..2879 minutes.",
+        },
+        {
+          line: 17,
+          column: 4,
+          length: 2,
+          message:
+            "Parent schedule rule (ln) must use schedule rule numbers between 1 and 144.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      [
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+      ],
+    );
+  });
+
   test("does not report end-judgment diagnostics for omitted defaults", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [


### PR DESCRIPTION
## Summary
- add grouped editor diagnostics for jobnet schedule-rule parameters `ln`, `st`, `cy`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`
- add focused regression coverage for valid schedule-rule values, out-of-range values, and the existing root-jobnet `ln` ignore rule
- sync the parameter-alignment SDD docs and editor-feedback use case with the delivered slice

## Why
- the JP1/AJS v13 alignment backlog still had remaining schedule-rule range gaps after the shared parsing seam was delivered
- this slice keeps the work grouped by a user-meaningful parameter family instead of reopening the backlog as single-parameter fixes

## Impact
- syntactically valid JP1/AJS jobnets now surface semantic diagnostics when explicit schedule-rule values fall outside the documented grouped ranges
- raw parser output, domain wrapper values, normalized parameters, unit-list projection, flow projection, and command generation remain unchanged
- remaining follow-up is limited to deferred `sd` policy and cross-parameter restrictions such as `cy` open/closed-day coupling

## Validation
- `rtk pnpm run qlty`
- `pnpm test`
- `pnpm run test:web`
- `npm run build`
- `rtk pnpm run lint:md`

## Notes
- `qlty` required an escalated rerun because the sandbox could not create its log file
- `test:web` required an escalated rerun because Chromium could not access required macOS APIs in the sandbox
- existing webpack asset-size warnings, macOS codesign noise, and `package.nls.json` 404 noise were unchanged from prior runs