### PR TITLE
[codex] add file-monitoring target-pattern diagnostics

### DIFF
--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/FILE_MONITORING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/FILE_MONITORING_JOB_ALIGNMENT.md
@@ -2,8 +2,7 @@
 
 ## Purpose
 
-Record the JP1/AJS3 version 13 alignment slice for file monitoring job
-defaults and unit-list projection behavior.
+Record the JP1/AJS3 version 13 alignment status for file monitoring jobs.
 
 This document focuses on the currently modeled file monitoring job parameters
 `flwf`, `flwc`, `flwi`, `flco`, and `ets` for `Flwj` / `Rflwj`.
@@ -64,6 +63,38 @@ This document focuses on the currently modeled file monitoring job parameters
   `m`, or explicit `flco` is present when effective `flwc` does not include
   `c`.
 
+## Delivered Target-Pattern Validation
+
+- Editor feedback now reports a semantic diagnostic when an explicit
+  file-monitoring job or recovery file-monitoring job sets `flwf` to a value
+  outside the JP1/AJS3 v13 byte-length range `1..255`.
+- Editor feedback now reports a semantic diagnostic when an explicit
+  file-monitoring job or recovery file-monitoring job sets `flwi` to a value
+  outside the JP1/AJS3 v13 numeric range `1..600`.
+- Editor feedback now reports a semantic diagnostic when an explicit
+  file-monitoring job or recovery file-monitoring job sets `flwf` to a
+  wildcard pattern containing `*` while the effective monitoring interval from
+  `flwi` is in the JP1/AJS3 v13 restricted range `1..9`.
+- The implementation stays in `buildSyntaxDiagnostics.ts`, preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation.
+- Omitted `flwf` remains non-diagnostic because no file-name default is
+  introduced, and omitted `flwi` remains non-diagnostic because the existing
+  default value `60` stays valid for wildcard usage.
+- Diagnostics point at the explicit `flwf` or `flwi` parameter, so parser and
+  DTO shapes remain unchanged.
+
+## Impact
+
+- User-visible diagnostics would change for syntactically valid JP1/AJS
+  documents containing explicit invalid monitored-file names or monitoring
+  intervals on `flwj` / `rflwj`.
+- Existing parsed parameter source-location metadata should be enough to point
+  diagnostics at explicit `flwf` and `flwi`, so no parser or DTO shape change
+  is expected.
+- The application diagnostics boundary remains the owner of focused semantic
+  parameter feedback; parser grammar and domain wrapper values remain raw.
+
 ## Alternatives
 
 - Keep group 13 raw by design and leave the matrix gap visible.
@@ -72,12 +103,18 @@ This document focuses on the currently modeled file monitoring job parameters
 - Change domain defaults or introduce a new file-monitoring helper seam;
   deferred because existing default values already match the manual and the
   behavior gap is projection-only.
-- Add diagnostics for `flwc` invalid combinations, wildcard restrictions, or
-  numeric ranges first; deferred because diagnostics policy is a separate
-  behavior contract.
+- Add diagnostics for `flwc` invalid combinations first; completed because the
+  invalid-combination rule was the narrowest safe first slice in this job
+  type.
+- Split `flwf` byte-length, `flwi` numeric range, and wildcard restrictions
+  into separate micro-slices; rejected because the manual couples wildcard
+  usage to short `flwi` values and the user asked for job-type or
+  parameter-family sized slices where practical.
+- Broaden the slice further to `ets` timeout behavior or other event-job rules,
+  deferred because that expands beyond the monitored-file and monitoring-
+  interval parameter family.
 
 ## Follow-up
 
-- Revisit `flwi` range validation, wildcard restrictions, byte-length
-  validation, and timeout behavior only after the focused diagnostics slice is
-  completed or explicitly deferred.
+- Revisit `ets` timeout behavior now that the grouped `flwf` / `flwi`
+  validation slice is implemented.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -124,9 +124,11 @@ coverage.
   `buildUnitListRemainingGroups.test.ts` for group 13 projection
 - Remaining gap:
   unit-list group 13 default-aware projection is aligned for these defaults,
-  and `flwc` / `flco` invalid-combination diagnostics are aligned through
-  editor-feedback. Wildcard restrictions, byte-length validation, and range
-  validation remain deferred.
+  `flwc` / `flco` invalid-combination diagnostics are aligned through
+  editor-feedback, and `flwf` / `flwi` target-pattern validation is aligned
+  through editor-feedback for byte-length, numeric range, and
+  wildcard-with-short-interval rules. `ets` timeout behavior remains
+  deferred.
 
 ### Execution-Interval Control Job Defaults
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -102,6 +102,15 @@ JP1/AJS3 version 13 reference documents.
   effective `flwc` value does not include `c`, while preserving raw parser
   output, domain wrapper values, normalized parameters, unit-list projection,
   flow projection, and command generation.
+- File monitoring job `flwf` / `flwi` validation is approval-sensitive
+  because existing behavior preserves explicit monitored-file patterns and
+  monitoring-interval values as raw parsed data without editor feedback. A
+  grouped validation slice should report explicit `flwf` values outside the
+  JP1/AJS3 v13 byte-length range `1..255`, explicit `flwi` values outside the
+  range `1..600`, and explicit wildcard `flwf` patterns when the effective
+  `flwi` value is in the JP1/AJS3 v13 restricted range `1..9`, while
+  preserving raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
 - Execution-interval control job defaults are approval-sensitive because
   JP1/AJS3 version 13 defines omitted `tmitv`, `etn`, and `ets` behavior for
   `tmwj` / `rtmwj`, while current code only has generic defaults for `etn` and

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -78,6 +78,17 @@
 - [x] Add focused regression evidence for explicit valid and out-of-range
       schedule-rule values in the approved key set
 - [x] Run required code-change validation after implementation
+- [x] Re-group the remaining JP1/AJS v13 parameter-alignment backlog around
+      user-meaningful job types or parameter families after the delivered
+      schedule-rule slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      file-monitoring target-pattern validation
+- [x] Implement grouped file-monitoring target-pattern validation only after
+      approval
+- [x] Add focused regression evidence for explicit valid and invalid `flwf`
+      / `flwi` values and wildcard-with-short-interval combinations
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -269,25 +280,55 @@
   parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, command generation, generated artifacts,
   configuration, dependency versions, and `engines.vscode` remain unchanged.
+- 2026-05-07: Remaining JP1/AJS v13 parameter-alignment gaps were re-grouped
+  again around user-meaningful job types or parameter families after the
+  delivered schedule-rule slice. The recommended next approval-gated
+  candidate is grouped file-monitoring target-pattern validation for
+  `flwj` / `rflwj`, centered on `flwf` / `flwi` byte-length, numeric range,
+  and wildcard-with-short-interval rules through the existing
+  editor-feedback boundary while preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation. Parser grammar, unit-list projection changes, `flwc` /
+  `flco` diagnostics already delivered, `ets` timeout behavior, generated
+  artifacts, configuration, dependency versions, `engines.vscode`, and
+  non-file-monitoring validation remain out of scope.
+- 2026-05-07: Grouped file-monitoring target-pattern validation now reports
+  explicit `flwf` values outside the JP1/AJS3 v13 byte-length range
+  `1..255`, explicit `flwi` values outside `1..600`, and explicit wildcard
+  `flwf` patterns when effective `flwi` is in the restricted range `1..9`,
+  through the existing editor-feedback boundary. Omitted `flwf` and omitted
+  `flwi` remain non-diagnostic, raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation remain unchanged, and `ets` timeout behavior remains deferred.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-07
-- Approved scope: grouped schedule-rule range diagnostics for already-modeled
-  jobnet parameters through the existing editor-feedback boundary, reusing the
-  shared schedule-rule helper seam where practical, while preserving raw
-  parser output, domain wrapper values, normalized parameters, unit-list
-  projection, flow projection, and command generation. Initial target keys:
-  `ln`, `st`, `cy`, `shd`, `cftd`, `sy`, `ey`, `wc`, and `wt`. Parser grammar
-  changes, schedule-rule value-shape parsing changes, generated artifacts,
-  configuration, dependency versions, `engines.vscode`, `sd` product-policy
-  changes, and non-schedule parameter validation remain out of scope.
+- Approved scope: grouped file-monitoring target-pattern validation for
+  `Flwj` / `Rflwj` through the existing editor-feedback boundary, limited to
+  `flwf` byte-length, `flwi` numeric range, and wildcard-with-short-interval
+  diagnostics, while preserving raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation.
 
-Current implementation gate: none; grouped schedule-rule range diagnostics are
-implemented and awaiting final validation sync.
+Current implementation gate: grouped file-monitoring target-pattern validation
+is approved for implementation inside the recorded scope.
 
 ## Prior Approval Evidence
+
+- 2026-05-07: User replied "Approved. Proceed with implementation." after the
+  grouped file-monitoring target-pattern validation approval request.
+  Approved changes were limited to adding grouped application-level semantic
+  diagnostics for `Flwj` / `Rflwj` `flwf` byte-length, `flwi` numeric range,
+  and wildcard-with-short-interval rules through the existing editor-feedback
+  boundary; preserving raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation;
+  adding focused regression evidence; updating SDD tracking; and running
+  validation. Parser grammar, unit-list projection changes, `flwc` / `flco`
+  diagnostics already delivered, `ets` timeout behavior, generated artifacts,
+  configuration, dependency versions, `engines.vscode`, and non-file-
+  monitoring validation were out of scope.
 
 - 2026-05-07: User replied "Approved. Proceed with implementation." after the
   grouped schedule-rule range-diagnostics approval request. Approved changes
@@ -498,6 +539,14 @@ implemented and awaiting final validation sync.
 
 ## Validation
 
+- 2026-05-07: `pnpm run qlty` completed with exit code 0 after the
+  file-monitoring target-pattern diagnostics implementation
+- 2026-05-07: `npm test` completed with exit code 0
+- 2026-05-07: `pnpm run test:web` failed in the sandbox because Chromium could
+  not access macOS Mach port APIs; escalated rerun completed with exit code 0
+  and existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-07: `pnpm run build` completed with existing webpack asset-size
+  warnings
 - 2026-05-07: `pnpm run qlty` required an escalated rerun after the sandboxed
   qlty log-file permission failure; escalated rerun completed with exit code 0
 - 2026-05-07: `pnpm test` completed with exit code 0; the VS Code harness

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -24,6 +24,11 @@ rules in `docs/specs/README.md`, not in this file.
   user-meaningful job type or parameter family where practical, instead of
   returning to single-parameter micro-slices once a family has shared seams
   and shared regression evidence.
+- After the delivered schedule-rule range diagnostics, the next recommended
+  JP1/AJS v13 slice is grouped file-monitoring target-pattern validation for
+  `Flwj` / `Rflwj`, centered on `flwf` / `flwi` byte-length, numeric range,
+  and wildcard-with-short-interval rules through the existing editor-feedback
+  boundary.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -42,9 +47,9 @@ rules in `docs/specs/README.md`, not in this file.
 ## Next Priority Tasks
 
 1. Request approval for the next grouped JP1/AJS3 v13 parameter-alignment
-   slice for the next user-meaningful remaining gap after the delivered
-   schedule-rule range diagnostics, keeping the grouping by job type or
-   parameter family.
+   slice selected from the remaining partial or deferred gaps after the
+   delivered file-monitoring target-pattern validation, keeping the grouping
+   by job type or parameter family.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -57,37 +62,38 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/schedule-rule-range-diagnostics`
+- Branch: `codex/file-monitoring-target-pattern-validation`
 - Objective: continue JP1/AJS v13 parameter alignment with a user-meaningful
-  grouped slice around the schedule-rule parameter family for jobnets, rather
-  than reopening the feature through another single-parameter fix.
-- Status: approved, implemented, and validated on
-  `codex/schedule-rule-range-diagnostics`.
-- Scope: add focused schedule-rule range diagnostics for already-modeled
-  jobnet parameters through the existing editor-feedback boundary while
-  reusing the shared schedule-rule helper seam; preserve raw parser output,
-  domain wrapper values, normalized parameters, unit-list projection, flow
-  projection, and command generation.
-- Out of scope: parser grammar changes, schedule-rule value-shape parsing
-  changes already delivered, unrelated unit-list redesign, generated
-  artifacts, dependency changes, `engines.vscode`, and non-schedule parameter
-  validation.
+  grouped slice around file-monitoring target-pattern validation for
+  `Flwj` / `Rflwj`, rather than reopening the feature through another
+  single-parameter fix.
+- Status: implemented and validated on
+  `codex/file-monitoring-target-pattern-validation`.
+- Scope: add focused file-monitoring semantic diagnostics for explicit
+  monitored-file and monitoring-interval constraints through the existing
+  editor-feedback boundary, covering `flwf` byte-length, `flwi` numeric range,
+  and wildcard-with-short-interval invalid combinations while preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation.
+- Out of scope: parser grammar changes, domain default changes, unit-list
+  projection changes, `flwc` / `flco` diagnostics already delivered, `ets`
+  timeout behavior, generated artifacts, dependency changes,
+  `engines.vscode`, and non-file-monitoring parameter validation.
 - Impact summary: the next slice is expected to affect
-  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
-  `src/domain/models/parameters/scheduleRuleHelpers.ts`, focused
-  schedule-rule helper and diagnostics tests, the schedule-rule alignment
-  record, and the editor-feedback behavior contract if new diagnostics are
-  approved.
-- Risks and assumptions: schedule-rule values already share a parsing seam, so
-  the remaining work can stay grouped by parameter family without duplicating
-  parsing rules in presentation code. The main open design point is whether
-  every documented out-of-range value should become an editor diagnostic or
-  whether some cases should remain documented as raw-only gaps.
-- Alternatives considered: reopen the backlog as smaller single-parameter
-  fixes, rejected because that hides the category-level nature of the
-  remaining schedule-rule work; switch to a different job type first, viable
-  but deferred because schedule rules already have the clearest shared seam
-  and evidence set for a grouped follow-up.
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
+  file-monitoring diagnostics tests, the file-monitoring alignment record, and
+  the editor-feedback behavior contract if the new diagnostics are approved.
+- Risks and assumptions: the file-monitoring manual couples `flwf` wildcard
+  usage and `flwi` short intervals, so the remaining work is best treated as a
+  single parameter-family validation slice instead of separate key-level
+  checks. Existing parameter source-location metadata is assumed to be
+  sufficient to point diagnostics at explicit `flwf` / `flwi` parameters
+  without parser or DTO changes.
+- Alternatives considered: switch to another job type first, viable but
+  deferred because file monitoring still has a coherent deferred validation
+  family after its delivered defaults and invalid-combination diagnostics;
+  split `flwf` and `flwi` into micro-slices, rejected because the manual
+  defines a shared wildcard/interval rule across those parameters.
 
 ## Build/Test Performance SDD
 
@@ -116,9 +122,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped schedule-rule range diagnostics is implemented; next
-  candidate should be selected from the remaining partial/deferred gaps using
-  the same user-meaningful grouping rule.
+  slice: grouped file-monitoring target-pattern validation is implemented and
+  validated; the next candidate should be selected from the remaining
+  partial/deferred gaps using the same user-meaningful grouping rule.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -145,6 +145,44 @@ const isValidExplicitIpv4Address = (
   });
 };
 
+const getByteLength = (value: string): number =>
+  new TextEncoder().encode(value).length;
+
+const hasWildcard = (value: string): boolean => value.includes("*");
+
+const isValidExplicitFileMonitoringFileName = (
+  parameter: UnitParameter | undefined,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (rawValue === undefined) {
+    return false;
+  }
+
+  const byteLength = getByteLength(rawValue);
+  return byteLength >= 1 && byteLength <= 255;
+};
+
+const isValidExplicitFileMonitoringInterval = (
+  parameter: UnitParameter | undefined,
+): boolean => parseExplicitDecimalInRange(parameter, 1, 600) !== undefined;
+
+const hasInvalidWildcardWithShortMonitoringInterval = (
+  parameter: UnitParameter,
+  unit: Unit,
+): boolean => {
+  if (!hasWildcard(parameter.value)) {
+    return false;
+  }
+
+  const effectiveFlwi = findParameter(unit, "flwi")?.value ?? DEFAULTS.Flwi;
+  if (!/^\d+$/.test(effectiveFlwi)) {
+    return false;
+  }
+
+  const monitoringInterval = Number(effectiveFlwi);
+  return monitoringInterval >= 1 && monitoringInterval <= 9;
+};
+
 const collectRuleDiagnostics = (
   unit: Unit,
   rules: readonly UnitParameterDiagnosticRule[],
@@ -417,6 +455,23 @@ const jobEndJudgmentNumericRangeRules = [
 ] as const;
 
 const fileMonitoringDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
+  {
+    key: "flwf",
+    message: "Monitored file name (flwf) must be between 1 and 255 bytes.",
+    isInvalid: (parameter) => !isValidExplicitFileMonitoringFileName(parameter),
+  },
+  {
+    key: "flwi",
+    message: "Monitoring interval (flwi) must be between 1 and 600.",
+    isInvalid: (parameter) => !isValidExplicitFileMonitoringInterval(parameter),
+  },
+  {
+    key: "flwf",
+    message:
+      "Monitored file name (flwf) cannot use wildcard (*) when monitoring interval (flwi) is between 1 and 9.",
+    isInvalid: (parameter, unit) =>
+      hasInvalidWildcardWithShortMonitoringInterval(parameter, unit),
+  },
   {
     key: "flwc",
     message: "File monitoring condition (flwc) cannot specify both s and m.",

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -521,6 +521,102 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(diagnostics, []);
   });
 
+  test("does not report file monitoring target-pattern diagnostics for valid explicit values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=file1,flwj,+0+0;",
+        "  el=file2,rflwj,+160+0;",
+        "  unit=file1,,jp1admin,;",
+        "  {",
+        "    ty=flwj;",
+        '    flwf="watch.txt";',
+        "    flwi=60;",
+        "  }",
+        "  unit=file2,,jp1admin,;",
+        "  {",
+        "    ty=rflwj;",
+        '    flwf="logs/*.txt";',
+        "    flwi=10;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports file monitoring target-pattern diagnostics for explicit out-of-range values and wildcard short intervals", () => {
+    const tooLongFileName = "a".repeat(256);
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=file1,flwj,+0+0;",
+        "  el=file2,rflwj,+160+0;",
+        "  el=file3,flwj,+320+0;",
+        "  unit=file1,,jp1admin,;",
+        "  {",
+        "    ty=flwj;",
+        `    flwf="${tooLongFileName}";`,
+        "  }",
+        "  unit=file2,,jp1admin,;",
+        "  {",
+        "    ty=rflwj;",
+        "    flwi=601;",
+        "  }",
+        "  unit=file3,,jp1admin,;",
+        "  {",
+        "    ty=flwj;",
+        '    flwf="logs/*.txt";',
+        "    flwi=9;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 3);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 10,
+          column: 4,
+          length: 4,
+          message:
+            "Monitored file name (flwf) must be between 1 and 255 bytes.",
+        },
+        {
+          line: 15,
+          column: 4,
+          length: 4,
+          message: "Monitoring interval (flwi) must be between 1 and 600.",
+        },
+        {
+          line: 20,
+          column: 4,
+          length: 4,
+          message:
+            "Monitored file name (flwf) cannot use wildcard (*) when monitoring interval (flwi) is between 1 and 9.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error"],
+    );
+  });
+
   test("reports file monitoring diagnostics for explicit invalid condition combinations", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [


### PR DESCRIPTION
## What changed
Added grouped file-monitoring target-pattern diagnostics for `Flwj` / `Rflwj` in the shared editor-feedback boundary.

- report `flwf` when the monitored file name falls outside the JP1/AJS3 v13 `1..255` byte range
- report `flwi` when the monitoring interval falls outside `1..600`
- report wildcard `flwf` patterns when the effective `flwi` value is in the restricted `1..9` range
- add focused regression coverage for valid values, invalid ranges, and wildcard-with-short-interval combinations
- sync SDD records for the implemented slice

## Why it changed
The remaining JP1/AJS v13 parameter-alignment backlog was regrouped into user-meaningful slices. File monitoring still had a coherent validation family around `flwf` and `flwi`, so this change closes that grouped diagnostics gap without broadening into unrelated timeout or projection behavior.

## Impact
Users now get semantic diagnostics for explicit invalid file-monitoring target patterns while raw parser output, domain wrapper values, normalized parameters, unit-list projection, flow projection, and command generation stay unchanged.

## Root cause
The existing implementation preserved explicit `flwf` and `flwi` values as raw parsed data without editor feedback for documented JP1/AJS3 v13 constraints.

## Validation
- `rtk pnpm run qlty`
- `npm test`
- `rtk pnpm run test:web` (required escalated rerun after sandbox Chromium Mach port failure)
- `rtk pnpm run build`
- `rtk pnpm run lint:md`