### PR TITLE
[codex] Align event-host diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -147,6 +147,15 @@ Scenario: Event reception monitoring identifiers must stay within documented
   When editor feedback is requested
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
+
+Scenario: Event host values must stay within documented byte-length rules
+  Given a syntactically valid JP1/AJS document with a JP1 event sending job
+    or JP1 event reception monitoring job
+  And explicit `evhst` is outside the JP1/AJS3 v13 byte-length range
+    `1..255`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
@@ -2,11 +2,12 @@
 
 ## Purpose
 
-Record the JP1/AJS3 version 13 alignment status and next grouped validation
-candidate for JP1 event reception monitoring job semantic diagnostics.
+Record the JP1/AJS3 version 13 alignment status and remaining grouped
+validation candidate for JP1 event reception monitoring job semantic
+diagnostics.
 
-This document covers the delivered `evesc` diagnostic slice and the next
-grouped validation candidate for `Evwj` / `Revwj`.
+This document covers the delivered `evesc`, `evwid`, and `evipa` diagnostic
+slices plus the remaining grouped follow-up for `Evwj` / `Revwj`.
 
 ## Normative Reference
 
@@ -28,9 +29,9 @@ grouped validation candidate for `Evwj` / `Revwj`.
 - Out of scope:
   parser grammar changes, domain wrapper normalization, unit-list projection
   changes, flow projection changes, command generation, generated artifacts,
-  dependency changes, `engines.vscode`, `evhst` byte-length validation,
-  host-name validation, regular-expression validation, macro-variable
-  validation, and broad event-job validation
+  dependency changes, `engines.vscode`, shared `evhst` byte-length
+  validation, broader string-filter validation, and broad event-job
+  validation
 
 ## Investigation Notes
 
@@ -47,6 +48,10 @@ grouped validation candidate for `Evwj` / `Revwj`.
   the range `00000000:00000000` to `FFFFFFFF:FFFFFFFF`.
 - The JP1/AJS3 v13 manual states that `evipa` accepts IPv4 dotted-decimal
   addresses in the range `0.0.0.0` to `255.255.255.255`.
+- The same manual also states that `evhst` accepts a character string of
+  `1..255` bytes and allows both regular-expression and macro-variable forms,
+  which makes the remaining `evhst` follow-up a better shared event-host
+  slice than a job-local literal-hostname check.
 - Existing raw projection evidence includes `evwid=EV-1;` in
   `buildUnitListView.test.ts`, which confirms that editor diagnostics can be
   tightened without changing raw unit-list projection.
@@ -73,32 +78,26 @@ grouped validation candidate for `Evwj` / `Revwj`.
 - Raw parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation remain unchanged.
 
-## Proposed Next Grouped Slice
+## Delivered EVWID / EVIPA Slice
 
-- Report a semantic diagnostic when an explicit JP1 event reception monitoring
-  job or recovery JP1 event reception monitoring job sets `evwid` to a value
-  outside the hexadecimal event-ID format and range
+- Explicit JP1 event reception monitoring job and recovery JP1 event
+  reception monitoring job `evwid` values now report a semantic diagnostic
+  when they fall outside the hexadecimal event-ID format and range
   `00000000:00000000` to `FFFFFFFF:FFFFFFFF`.
-- Report a semantic diagnostic when an explicit JP1 event reception monitoring
-  job or recovery JP1 event reception monitoring job sets `evipa` to a value
+- Explicit `evipa` values now report a semantic diagnostic when they fall
   outside the IPv4 dotted-decimal range `0.0.0.0` to `255.255.255.255`.
-- Treat both rules as application-level format validations owned by
-  `buildSyntaxDiagnostics.ts`, preserving raw parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection, and
-  command generation.
-- Keep omitted `evwid` and `evipa` non-diagnostic.
-- Treat one to eight hexadecimal digits per `evwid` segment as valid when the
-  value stays within the documented range, because the manual defines a
-  hexadecimal range but does not explicitly require zero-padded eight-digit
-  segments.
-- Point diagnostics at the explicit `evwid` and `evipa` parameters so parser
-  and DTO shapes remain unchanged.
+- Omitted `evwid` and `evipa` values remain non-diagnostic.
+- One to eight hexadecimal digits per `evwid` segment remain accepted when
+  the value stays inside the documented range, because the manual defines a
+  hexadecimal range rather than a fixed-width token requirement.
+- Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.
 
 ## Impact
 
-- User-visible diagnostics would change for syntactically valid JP1/AJS
-  documents containing explicit invalid event IDs or event source IP
-  addresses on `evwj` / `revwj`.
+- User-visible diagnostics changed for syntactically valid JP1/AJS documents
+  containing explicit invalid event IDs or event source IP addresses on
+  `evwj` / `revwj`.
 - Existing parsed parameter source-location metadata should be enough to point
   diagnostics at explicit `evwid` and `evipa`, so no parser or DTO shape
   change is expected.
@@ -113,15 +112,16 @@ grouped validation candidate for `Evwj` / `Revwj`.
   slice because the current diagnostics policy preserves raw manual-invalid
   values.
 - Keep `evwid` and `evipa` as separate micro-slices, rejected because this
-  job type already has multiple related deferred validations and the user asked
-  for grouped fixes by job type or category where practical.
-- Broaden the slice further to `evhst` or message/regular-expression
-  validation, deferred because that increases behavior and regression surface
-  due to regex and macro-variable allowances.
+  job type already had multiple related deferred validations and the user
+  asked for grouped fixes by job type or category where practical.
+- Broaden the delivered slice further to `evhst` or
+  message/regular-expression validation, deferred because that increases
+  behavior and regression surface due to regex and macro-variable allowances.
 
 ## Follow-up
 
-- Revisit event reception monitoring job host-name byte-length,
-  regular-expression, macro-variable, and broader string-filter validation
-  after the grouped `evwid` / `evipa` diagnostics slice is completed or
-  explicitly deferred.
+- Shared grouped event-host validation now aligns explicit `evhst`
+  byte-length diagnostics through the existing editor-feedback boundary while
+  preserving regular-expression and macro-variable allowance.
+- Revisit broader event reception monitoring job string-filter validation only
+  after the shared `evhst` follow-up is completed or explicitly deferred.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_SEND_JOB_ALIGNMENT.md
@@ -242,6 +242,9 @@ parameters `evssv`, `evsrt`, `evspl`, and `evsrc` for `Evsj` / `Revsj`.
 
 ## Follow-up
 
-- Revisit `evhst` byte-length, macro-variable, or host-name validation only
-  after the focused `evsid` diagnostics slice is completed or explicitly
-  deferred.
+- Shared grouped event-host validation now aligns explicit `evhst`
+  byte-length diagnostics through the existing editor-feedback boundary while
+  preserving macro-variable allowance.
+- Revisit broader `evhst` host-name or string-shape validation only if a later
+  JP1/AJS v13 slice explicitly broadens scope beyond the approved byte-length
+  rule.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -109,8 +109,10 @@ coverage.
   unit-list group 14 default-aware projection is aligned for these defaults;
   `evhst` requiredness diagnostics are aligned through editor-feedback;
   `evspl` / `evsrc` range diagnostics are aligned through editor-feedback;
-  `evsid` hexadecimal diagnostics are aligned through editor-feedback; other
-  event-job validation remains deferred
+  `evsid` hexadecimal diagnostics are aligned through editor-feedback; shared
+  `evhst` byte-length validation is aligned through editor-feedback while
+  preserving macro-variable allowance; other event-job validation remains
+  deferred
 
 ### File Monitoring Job Defaults
 
@@ -160,10 +162,10 @@ coverage.
 - Evidence: `buildSyntaxDiagnostics.test.ts`
 - Remaining gap:
   `evesc` range diagnostics plus grouped `evwid` event-ID and `evipa` IPv4
-  validation are aligned through editor-feedback. `evhst` byte-length
-  validation, host-name validation, regular-expression validation,
-  macro-variable validation, and broader event-job validation remain
-  deferred.
+  validation are aligned through editor-feedback. Shared `evhst`
+  byte-length validation is aligned through editor-feedback while preserving
+  regular-expression and macro-variable allowance. Broader event-job
+  string-filter validation remains deferred.
 
 ## Boundary Decisions
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -200,6 +200,15 @@ JP1/AJS3 version 13 reference documents.
   `255.255.255.255`, while raw parser output, domain wrapper values,
   normalized parameters, unit-list projection, flow projection, and command
   generation remain unchanged.
+- Event-host `evhst` validation is approval-sensitive because the same
+  parameter name appears in both JP1 event sending jobs and JP1 event
+  reception monitoring jobs, but the documented allowances differ by job
+  family. A grouped follow-up should stay inside application editor-feedback,
+  enforce the documented `1..255` byte-length rule for explicit values, keep
+  event-sending macro-variable allowance visible, keep event-reception
+  regular-expression and macro-variable allowances visible, and preserve raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -89,6 +89,14 @@
 - [x] Add focused regression evidence for explicit valid and invalid `flwf`
       / `flwi` values and wildcard-with-short-interval combinations
 - [x] Run required code-change validation after implementation
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      event-host validation for `evhst` across JP1 event sending and JP1
+      event reception monitoring jobs
+- [x] Implement grouped event-host validation only after approval
+- [x] Add focused regression evidence for explicit valid and invalid `evhst`
+      values across both event-job families
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -300,22 +308,57 @@
   `flwi` remain non-diagnostic, raw parser output, domain wrapper values,
   normalized parameters, unit-list projection, flow projection, and command
   generation remain unchanged, and `ets` timeout behavior remains deferred.
+- 2026-05-07: Remaining JP1/AJS v13 parameter-alignment gaps were re-grouped
+  again by user-meaningful job type or parameter family after the delivered
+  file-monitoring target-pattern slice. The recommended next approval-gated
+  candidate is grouped event-host validation for `evhst` across JP1 event
+  sending and JP1 event reception monitoring jobs, centered on the documented
+  `1..255` byte-length rule plus the existing macro-variable or
+  regular-expression allowances through the existing editor-feedback
+  boundary while preserving raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation. Parser grammar, broader event-job string-filter validation,
+  generated artifacts, configuration, dependency versions, and
+  `engines.vscode` remain out of scope.
+- 2026-05-07: Grouped event-host validation now reports explicit out-of-range
+  `evhst` values across JP1 event sending and JP1 event reception monitoring
+  jobs when the byte length falls outside `1..255`, through the existing
+  editor-feedback boundary. Existing macro-variable allowance for event
+  sending jobs and regular-expression or macro-variable allowance for event
+  reception monitoring jobs remain preserved because the slice adds no
+  string-shape validation. Raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-07
-- Approved scope: grouped file-monitoring target-pattern validation for
-  `Flwj` / `Rflwj` through the existing editor-feedback boundary, limited to
-  `flwf` byte-length, `flwi` numeric range, and wildcard-with-short-interval
-  diagnostics, while preserving raw parser output, domain wrapper values,
-  normalized parameters, unit-list projection, flow projection, and command
-  generation.
+- Approved scope: grouped event-host validation for `evhst` across JP1 event
+  sending and JP1 event reception monitoring jobs through the existing
+  editor-feedback boundary, limited to the documented `1..255` byte-length
+  rule plus the existing macro-variable or regular-expression allowances,
+  while preserving raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation.
 
-Current implementation gate: grouped file-monitoring target-pattern validation
-is approved for implementation inside the recorded scope.
+Current implementation gate: grouped event-host validation for `evhst` is
+approved for implementation inside the recorded scope.
 
 ## Prior Approval Evidence
+
+- 2026-05-07: User replied "Approved. Proceed with implementation." after the
+  grouped event-host validation approval request. Approved changes were
+  limited to adding grouped application-level semantic diagnostics for
+  explicit `evhst` values across JP1 event sending and JP1 event reception
+  monitoring jobs through the existing editor-feedback boundary, limited to
+  the documented `1..255` byte-length rule while preserving existing
+  macro-variable or regular-expression allowances; preserving raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation; adding focused regression
+  evidence; updating SDD tracking; and running validation. Parser grammar,
+  broader event-job string-filter validation, generated artifacts,
+  configuration, dependency versions, and `engines.vscode` were out of
+  scope.
 
 - 2026-05-07: User replied "Approved. Proceed with implementation." after the
   grouped file-monitoring target-pattern validation approval request.
@@ -539,6 +582,21 @@ is approved for implementation inside the recorded scope.
 
 ## Validation
 
+- 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  event-host validation implementation
+- 2026-05-07: `rtk pnpm test` completed with exit code 0; the VS Code harness
+  emitted an existing macOS `task_name_for_pid` codesign noise line
+- 2026-05-07: `rtk pnpm run test:web` completed with exit code 0 and existing
+  localhost dev-extension `package.nls.json` 404 noise after grouped
+  event-host validation implementation
+- 2026-05-07: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped event-host validation implementation
+- 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after grouped
+  event-host validation implementation
+- 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after the
+  docs-only event-host regrouping investigation
+- 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after the
+  docs-only event-host regrouping investigation
 - 2026-05-07: `pnpm run qlty` completed with exit code 0 after the
   file-monitoring target-pattern diagnostics implementation
 - 2026-05-07: `npm test` completed with exit code 0

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -24,11 +24,10 @@ rules in `docs/specs/README.md`, not in this file.
   user-meaningful job type or parameter family where practical, instead of
   returning to single-parameter micro-slices once a family has shared seams
   and shared regression evidence.
-- After the delivered schedule-rule range diagnostics, the next recommended
-  JP1/AJS v13 slice is grouped file-monitoring target-pattern validation for
-  `Flwj` / `Rflwj`, centered on `flwf` / `flwi` byte-length, numeric range,
-  and wildcard-with-short-interval rules through the existing editor-feedback
-  boundary.
+- After the delivered grouped event-host validation for `evhst`, the next
+  recommended JP1/AJS v13 slice should again be selected from the remaining
+  partial or deferred gaps using the same user-meaningful job type or
+  parameter-family grouping rule.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -48,8 +47,8 @@ rules in `docs/specs/README.md`, not in this file.
 
 1. Request approval for the next grouped JP1/AJS3 v13 parameter-alignment
    slice selected from the remaining partial or deferred gaps after the
-   delivered file-monitoring target-pattern validation, keeping the grouping
-   by job type or parameter family.
+   delivered grouped event-host validation, keeping the grouping by job type
+   or parameter family.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -122,7 +121,7 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped file-monitoring target-pattern validation is implemented and
+  slice: grouped event-host validation for `evhst` is implemented and
   validated; the next candidate should be selected from the remaining
   partial/deferred gaps using the same user-meaningful grouping rule.
 - `docs/specs/features/import-definition-via-webapi/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -162,6 +162,18 @@ const isValidExplicitFileMonitoringFileName = (
   return byteLength >= 1 && byteLength <= 255;
 };
 
+const isValidExplicitEventHostValue = (
+  parameter: UnitParameter | undefined,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (rawValue === undefined) {
+    return false;
+  }
+
+  const byteLength = getByteLength(rawValue);
+  return byteLength >= 1 && byteLength <= 255;
+};
+
 const isValidExplicitFileMonitoringInterval = (
   parameter: UnitParameter | undefined,
 ): boolean => parseExplicitDecimalInRange(parameter, 1, 600) !== undefined;
@@ -493,6 +505,11 @@ const fileMonitoringDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
 
 const eventSendingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
   {
+    key: "evhst",
+    message: "Event host (evhst) must be between 1 and 255 bytes.",
+    isInvalid: (parameter) => !isValidExplicitEventHostValue(parameter),
+  },
+  {
     key: "evsid",
     message:
       "Event ID (evsid) must be hexadecimal within 00000000-00001FFF or 7FFF8000-7FFFFFFF.",
@@ -531,6 +548,11 @@ const eventSendingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
 ];
 
 const eventReceivingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
+  {
+    key: "evhst",
+    message: "Event host (evhst) must be between 1 and 255 bytes.",
+    isInvalid: (parameter) => !isValidExplicitEventHostValue(parameter),
+  },
   {
     key: "evwid",
     message:

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -937,6 +937,34 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("does not report event-host diagnostics for valid explicit evhst values", () => {
+    const sendingHost = "a".repeat(255);
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=event1,evsj,+0+0;",
+        "  el=wait1,evwj,+160+0;",
+        "  unit=event1,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        `    evhst=${sendingHost};`,
+        "    evsrt=y;",
+        "  }",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evhst=*;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
   test("does not report event receiving diagnostics for omitted defaults and valid explicit values", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [
@@ -1067,6 +1095,85 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(
       diagnostics.map((diagnostic) => diagnostic.severity),
       ["error", "error", "error", "error", "error"],
+    );
+  });
+
+  test("reports event-host diagnostics for explicit out-of-range evhst values", () => {
+    const oversizedHost = "a".repeat(256);
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=event1,evsj,+0+0;",
+        "  el=event2,revsj,+160+0;",
+        "  el=wait1,evwj,+320+0;",
+        "  el=wait2,revwj,+480+0;",
+        "  unit=event1,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        `    evhst=${oversizedHost};`,
+        "    evsrt=y;",
+        "  }",
+        "  unit=event2,,jp1admin,;",
+        "  {",
+        "    ty=revsj;",
+        `    evhst=${oversizedHost};`,
+        "    evsrt=y;",
+        "  }",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        `    evhst=${oversizedHost};`,
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        `    evhst=${oversizedHost};`,
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 4);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 5,
+          message: "Event host (evhst) must be between 1 and 255 bytes.",
+        },
+        {
+          line: 15,
+          column: 4,
+          length: 5,
+          message: "Event host (evhst) must be between 1 and 255 bytes.",
+        },
+        {
+          line: 21,
+          column: 4,
+          length: 5,
+          message: "Event host (evhst) must be between 1 and 255 bytes.",
+        },
+        {
+          line: 26,
+          column: 4,
+          length: 5,
+          message: "Event host (evhst) must be between 1 and 255 bytes.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error", "error"],
     );
   });
 });


### PR DESCRIPTION
## What changed
- add grouped editor-feedback diagnostics for explicit `evhst` values outside the JP1/AJS v13 `1..255` byte range
- cover both JP1 event sending and JP1 event reception monitoring jobs while preserving existing macro-variable and regular-expression allowances
- update SDD tracking docs and editor-feedback use-case notes for the delivered slice

## Why
- the remaining JP1/AJS v13 alignment work is being completed in user-meaningful job-type or parameter-family slices
- `evhst` was the next shared event-host gap across event job families

## Validation
- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`