### PR TITLE
[codex] add job end threshold ordering diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -94,6 +94,15 @@ Scenario: Job end-judgment numeric values must stay within documented ranges
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Job end-judgment thresholds must preserve warning-to-abnormal order
+  Given a syntactically valid JP1/AJS document with a UNIX/PC job
+  And effective `jd` is judgment by threshold
+  And explicit `wth` and `tho` do not preserve the documented warning-to-
+    abnormal threshold ordering
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Schedule-rule values must stay within documented ranges
   Given a syntactically valid JP1/AJS document with a jobnet
   And explicit `ln`, `st`, `cy`, `shd`, `cftd`, `sy`, `ey`, `wc`, or `wt`

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
@@ -15,10 +15,12 @@ This document covers the implemented behavior for `jd`, `wth`, `tho`, `jdf`,
   - Command Reference, `5.2.6 UNIX/PC job definition`
   - Command Reference, `5.2.24 UNIX/PC custom job definition`
   - Command Reference, `ajsprint`, default values table
+  - System Design (Work Tasks) Guide, `2.1.4 Job definition considerations`
 - Source URLs:
   - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0221.HTM>
   - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0239.HTM>
   - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0121.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4410e/AJSG0015.HTM>
 
 ## Slice Boundary
 
@@ -40,8 +42,8 @@ This document covers the implemented behavior for `jd`, `wth`, `tho`, `jdf`,
   `src/test/suite/jobEndJudgmentHelpers.test.ts`, and
   `src/test/suite/buildSyntaxDiagnostics.test.ts`
 - Out of scope:
-  parser grammar changes, byte-length validation, numeric range validation,
-  retry threshold ordering, and command-generation changes
+  parser grammar changes, byte-length validation, and command-generation
+  changes
 
 ## Shared Expectations
 
@@ -99,7 +101,7 @@ This document covers the implemented behavior for `jd`, `wth`, `tho`, `jdf`,
 - Raw parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation remain unchanged.
 
-## Proposed Next Grouped Slice
+## Delivered Numeric Range Slice
 
 - Report semantic diagnostics when an explicit UNIX/PC job or UNIX/PC custom
   job sets `wth` or `tho` outside the JP1/AJS3 v13 range
@@ -142,6 +144,56 @@ This document covers the implemented behavior for `jd`, `wth`, `tho`, `jdf`,
 
 ## Follow-up
 
-- Implement grouped numeric range validation first, then revisit retry
-  threshold ordering as a separate approval-gated slice if the grouped numeric
-  diagnostics land cleanly.
+- Revisit explicit `wth` / `tho` threshold ordering as the next approval-gated
+  slice inside the existing job end-judgment diagnostics boundary.
+
+## Delivered Numeric Range Validation
+
+- The editor-feedback boundary now reports semantic diagnostics when explicit
+  UNIX/PC job or UNIX/PC custom job values fall outside the JP1/AJS3 v13
+  ranges for `wth`, `tho`, `rjs`, `rje`, `rec`, and `rei`.
+- Omitted values remain non-diagnostic, preserving the existing default-aware
+  wrapper semantics.
+- Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.
+
+## Proposed Next Grouped Slice
+
+- Report semantic diagnostics when an explicit UNIX/PC job or UNIX/PC custom
+  job sets `wth` and `tho` in an order that does not preserve the documented
+  warning-to-abnormal threshold progression.
+- Treat the rule as application-level threshold-ordering validation owned by
+  `buildSyntaxDiagnostics.ts`, preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation.
+- Keep omitted thresholds non-diagnostic so the existing wrapper behavior
+  remains unchanged.
+- Point each diagnostic at the explicit threshold parameter or parameters so
+  parser and DTO shapes remain unchanged.
+
+## Threshold-Ordering Note
+
+- The official JP1/AJS3 v13 end-judgment description explains that a job ends
+  normally below the warning threshold, ends with a warning between the
+  warning and abnormal thresholds, and ends abnormally beyond the abnormal
+  threshold.
+- This feature therefore treats threshold ordering as a semantic
+  application-level rule. The precise invalid pattern is expected to be
+  confirmed during implementation as part of the approved scope; if the
+  product behavior appears to allow an edge case that contradicts this
+  interpretation, return to investigation and approval before changing the
+  scope.
+
+## Delivered Threshold-Ordering Validation
+
+- The editor-feedback boundary now reports semantic diagnostics when explicit
+  UNIX/PC job or UNIX/PC custom job `wth` / `tho` pairs do not preserve the
+  documented warning-to-abnormal threshold progression.
+- This validation stays narrow to the approved scope: it runs when effective
+  `jd=cod`, both thresholds are explicitly present, and both values already
+  satisfy the delivered numeric range rules.
+- Omitted thresholds, out-of-range thresholds already handled by numeric range
+  diagnostics, and non-`cod` end-judgment modes remain outside this delivered
+  ordering slice.
+- Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -80,7 +80,9 @@ coverage.
   editor-feedback. Retry-parameter diagnostics for effective non-`cod` end
   judgment are aligned through editor-feedback. Retry-parameter diagnostics for
   effective non-`y` automatic retry are aligned through editor-feedback.
-  Numeric range validation and retry threshold ordering remain deferred.
+  Numeric range validation is aligned through editor-feedback. Threshold-
+  ordering diagnostics for explicit `wth` / `tho` pairs are aligned through
+  editor-feedback when effective `jd=cod`.
 
 ### HTTP Connection Job Defaults
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -140,6 +140,16 @@ JP1/AJS3 version 13 reference documents.
   report these explicit invalid combinations through editor-feedback while
   preserving raw parser output, domain wrapper values, normalized parameters,
   unit-list projection, flow projection, and command generation.
+- Job end-judgment threshold-ordering diagnostics are approval-sensitive
+  because existing behavior preserves explicit `wth` / `tho` pairs without
+  semantic feedback. A focused diagnostic slice should stay inside
+  application editor-feedback and report explicit threshold pairs that do not
+  preserve the documented warning-to-abnormal ordering while preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation. This ordering rule is
+  inferred from the official JP1/AJS3 v13 description that normal ends fall
+  below the warning threshold, warning ends fall between the warning and
+  abnormal thresholds, and abnormal ends exceed the abnormal threshold.
 - JP1 event sending job `evhst` requiredness diagnostics are aligned through
   application editor-feedback. Explicit `evsrt=y` on `evsj` / `revsj` now
   reports a semantic diagnostic when `evhst` is omitted, while raw parser

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -97,6 +97,17 @@
 - [x] Add focused regression evidence for explicit valid and invalid `evhst`
       values across both event-job families
 - [x] Run required code-change validation after implementation
+- [x] Re-group the remaining JP1/AJS v13 parameter-alignment backlog around
+      user-meaningful job types or parameter families after the delivered
+      event-host slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      job end-judgment threshold-ordering diagnostics
+- [x] Implement grouped job end-judgment threshold-ordering diagnostics only
+      after approval
+- [x] Add focused regression evidence for explicit valid and invalid `wth` /
+      `tho` ordering
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -329,23 +340,59 @@
   string-shape validation. Raw parser output, domain wrapper values,
   normalized parameters, unit-list projection, flow projection, and command
   generation remain unchanged.
+- 2026-05-07: Remaining JP1/AJS v13 parameter-alignment gaps were re-grouped
+  again by user-meaningful job type or parameter family after the delivered
+  event-host slice. The recommended next approval-gated candidate is grouped
+  job end-judgment threshold-ordering diagnostics for UNIX/PC jobs and UNIX/PC
+  custom jobs, centered on explicit `wth` / `tho` pairs through the existing
+  editor-feedback boundary while preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation. Parser grammar, domain default behavior, numeric range
+  diagnostics already delivered, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` remain out of scope.
+- 2026-05-07: Grouped job end-judgment threshold-ordering diagnostics now
+  report explicit `wth` / `tho` pairs on UNIX/PC jobs and UNIX/PC custom jobs
+  when effective `jd=cod` and the threshold values do not preserve the
+  documented warning-to-abnormal ordering. Omitted thresholds remain
+  non-diagnostic, out-of-range thresholds continue to be owned by the existing
+  numeric range diagnostics, and raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, command
+  generation, generated artifacts, configuration, dependency versions, and
+  `engines.vscode` remain unchanged.
+- 2026-05-07: The grouped job end-judgment threshold-ordering slice is now
+  implemented and validated on `codex/job-end-threshold-ordering`. The next
+  JP1/AJS v13 parameter-alignment candidate should be re-selected from the
+  remaining partial or deferred gaps using the same user-meaningful job-type
+  or parameter-family grouping rule.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-07
-- Approved scope: grouped event-host validation for `evhst` across JP1 event
-  sending and JP1 event reception monitoring jobs through the existing
-  editor-feedback boundary, limited to the documented `1..255` byte-length
-  rule plus the existing macro-variable or regular-expression allowances,
-  while preserving raw parser output, domain wrapper values, normalized
-  parameters, unit-list projection, flow projection, and command generation.
+- Approved scope: grouped job end-judgment threshold-ordering diagnostics for
+  explicit `wth` / `tho` pairs on UNIX/PC jobs and UNIX/PC custom jobs
+  through the existing editor-feedback boundary, keeping the slice narrow to
+  semantic diagnostics while preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation.
 
-Current implementation gate: grouped event-host validation for `evhst` is
-approved for implementation inside the recorded scope.
+Current implementation gate: grouped job end-judgment threshold-ordering
+diagnostics for explicit `wth` / `tho` pairs is approved for implementation
+inside the recorded scope.
 
 ## Prior Approval Evidence
 
+- 2026-05-07: User replied "Approved. Proceed with implementation." after the
+  grouped job end-judgment threshold-ordering diagnostics approval request.
+  Approved changes were limited to adding grouped application-level semantic
+  diagnostics for explicit UNIX/PC jobs and UNIX/PC custom jobs where `wth`
+  and `tho` do not preserve documented threshold ordering; preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation; adding focused
+  regression evidence; updating SDD tracking; and running validation. Parser
+  grammar, domain default behavior, numeric range diagnostics already
+  delivered, generated artifacts, configuration, dependency versions, and
+  `engines.vscode` were out of scope.
 - 2026-05-07: User replied "Approved. Proceed with implementation." after the
   grouped event-host validation approval request. Approved changes were
   limited to adding grouped application-level semantic diagnostics for
@@ -597,6 +644,19 @@ approved for implementation inside the recorded scope.
   docs-only event-host regrouping investigation
 - 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after the
   docs-only event-host regrouping investigation
+- 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  job end-judgment threshold-ordering diagnostics implementation
+- 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped job
+  end-judgment threshold-ordering diagnostics implementation; the VS Code
+  harness emitted the existing macOS `task_name_for_pid` codesign noise line
+- 2026-05-07: `rtk pnpm run test:web` completed with exit code 0 after grouped
+  job end-judgment threshold-ordering diagnostics implementation and emitted
+  the existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-07: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped job end-judgment threshold-ordering diagnostics
+  implementation
+- 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after grouped
+  job end-judgment threshold-ordering diagnostics implementation
 - 2026-05-07: `pnpm run qlty` completed with exit code 0 after the
   file-monitoring target-pattern diagnostics implementation
 - 2026-05-07: `npm test` completed with exit code 0

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -25,9 +25,13 @@ rules in `docs/specs/README.md`, not in this file.
   returning to single-parameter micro-slices once a family has shared seams
   and shared regression evidence.
 - After the delivered grouped event-host validation for `evhst`, the next
-  recommended JP1/AJS v13 slice should again be selected from the remaining
-  partial or deferred gaps using the same user-meaningful job type or
-  parameter-family grouping rule.
+  recommended JP1/AJS v13 slice stayed inside the already-modeled job
+  end-judgment family and tackled threshold ordering for explicit `wth` /
+  `tho` pairs before expanding to broader new parameter families.
+- After the delivered grouped job end-judgment threshold-ordering slice, the
+  next recommended JP1/AJS v13 candidate should again be selected from the
+  remaining partial or deferred gaps using the same user-meaningful grouping
+  rule.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -47,8 +51,8 @@ rules in `docs/specs/README.md`, not in this file.
 
 1. Request approval for the next grouped JP1/AJS3 v13 parameter-alignment
    slice selected from the remaining partial or deferred gaps after the
-   delivered grouped event-host validation, keeping the grouping by job type
-   or parameter family.
+   delivered job end-judgment threshold-ordering diagnostics, keeping the
+   grouping by job type or parameter family.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -61,38 +65,38 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/file-monitoring-target-pattern-validation`
+- Branch: `codex/job-end-threshold-ordering`
 - Objective: continue JP1/AJS v13 parameter alignment with a user-meaningful
-  grouped slice around file-monitoring target-pattern validation for
-  `Flwj` / `Rflwj`, rather than reopening the feature through another
-  single-parameter fix.
-- Status: implemented and validated on
-  `codex/file-monitoring-target-pattern-validation`.
-- Scope: add focused file-monitoring semantic diagnostics for explicit
-  monitored-file and monitoring-interval constraints through the existing
-  editor-feedback boundary, covering `flwf` byte-length, `flwi` numeric range,
-  and wildcard-with-short-interval invalid combinations while preserving raw
+  grouped slice around job end-judgment threshold-ordering diagnostics for
+  UNIX/PC jobs and UNIX/PC custom jobs, rather than opening a broader new job
+  family before closing the remaining focused follow-up in the existing
+  end-judgment diagnostics seam.
+- Status: implemented and validated on `codex/job-end-threshold-ordering`.
+- Scope: add focused semantic diagnostics through the existing
+  editor-feedback boundary when explicit `wth` / `tho` pairs do not preserve
+  the documented warning-to-abnormal threshold ordering, while preserving raw
   parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation.
-- Out of scope: parser grammar changes, domain default changes, unit-list
-  projection changes, `flwc` / `flco` diagnostics already delivered, `ets`
-  timeout behavior, generated artifacts, dependency changes,
-  `engines.vscode`, and non-file-monitoring parameter validation.
+- Out of scope: parser grammar changes, domain default changes, numeric range
+  diagnostics already delivered, retry-parameter diagnostics already
+  delivered, generated artifacts, dependency changes, `engines.vscode`, and
+  non-end-judgment parameter validation.
 - Impact summary: the next slice is expected to affect
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
-  file-monitoring diagnostics tests, the file-monitoring alignment record, and
-  the editor-feedback behavior contract if the new diagnostics are approved.
-- Risks and assumptions: the file-monitoring manual couples `flwf` wildcard
-  usage and `flwi` short intervals, so the remaining work is best treated as a
-  single parameter-family validation slice instead of separate key-level
-  checks. Existing parameter source-location metadata is assumed to be
-  sufficient to point diagnostics at explicit `flwf` / `flwi` parameters
-  without parser or DTO changes.
-- Alternatives considered: switch to another job type first, viable but
-  deferred because file monitoring still has a coherent deferred validation
-  family after its delivered defaults and invalid-combination diagnostics;
-  split `flwf` and `flwi` into micro-slices, rejected because the manual
-  defines a shared wildcard/interval rule across those parameters.
+  job-end-judgment diagnostics tests, the job-end-judgment alignment record,
+  the coverage matrix, and the editor-feedback behavior contract if the new
+  diagnostics are approved.
+- Risks and assumptions: the official JP1/AJS3 v13 end-judgment description is
+  interpreted to require a warning threshold below the abnormal threshold so
+  that normal, warning, and abnormal outcomes remain distinguishable. If
+  implementation investigation finds product behavior that permits an edge
+  case such as equal thresholds, stop and re-approve before broadening or
+  changing the rule.
+- Alternatives considered: switch to a different job type first, viable but
+  deferred because job end judgment already has an established diagnostics seam
+  and one coherent remaining follow-up; move directly to broader event or
+  transfer-parameter validation, rejected for now because that increases scope
+  before this narrower family-level gap is closed.
 
 ## Build/Test Performance SDD
 
@@ -121,8 +125,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped event-host validation for `evhst` is implemented and
-  validated; the next candidate should be selected from the remaining
+  slice: grouped job end-judgment threshold-ordering diagnostics for explicit
+  `wth` / `tho` pairs on UNIX/PC jobs and UNIX/PC custom jobs is implemented
+  and validated; the next candidate should be selected from the remaining
   partial/deferred gaps using the same user-meaningful grouping rule.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -87,6 +87,25 @@ const parseExplicitDecimalInRange = (
     : undefined;
 };
 
+const hasInvalidExplicitThresholdOrdering = (unit: Unit): boolean => {
+  const warningThreshold = parseExplicitDecimalInRange(
+    findParameter(unit, "wth"),
+    0,
+    2147483647,
+  );
+  const abnormalThreshold = parseExplicitDecimalInRange(
+    findParameter(unit, "tho"),
+    0,
+    2147483647,
+  );
+
+  if (warningThreshold === undefined || abnormalThreshold === undefined) {
+    return false;
+  }
+
+  return warningThreshold >= abnormalThreshold;
+};
+
 const parseExplicitHexadecimalInRange = (
   value: string | undefined,
   minimum: number,
@@ -652,9 +671,34 @@ const buildJobEndJudgmentDiagnostics = (
         jobEndJudgmentNumericRangeRules,
       );
       const abrParameter = findParameter(unit, "abr");
+      const warningThresholdParameter = findParameter(unit, "wth");
+      const abnormalThresholdParameter = findParameter(unit, "tho");
       const effectiveJobEndJudgment =
         findParameter(unit, "jd")?.value ?? DEFAULTS.Jd;
       const effectiveAutomaticRetry = abrParameter?.value ?? DEFAULTS.Abr;
+
+      if (
+        effectiveJobEndJudgment === DEFAULTS.Jd &&
+        hasInvalidExplicitThresholdOrdering(unit)
+      ) {
+        if (warningThresholdParameter) {
+          diagnostics.push(
+            buildDiagnostic(
+              warningThresholdParameter,
+              "Warning threshold (wth) must be less than abnormal threshold (tho).",
+            ),
+          );
+        }
+
+        if (abnormalThresholdParameter) {
+          diagnostics.push(
+            buildDiagnostic(
+              abnormalThresholdParameter,
+              "Abnormal threshold (tho) must be greater than warning threshold (wth).",
+            ),
+          );
+        }
+      }
 
       if (effectiveJobEndJudgment !== DEFAULTS.Jd) {
         if (abrParameter?.value === "y") {

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -494,6 +494,114 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("does not report threshold-ordering diagnostics for omitted or ordered explicit end-judgment thresholds", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=job2,cj,+160+0;",
+        "  el=job3,j,+320+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    jd=cod;",
+        "  }",
+        "  unit=job2,,jp1admin,;",
+        "  {",
+        "    ty=cj;",
+        "    jd=cod;",
+        "    wth=10;",
+        "    tho=20;",
+        "  }",
+        "  unit=job3,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    jd=ab;",
+        "    wth=30;",
+        "    tho=10;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports threshold-ordering diagnostics for explicit invalid end-judgment thresholds", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=job2,cj,+160+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    jd=cod;",
+        "    wth=20;",
+        "    tho=10;",
+        "  }",
+        "  unit=job2,,jp1admin,;",
+        "  {",
+        "    ty=cj;",
+        "    jd=cod;",
+        "    wth=15;",
+        "    tho=15;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 4);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 10,
+          column: 4,
+          length: 3,
+          message:
+            "Warning threshold (wth) must be less than abnormal threshold (tho).",
+        },
+        {
+          line: 11,
+          column: 4,
+          length: 3,
+          message:
+            "Abnormal threshold (tho) must be greater than warning threshold (wth).",
+        },
+        {
+          line: 17,
+          column: 4,
+          length: 3,
+          message:
+            "Warning threshold (wth) must be less than abnormal threshold (tho).",
+        },
+        {
+          line: 18,
+          column: 4,
+          length: 3,
+          message:
+            "Abnormal threshold (tho) must be greater than warning threshold (wth).",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error", "error"],
+    );
+  });
+
   test("does not report file monitoring diagnostics for omitted defaults and valid explicit combinations", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [


### PR DESCRIPTION
## What changed
- add editor-feedback diagnostics for explicit UNIX/PC job and custom job wth / tho pairs that violate warning-to-abnormal threshold ordering
- add focused regression coverage for valid and invalid threshold-ordering cases
- update SDD artifacts and the editor-feedback use case to record the approved slice, delivery notes, and validation results

## Why
- JP1/AJS v13 parameter alignment still had a remaining job end-judgment gap after numeric range and retry diagnostics were delivered
- this closes the next user-meaningful slice in the existing end-judgment diagnostics seam without changing raw parser output or projections

## Impact
- syntactically valid JP1/AJS documents now surface semantic diagnostics when explicit wth / tho values are ordered incorrectly under effective jd=cod
- parser output, domain wrapper values, normalized parameters, unit-list projection, flow projection, and command generation remain unchanged

## Validation
- rtk pnpm run qlty
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
- rtk pnpm run lint:md