### PR TITLE
Align sd/cy schedule-rule diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -111,6 +111,15 @@ Scenario: Schedule-rule values must stay within documented ranges
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Weekly schedule cycles must not use open-day or closed-day dates
+  Given a syntactically valid JP1/AJS document with a jobnet
+  And explicit `cy=(n,w)` is specified for a schedule rule
+  And the matching `sd` rule for that schedule rule uses open-day or
+    closed-day scheduling semantics
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Event arrival check requires an event destination host
   Given a syntactically valid JP1/AJS document with a JP1 event sending job
   And effective `evsrt` is event-arrival checking enabled

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
@@ -123,5 +123,5 @@ slices plus the remaining grouped follow-up for `Evwj` / `Revwj`.
 - Shared grouped event-host validation now aligns explicit `evhst`
   byte-length diagnostics through the existing editor-feedback boundary while
   preserving regular-expression and macro-variable allowance.
-- Revisit broader event reception monitoring job string-filter validation only
-  after the shared `evhst` follow-up is completed or explicitly deferred.
+- Revisit broader event reception monitoring job string-filter validation as a
+  separate later slice now that the shared `evhst` follow-up is complete.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/JOB_END_JUDGMENT_ALIGNMENT.md
@@ -157,7 +157,7 @@ This document covers the implemented behavior for `jd`, `wth`, `tho`, `jdf`,
 - Raw parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation remain unchanged.
 
-## Proposed Next Grouped Slice
+## Historical Grouped Slice Plan
 
 - Report semantic diagnostics when an explicit UNIX/PC job or UNIX/PC custom
   job sets `wth` and `tho` in an order that does not preserve the documented

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -35,10 +35,12 @@ coverage.
   `buildUnitListView.test.ts`, and `buildSyntaxDiagnostics.test.ts`
 - Remaining gap:
   grouped range diagnostics are aligned for `ln`, `st`, `cy`, `shd`, `cftd`,
-  `sy`, `ey`, `wc`, and `wt` through editor-feedback. `sd` date/rule range
-  policy, `cy` open/closed-day restrictions, and any broader cross-parameter
-  invalidation remain deferred. `wc` / `wt` effective-value pairing is aligned
-  in the domain wrapper boundary and unit-list group 10 projection.
+  `sy`, `ey`, `wc`, and `wt` through editor-feedback. Grouped `sd` / `cy`
+  weekly-cycle compatibility for open-day and closed-day schedules is also
+  aligned through editor-feedback. `sd` date/rule range policy and any broader
+  cross-parameter invalidation remain deferred. `wc` / `wt` effective-value
+  pairing is aligned in the domain wrapper boundary and unit-list group 10
+  projection.
 
 ### Transfer Operation
 
@@ -46,7 +48,7 @@ coverage.
   `top1` to `top4`, with `ts1` to `ts4` and `td1` to `td4` presence
   checks
 - Unit scope: UNIX/PC jobs and UNIX/PC custom jobs
-- Status: aligned for default resolution
+- Status: partial
 - Owning seam:
   `transferOperationHelpers.ts` and `transferOperationParameterBuilders.ts`
 - Evidence: `parameterHelpers.test.ts` and `parameterFactory.test.ts`
@@ -58,7 +60,7 @@ coverage.
 
 - Keys: `ts1` to `ts4` and `td1` to `td4`
 - Unit scope: QUEUE jobs and recovery QUEUE jobs
-- Status: aligned for wrapper boundary
+- Status: partial
 - Owning seam: `Qj.ts` and `ParameterFactory.ts`
 - Evidence: `parameterFactory.test.ts`
 - Remaining gap:
@@ -70,19 +72,15 @@ coverage.
 - Keys: `jd`, `wth`, `tho`, `jdf`, and `abr`
 - Unit scope:
   UNIX/PC jobs, UNIX/PC custom jobs, and wrappers exposing end-judgment fields
-- Status: partial
+- Status: aligned
 - Owning seam:
   `jobEndJudgmentHelpers.ts`, `optionalScalarParameterBuilders.ts`, and
   `Defaults.ts`
-- Evidence: `parameterFactory.test.ts` and `jobEndJudgmentHelpers.test.ts`
+- Evidence:
+  `parameterFactory.test.ts`, `jobEndJudgmentHelpers.test.ts`, and
+  `buildSyntaxDiagnostics.test.ts`
 - Remaining gap:
-  `jd` / `abr` invalid-combination diagnostics are aligned through
-  editor-feedback. Retry-parameter diagnostics for effective non-`cod` end
-  judgment are aligned through editor-feedback. Retry-parameter diagnostics for
-  effective non-`y` automatic retry are aligned through editor-feedback.
-  Numeric range validation is aligned through editor-feedback. Threshold-
-  ordering diagnostics for explicit `wth` / `tho` pairs are aligned through
-  editor-feedback when effective `jd=cod`.
+  none for the currently modeled end-judgment fields in this feature scope
 
 ### HTTP Connection Job Defaults
 
@@ -103,18 +101,15 @@ coverage.
 - Keys: `evssv`, `evsrt`, `evspl`, and `evsrc`
 - Unit scope:
   JP1 event sending jobs and recovery JP1 event sending jobs
-- Status: partial
+- Status: aligned
 - Owning seam: `Evsj.ts`, `optionalScalarParameterBuilders.ts`, and
   `Defaults.ts`
-- Evidence: `parameterFactory.test.ts` and `buildUnitListView.test.ts`
+- Evidence:
+  `parameterFactory.test.ts`, `buildUnitListView.test.ts`, and
+  `buildSyntaxDiagnostics.test.ts`
 - Remaining gap:
-  unit-list group 14 default-aware projection is aligned for these defaults;
-  `evhst` requiredness diagnostics are aligned through editor-feedback;
-  `evspl` / `evsrc` range diagnostics are aligned through editor-feedback;
-  `evsid` hexadecimal diagnostics are aligned through editor-feedback; shared
-  `evhst` byte-length validation is aligned through editor-feedback while
-  preserving macro-variable allowance; other event-job validation remains
-  deferred
+  broader event-job validation outside the arrival-check keys in this row
+  remains deferred
 
 ### File Monitoring Job Defaults
 
@@ -157,17 +152,14 @@ coverage.
 - Unit scope:
   JP1 event reception monitoring jobs and recovery JP1 event reception
   monitoring jobs
-- Status: partial
+- Status: aligned
 - Owning seam:
   `Evwj.ts`, `optionalScalarParameterBuilders.ts`, and
   `buildSyntaxDiagnostics.ts`
 - Evidence: `buildSyntaxDiagnostics.test.ts`
 - Remaining gap:
-  `evesc` range diagnostics plus grouped `evwid` event-ID and `evipa` IPv4
-  validation are aligned through editor-feedback. Shared `evhst`
-  byte-length validation is aligned through editor-feedback while preserving
-  regular-expression and macro-variable allowance. Broader event-job
-  string-filter validation remains deferred.
+  broader event reception monitoring string-filter validation outside the
+  search-scope keys in this row remains deferred
 
 ## Boundary Decisions
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
@@ -148,7 +148,7 @@ and `wt`.
   `scheduleRuleHelpers.ts`, and unit-list projection no longer maintains a
   separate set of schedule-rule regular expressions.
 
-## Proposed Next Grouped Slice
+## Historical Grouped Slice Plan
 
 - Treat the next remaining schedule-rule work as one parameter-family slice for
   jobnets, not as a return to one-key diagnostics.
@@ -208,9 +208,27 @@ and `wt`.
 
 ## Follow-up
 
+- Grouped jobnet schedule-rule compatibility for `sd` / `cy` is now aligned
+  through `buildSyntaxDiagnostics.ts`. Explicit `cy=(n,w)` values now report a
+  semantic diagnostic when the matching `sd` rule for the same schedule rule
+  number uses open-day (`*`) or closed-day (`@`) scheduling semantics.
 - Revisit `sd` date/rule range policy separately because `sd=0,ud` handling
-  still carries a product-decision note outside this grouped diagnostics slice.
-- Revisit `cy` open/closed-day restrictions and any other cross-parameter
-  invalidation separately from the delivered single-parameter range checks.
+  and the `SCHEDULELIMIT`-dependent year range still carry product-decision
+  notes outside this grouped compatibility slice.
+- Revisit any broader schedule-rule cross-parameter invalidation separately if
+  implementation investigation reveals rules beyond the approved `sd` / `cy`
+  weekly-cycle restriction.
 - Apply this category-level parser alignment workflow to the next non-schedule
   parameter family before marking that category official-reference aligned.
+
+## Delivered SD / CY Compatibility Diagnostics
+
+- The editor-feedback boundary now reports semantic diagnostics for explicit
+  jobnet `cy=(n,w)` values when the matching `sd` rule for the same schedule
+  rule number uses open-day (`*`) or closed-day (`@`) scheduling semantics.
+- Diagnostics stay focused on explicit `cy` parameters and preserve raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation.
+- The delivered slice intentionally does not broaden into `sd` date-range
+  validation, `sd=0,ud` product policy, or broader schedule-rule
+  cross-parameter invalidation.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -80,6 +80,14 @@ JP1/AJS3 version 13 reference documents.
   diagnostics, while still preserving raw parser output, domain wrapper
   values, normalized parameters, unit-list projection, flow projection, and
   command generation unless a narrower approval explicitly broadens scope.
+- Schedule-rule `sd` / `cy` compatibility is approval-sensitive because
+  existing behavior preserves explicit weekly cycle values on open-day or
+  closed-day schedules as raw parsed data without editor feedback. A focused
+  follow-up should stay inside application editor-feedback, report explicit
+  `cy=(n,w)` values when the matching `sd` rule for the same schedule rule
+  number uses open-day (`*`) or closed-day (`@`) scheduling semantics, and
+  preserve raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
 - Unit-list group 10 `wc` / `wt` projection is a separate approval-sensitive
   boundary from domain interpretation because it is user-visible table output.
   If approved, it should consume the existing paired effective-value semantics

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -108,6 +108,15 @@
 - [x] Add focused regression evidence for explicit valid and invalid `wth` /
       `tho` ordering
 - [x] Run required code-change validation after implementation
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      schedule-rule `sd` / `cy` compatibility diagnostics
+- [x] Implement grouped schedule-rule `sd` / `cy` compatibility diagnostics
+      only after approval
+- [x] Add focused regression evidence for explicit valid and invalid jobnet
+      `sd` / `cy` combinations, including weekly cycles on open-day or
+      closed-day schedules
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -364,24 +373,54 @@
   JP1/AJS v13 parameter-alignment candidate should be re-selected from the
   remaining partial or deferred gaps using the same user-meaningful job-type
   or parameter-family grouping rule.
+- 2026-05-07: Remaining JP1/AJS v13 parameter-alignment gaps were re-checked
+  again from the user-visible grouping perspective. The next recommended
+  approval-gated candidate is grouped schedule-rule `sd` / `cy`
+  compatibility diagnostics for jobnets, centered on the JP1/AJS3 v13 rule
+  that weekly cycles cannot be combined with open-day or closed-day
+  execution-start dates for the same schedule rule number.
+- 2026-05-07: Grouped schedule-rule `sd` / `cy` compatibility diagnostics now
+  report explicit jobnet `cy=(n,w)` values when the matching `sd` rule for the
+  same schedule rule number uses open-day (`*`) or closed-day (`@`)
+  scheduling semantics. Raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, command generation,
+  generated artifacts, configuration, dependency versions, and
+  `engines.vscode` remain unchanged.
+- 2026-05-07: The grouped schedule-rule `sd` / `cy` compatibility slice is
+  implemented on `codex/sd-cy-compatibility`. The next JP1/AJS v13
+  parameter-alignment candidate should be re-selected from the remaining
+  partial or deferred gaps using the same user-meaningful job-type or
+  parameter-family grouping rule.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-07
-- Approved scope: grouped job end-judgment threshold-ordering diagnostics for
-  explicit `wth` / `tho` pairs on UNIX/PC jobs and UNIX/PC custom jobs
-  through the existing editor-feedback boundary, keeping the slice narrow to
-  semantic diagnostics while preserving raw parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection, and
-  command generation.
+- Approved scope: grouped schedule-rule `sd` / `cy` compatibility diagnostics
+  for jobnets through the existing editor-feedback boundary, limited to
+  reporting explicit `cy=(n,w)` weekly-cycle values when the matching `sd`
+  rule for the same schedule rule number uses open-day (`*`) or closed-day
+  (`@`) scheduling semantics, while preserving raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation.
 
-Current implementation gate: grouped job end-judgment threshold-ordering
-diagnostics for explicit `wth` / `tho` pairs is approved for implementation
-inside the recorded scope.
+Current implementation gate: grouped schedule-rule `sd` / `cy` compatibility
+diagnostics are approved and implemented inside the recorded scope.
 
 ## Prior Approval Evidence
 
+- 2026-05-07: User replied "Approved. Proceed with implementation." after the
+  grouped schedule-rule `sd` / `cy` compatibility diagnostics approval
+  request. Approved changes were limited to adding grouped application-level
+  semantic diagnostics for explicit jobnet `cy=(n,w)` values when the matching
+  `sd` rule for the same schedule rule number uses open-day (`*`) or
+  closed-day (`@`) scheduling semantics; preserving raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation; adding focused regression evidence;
+  updating SDD tracking; and running validation. Parser grammar, schedule-rule
+  value-shape parsing and range diagnostics already delivered, `sd` date/rule
+  range policy, `sd=0,ud` product-decision handling, generated artifacts,
+  configuration, dependency versions, and `engines.vscode` were out of scope.
 - 2026-05-07: User replied "Approved. Proceed with implementation." after the
   grouped job end-judgment threshold-ordering diagnostics approval request.
   Approved changes were limited to adding grouped application-level semantic
@@ -629,6 +668,25 @@ inside the recorded scope.
 
 ## Validation
 
+- 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  schedule-rule `sd` / `cy` compatibility diagnostics implementation
+- 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped
+  schedule-rule `sd` / `cy` compatibility diagnostics implementation; the VS
+  Code harness emitted the existing macOS `task_name_for_pid` codesign noise
+  line
+- 2026-05-07: `rtk pnpm run test:web` completed with exit code 0 after
+  grouped schedule-rule `sd` / `cy` compatibility diagnostics implementation
+  and emitted the existing localhost dev-extension `package.nls.json` 404
+  noise
+- 2026-05-07: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped schedule-rule `sd` / `cy` compatibility diagnostics
+  implementation
+- 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after grouped
+  schedule-rule `sd` / `cy` compatibility diagnostics implementation
+- 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after the
+  docs-only `sd` / `cy` regrouping investigation
+- 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after the
+  docs-only `sd` / `cy` regrouping investigation
 - 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
   event-host validation implementation
 - 2026-05-07: `rtk pnpm test` completed with exit code 0; the VS Code harness

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -32,6 +32,11 @@ rules in `docs/specs/README.md`, not in this file.
   next recommended JP1/AJS v13 candidate should again be selected from the
   remaining partial or deferred gaps using the same user-meaningful grouping
   rule.
+- After re-checking the remaining partial and deferred gaps, the next
+  recommended JP1/AJS v13 candidate should stay inside the already-modeled
+  schedule-rule family and group the remaining `sd` / `cy` compatibility
+  rule around user-visible jobnet scheduling semantics, instead of opening a
+  new single-parameter micro-slice or a broader lower-evidence job family.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -49,10 +54,10 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Request approval for the next grouped JP1/AJS3 v13 parameter-alignment
-   slice selected from the remaining partial or deferred gaps after the
-   delivered job end-judgment threshold-ordering diagnostics, keeping the
-   grouping by job type or parameter family.
+1. Re-select the next grouped JP1/AJS3 v13 parameter-alignment slice from the
+   remaining partial or deferred gaps after the delivered `sd` / `cy`
+   compatibility diagnostics, keeping the grouping by job type or parameter
+   family.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -65,38 +70,38 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/job-end-threshold-ordering`
+- Branch: `codex/sd-cy-compatibility`
 - Objective: continue JP1/AJS v13 parameter alignment with a user-meaningful
-  grouped slice around job end-judgment threshold-ordering diagnostics for
-  UNIX/PC jobs and UNIX/PC custom jobs, rather than opening a broader new job
-  family before closing the remaining focused follow-up in the existing
-  end-judgment diagnostics seam.
-- Status: implemented and validated on `codex/job-end-threshold-ordering`.
+  grouped slice around jobnet schedule-rule `sd` / `cy` compatibility, so the
+  remaining follow-up stays inside the already-modeled schedule-rule family
+  rather than switching to a lower-evidence job family or a one-key fix.
+- Status: implemented and validated on `codex/sd-cy-compatibility`.
 - Scope: add focused semantic diagnostics through the existing
-  editor-feedback boundary when explicit `wth` / `tho` pairs do not preserve
-  the documented warning-to-abnormal threshold ordering, while preserving raw
-  parser output, domain wrapper values, normalized parameters, unit-list
+  editor-feedback boundary when an explicit jobnet `cy=(n,w)` weekly cycle is
+  paired with an `sd` rule for the same schedule rule number that uses
+  open-day (`*`) or closed-day (`@`) scheduling semantics, while preserving
+  raw parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation.
-- Out of scope: parser grammar changes, domain default changes, numeric range
-  diagnostics already delivered, retry-parameter diagnostics already
-  delivered, generated artifacts, dependency changes, `engines.vscode`, and
-  non-end-judgment parameter validation.
-- Impact summary: the next slice is expected to affect
+- Out of scope: parser grammar changes, schedule-rule value-shape parsing and
+  range diagnostics already delivered, `sd` year/month/day range policy,
+  `sd=0,ud` product-decision handling, domain default changes, generated
+  artifacts, dependency changes, `engines.vscode`, and non-schedule parameter
+  validation.
+- Impact summary: the implemented slice affects
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
-  job-end-judgment diagnostics tests, the job-end-judgment alignment record,
-  the coverage matrix, and the editor-feedback behavior contract if the new
-  diagnostics are approved.
-- Risks and assumptions: the official JP1/AJS3 v13 end-judgment description is
-  interpreted to require a warning threshold below the abnormal threshold so
-  that normal, warning, and abnormal outcomes remain distinguishable. If
-  implementation investigation finds product behavior that permits an edge
-  case such as equal thresholds, stop and re-approve before broadening or
-  changing the rule.
+  schedule-rule diagnostics tests, the schedule-rule alignment record, the
+  coverage matrix, and the editor-feedback behavior contract.
+- Risks and assumptions: this slice assumes the JP1/AJS3 v13 rule that
+  weekly-cycle `cy=(n,w)` must not be used when the matching `sd` rule is
+  based on open days or closed days should be enforced as an application-level
+  semantic diagnostic rather than as parser rejection or wrapper mutation. If
+  implementation investigation reveals additional coupled schedule semantics
+  beyond this rule, stop and re-approve before broadening scope.
 - Alternatives considered: switch to a different job type first, viable but
-  deferred because job end judgment already has an established diagnostics seam
-  and one coherent remaining follow-up; move directly to broader event or
-  transfer-parameter validation, rejected for now because that increases scope
-  before this narrower family-level gap is closed.
+  deferred because schedule rules already have shared parsing seams and test
+  coverage; broaden the slice to all remaining `sd` validation, rejected for
+  now because `SCHEDULELIMIT` and `sd=0,ud` policy raise separate product
+  questions that would make the slice less reviewable.
 
 ## Build/Test Performance SDD
 
@@ -125,10 +130,10 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped job end-judgment threshold-ordering diagnostics for explicit
-  `wth` / `tho` pairs on UNIX/PC jobs and UNIX/PC custom jobs is implemented
-  and validated; the next candidate should be selected from the remaining
-  partial/deferred gaps using the same user-meaningful grouping rule.
+  slice: grouped `sd` / `cy` schedule-rule compatibility diagnostics for
+  jobnets is implemented; the next candidate should be re-selected from the
+  remaining partial/deferred gaps using the same user-meaningful grouping
+  rule.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -39,6 +39,9 @@ const flattenUnits = (units: Unit[]): Unit[] =>
 const findParameter = (unit: Unit, key: string): UnitParameter | undefined =>
   unit.parameters.find((parameter) => parameter.key === key);
 
+const findParameters = (unit: Unit, key: string): UnitParameter[] =>
+  unit.parameters.filter((parameter) => parameter.key === key);
+
 const findUnitsByTypes = (
   rootUnits: Unit[],
   targetTypes: Set<string>,
@@ -350,6 +353,43 @@ const isValidExplicitCycle = (parameter: UnitParameter): boolean => {
   return cycle >= 1 && cycle <= maximumByUnit[unitType];
 };
 
+const isExplicitWeeklyCycle = (
+  parameter: UnitParameter,
+): ParsedExplicitScheduleRuleValue | undefined => {
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
+    return undefined;
+  }
+
+  return /^\(\d{1,3},w\)$/.test(parsed.value) ? parsed : undefined;
+};
+
+const usesOpenOrClosedDaySchedule = (
+  parameter: UnitParameter,
+): ParsedExplicitScheduleRuleValue | undefined => {
+  const parsed = parseExplicitScheduleRuleValue(parameter.value);
+  if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
+    return undefined;
+  }
+
+  return /^((\d{4}\/)?\d{2}\/)?[*@]/.test(parsed.value) ? parsed : undefined;
+};
+
+const hasInvalidExplicitWeeklyCycleScheduleCompatibility = (
+  parameter: UnitParameter,
+  unit: Unit,
+): boolean => {
+  const weeklyCycle = isExplicitWeeklyCycle(parameter);
+  if (!weeklyCycle) {
+    return false;
+  }
+
+  return findParameters(unit, "sd").some((scheduleDateParameter) => {
+    const scheduleDate = usesOpenOrClosedDaySchedule(scheduleDateParameter);
+    return scheduleDate?.ruleNumber === weeklyCycle.ruleNumber;
+  });
+};
+
 const isValidExplicitShiftDays = (parameter: UnitParameter): boolean => {
   const parsed = parseExplicitScheduleRuleValue(parameter.value);
   if (!isValidScheduleRuleNumber(parsed) || parsed === undefined) {
@@ -596,8 +636,8 @@ const buildScheduleRuleDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
   findUnitsByTypes(rootUnits, scheduleRuleDiagnosticTargetTypes).flatMap(
-    (unit) =>
-      collectRuleDiagnostics(unit, [
+    (unit) => [
+      ...collectRuleDiagnostics(unit, [
         {
           key: "ln",
           message:
@@ -659,6 +699,17 @@ const buildScheduleRuleDiagnostics = (
           isInvalid: (parameter) => !isValidExplicitWaitTime(parameter),
         },
       ]),
+      ...findParameters(unit, "cy").flatMap((parameter) =>
+        hasInvalidExplicitWeeklyCycleScheduleCompatibility(parameter, unit)
+          ? [
+              buildDiagnostic(
+                parameter,
+                "Weekly cycle (cy=(n,w)) cannot be specified when execution-start date (sd) uses open-day (*) or closed-day (@) scheduling for the same rule.",
+              ),
+            ]
+          : [],
+      ),
+    ],
   );
 
 const buildJobEndJudgmentDiagnostics = (

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -168,6 +168,74 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("does not report sd/cy compatibility diagnostics for valid explicit schedule combinations", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  sd=1,15;",
+        "  cy=1,(2,w);",
+        "  sd=2,*15;",
+        "  cy=2,(3,d);",
+        "  sd=3,@su;",
+        "  cy=4,(1,w);",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports sd/cy compatibility diagnostics for explicit weekly cycles on open-day and closed-day schedules", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  sd=1,*15;",
+        "  cy=1,(2,w);",
+        "  sd=2,@su;",
+        "  cy=2,(1,w);",
+        "  sd=3,20;",
+        "  cy=3,(4,w);",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 2);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 5,
+          column: 2,
+          length: 2,
+          message:
+            "Weekly cycle (cy=(n,w)) cannot be specified when execution-start date (sd) uses open-day (*) or closed-day (@) scheduling for the same rule.",
+        },
+        {
+          line: 7,
+          column: 2,
+          length: 2,
+          message:
+            "Weekly cycle (cy=(n,w)) cannot be specified when execution-start date (sd) uses open-day (*) or closed-day (@) scheduling for the same rule.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error"],
+    );
+  });
+
   test("does not report end-judgment diagnostics for omitted defaults", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [


### PR DESCRIPTION
## Summary
- add JP1/AJS v13 editor-feedback diagnostics for invalid jobnet sd/cy weekly-cycle combinations
- add regression coverage for valid and invalid sd/cy combinations
- sync feature specs, tasks, plans, and the parameter coverage matrix with the implemented slice

## Testing
- rtk pnpm run qlty
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
- rtk pnpm run lint:md