### PR TITLE
Add generic parameter-rule diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -174,6 +174,23 @@ Scenario: Event host values must stay within documented byte-length rules
   When editor feedback is requested
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
+
+Scenario: Shared filename-like rules stay explicit across parameter families
+  Given a syntactically valid JP1/AJS document with a parameter family that
+    uses documented filename-like or host-like values
+  And an explicit value is outside that family's JP1/AJS3 v13 byte-length or
+    invalid-combination rule
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
+Scenario: Shared string diagnostics preserve documented macro-variable allowance
+  Given a syntactically valid JP1/AJS document with a parameter family that
+    explicitly allows macro-variable or regular-expression forms
+  When editor feedback is requested
+  Then application-level diagnostic DTOs do not reject the value only because
+    it uses an allowed explicit string form
+  And raw parser output remains available to downstream consumers
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/GENERIC_PARAMETER_RULE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/GENERIC_PARAMETER_RULE_ALIGNMENT.md
@@ -1,0 +1,150 @@
+# Generic Parameter Rule Alignment
+
+## Purpose
+
+Record the next JP1/AJS3 version 13 parameter-alignment candidate around
+shared validation rules that are no longer best grouped by job type alone.
+
+This investigation groups the remaining deferred work around filename-like
+values, byte-length limits, macro-variable-aware string rules, and invalid
+combinations whose current or planned owner is the shared
+`buildSyntaxDiagnostics.ts` editor-feedback boundary.
+
+This slice must be implemented together with the small refactoring needed to
+keep the new rules inside the existing generic-rule structure in
+`buildSyntaxDiagnostics.ts`, rather than adding a separate parallel rule path.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual sections:
+  - Command Reference, `5.2.6 UNIX/PC job definition`
+  - Command Reference, `5.2.7 QUEUE job definition`
+  - Command Reference, `5.2.9 Job definition for monitoring JP1 event reception`
+  - Command Reference, `5.2.10 File monitoring job definition`
+  - Command Reference, `5.2.17 JP1 event sending job definition`
+  - Command Reference, `5.2.24 UNIX/PC custom job definition`
+- Source URLs:
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0221.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0222.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0224.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0225.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4900e/AJSO0231.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0239.HTM>
+
+## Slice Boundary
+
+- Application seam:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`
+- Existing consumers:
+  `src/extension/diagnostics/registerDiagnostics.ts` plus focused unit types
+  whose wrappers already preserve raw explicit values:
+  `J`, `Cj`, `Qj`, `Rq`, `Flwj`, `Rflwj`, `Evsj`, `Revsj`, `Evwj`, and
+  `Revwj`
+- Regression evidence:
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`
+- Preservation evidence:
+  existing unit-list projection tests such as
+  `src/test/suite/buildUnitListView.test.ts` and
+  `src/test/suite/buildUnitListRemainingGroups.test.ts`
+- Out of scope:
+  parser grammar changes, domain wrapper normalization changes, unit-list or
+  flow projection changes, command generation changes, generated artifacts,
+  dependency changes, `engines.vscode`, and category-specific product
+  decisions outside the stated generic-rule families
+
+## Investigation Notes
+
+- The remaining deferred gaps in `PARAMETER_COVERAGE_MATRIX.md` now cluster
+  more strongly by validation-rule shape than by unit family.
+- `buildSyntaxDiagnostics.ts` already owns the delivered grouped diagnostics
+  for `flwf`, `flwi`, `flwc`, `flco`, `evhst`, `evsid`, `evspl`, `evsrc`,
+  `evwid`, `evipa`, `evesc`, and the schedule-rule/job-end-judgment slices.
+- The current file already duplicates the same `1..255` byte-length check in
+  `isValidExplicitFileMonitoringFileName` and `isValidExplicitEventHostValue`,
+  which is a strong indicator that the next slice should reuse shared helpers
+  instead of continuing to add one-off validators per job type.
+- The current file structure already has a generic-rule shape:
+  shared helpers such as `buildExplicitDecimalRangeRule`,
+  `collectRuleDiagnostics`, and per-family rule arrays. The approved
+  implementation should refactor within that structure so the new rules and
+  the existing generic rules converge instead of diverging into a new layer.
+- `collectRuleDiagnostics` is keyed to explicit source-backed parameters, so
+  the existing application boundary can add more diagnostics without changing
+  parser DTO shape or inventing normalized values.
+- Transfer-operation and QUEUE transfer-file rows still defer filename,
+  byte-length, macro-variable, and invalid-combination follow-up, but those
+  rules are expected to stay as diagnostics rather than parser rejection or
+  wrapper mutation if the current editor-feedback policy is preserved.
+- Macro-variable allowance is not uniform across parameter families. Event
+  sending and event reception already preserve different explicit string forms
+  for `evhst`, so any helper extraction must keep allowance rules data-driven
+  per family instead of introducing a single generic string validator.
+
+## Planned Alignment
+
+After approval:
+
+- keep ownership in the shared application editor-feedback boundary;
+- extract or reshape reusable explicit-value validators or rule builders where
+  that reduces duplication in `buildSyntaxDiagnostics.ts` and keeps old and
+  new generic rules on the same path;
+- group the next implementation around shared byte-length, filename-like,
+  macro-variable-aware, and invalid-combination rules that still remain
+  deferred in the coverage matrix;
+- preserve raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
+
+## Delivered Behavior
+
+- `buildSyntaxDiagnostics.ts` now keeps the new transfer/QUEUE generic rules
+  on the existing helper-and-rule-array path instead of introducing a second
+  diagnostics layer.
+- Shared explicit byte-length validation is now reused for the existing
+  `1..255` event-host / file-monitoring rules and the new `1..511`
+  transfer-file rules.
+- Editor feedback now reports transfer-operation and QUEUE transfer-file
+  diagnostics when explicit `tsN` or `tdN` values fall outside the documented
+  `1..511` byte-length range.
+- Editor feedback now reports invalid combinations when explicit `tdN` is
+  specified without `tsN`, and when explicit transfer-operation `topN` is
+  specified without `tsN`.
+- Existing macro-variable and regular-expression allowance remains preserved
+  because the new generic helper only enforces explicit byte-length and
+  dependency rules in this slice.
+
+## Affected Backlog Rows
+
+- Transfer Operation:
+  remaining filename, byte-length, macro-variable, and invalid-combination
+  validation
+- QUEUE Transfer Files:
+  remaining byte-length, macro-variable, and invalid-combination validation
+- File Monitoring Job:
+  delivered validations should become a reuse reference for shared
+  filename-like and invalid-combination rule builders rather than a separate
+  one-off pattern
+- Event Sending and Event Receiving Jobs:
+  delivered `evhst` diagnostics should remain the shared macro-variable-aware
+  and byte-length reference point rather than diverging by job family
+
+## Alternatives
+
+- Continue selecting one job type at a time:
+  viable, but rejected for now because the remaining gaps share validation
+  shape and test seam more than wrapper seam.
+- Move generic string validation into domain wrappers:
+  rejected because the current policy preserves raw explicit invalid values and
+  surfaces them through editor feedback.
+- Broaden the slice to every remaining deferred parameter:
+  rejected because it would mix generic-rule cleanup with unrelated
+  category-specific semantics and make approval less reviewable.
+
+## Follow-up
+
+- If approval is given, perform a reference-impact pass on
+  `buildSyntaxDiagnostics.ts` and `buildSyntaxDiagnostics.test.ts` before
+  editing runtime code.
+- If implementation uncovers family-specific macro-variable semantics that do
+  not fit the planned generic-rule grouping, stop and request re-approval with
+  the broadened scope.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -53,8 +53,11 @@ coverage.
   `transferOperationHelpers.ts` and `transferOperationParameterBuilders.ts`
 - Evidence: `parameterHelpers.test.ts` and `parameterFactory.test.ts`
 - Remaining gap:
-  filename, byte-length, macro-variable, and invalid-combination validation
-  remain deferred
+  editor-feedback now aligns `tsN` / `tdN` byte-length diagnostics and
+  `tdN` / `topN` source-file dependency diagnostics for the currently modeled
+  transfer-operation parameters. Full filename/path-shape validation and
+  macro-variable syntax validation remain deferred under
+  `GENERIC_PARAMETER_RULE_ALIGNMENT.md`
 
 ### QUEUE Transfer Files
 
@@ -64,8 +67,12 @@ coverage.
 - Owning seam: `Qj.ts` and `ParameterFactory.ts`
 - Evidence: `parameterFactory.test.ts`
 - Remaining gap:
-  group 15 unit-type-aware projection now hides `topN` on QUEUE jobs; byte
-  length, macro-variable, and invalid-combination validation remain deferred
+  group 15 unit-type-aware projection now hides `topN` on QUEUE jobs.
+  Editor-feedback now aligns `tsN` / `tdN` byte-length diagnostics and `tdN`
+  source-file dependency diagnostics for the currently modeled QUEUE
+  transfer-file parameters. Full filename/path-shape validation and
+  macro-variable syntax validation remain deferred under
+  `GENERIC_PARAMETER_RULE_ALIGNMENT.md`
 
 ### Job End Judgment
 
@@ -127,7 +134,9 @@ coverage.
   editor-feedback, and `flwf` / `flwi` target-pattern validation is aligned
   through editor-feedback for byte-length, numeric range, and
   wildcard-with-short-interval rules. `ets` timeout behavior remains
-  deferred.
+  deferred. The delivered file-monitoring diagnostics now serve as one reuse
+  reference for the shared generic-rule slice recorded in
+  `GENERIC_PARAMETER_RULE_ALIGNMENT.md`.
 
 ### Execution-Interval Control Job Defaults
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -227,6 +227,17 @@ JP1/AJS3 version 13 reference documents.
   regular-expression and macro-variable allowances visible, and preserve raw
   parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation.
+- The remaining generic validation backlog is approval-sensitive because
+  multiple coverage-matrix rows now defer the same families of rules:
+  filename-like value checks, byte-length limits, macro-variable-aware string
+  handling, and invalid combinations. The next grouped slice should stay
+  inside application editor-feedback, reuse or extract shared explicit-value
+  validators only where that reduces duplication in
+  `buildSyntaxDiagnostics.ts`, include the small refactoring needed so the new
+  rules do not split away from the existing generic-rule path, and keep
+  per-family macro-variable allowances explicit so shared helpers do not
+  accidentally collapse distinct JP1/AJS3 v13 rules into one generic string
+  policy.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -117,6 +117,20 @@
       `sd` / `cy` combinations, including weekly cycles on open-day or
       closed-day schedules
 - [x] Run required code-change validation after implementation
+- [x] Re-group the remaining JP1/AJS v13 parameter-alignment backlog around
+      shared filename-like, byte-length, macro-variable, and
+      invalid-combination rules after the delivered `sd` / `cy` slice
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      generic parameter-rule diagnostics
+- [x] Implement grouped generic parameter-rule diagnostics only after approval
+- [x] Refactor `buildSyntaxDiagnostics.ts` within the approved scope so the
+      new rules stay on the existing generic-rule path instead of creating a
+      separate rule layer
+- [x] Add focused regression evidence for shared byte-length, filename-like,
+      macro-variable-aware, and invalid-combination validation in the
+      approved parameter families
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -391,24 +405,57 @@
   parameter-alignment candidate should be re-selected from the remaining
   partial or deferred gaps using the same user-meaningful job-type or
   parameter-family grouping rule.
+- 2026-05-07: Remaining partial and deferred JP1/AJS v13 gaps were re-checked
+  against the coverage matrix and existing editor-feedback seam. The next
+  candidate is now re-grouped around shared filename-like, byte-length,
+  macro-variable, and invalid-combination rules rather than another
+  single-job follow-up, because the remaining gaps cluster more strongly by
+  validation-rule shape than by unit family.
+- 2026-05-07: The approved-scope draft was refined so this slice includes the
+  small refactoring needed to keep new generic rules in the existing
+  `buildSyntaxDiagnostics.ts` helper/rule-array structure, rather than adding
+  a separate implementation path beside the current general rules.
+- 2026-05-07: Grouped generic parameter-rule diagnostics now keep transfer
+  operation and QUEUE transfer-file validation on the existing
+  `buildSyntaxDiagnostics.ts` helper/rule-array path. Shared explicit
+  byte-length validation is reused for current `1..255` rules and new
+  `1..511` transfer-file rules; focused diagnostics now report explicit
+  `tdN` without `tsN`, explicit `topN` without `tsN`, and explicit out-of-
+  range transfer file values while preserving raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-07
-- Approved scope: grouped schedule-rule `sd` / `cy` compatibility diagnostics
-  for jobnets through the existing editor-feedback boundary, limited to
-  reporting explicit `cy=(n,w)` weekly-cycle values when the matching `sd`
-  rule for the same schedule rule number uses open-day (`*`) or closed-day
-  (`@`) scheduling semantics, while preserving raw parser output, domain
-  wrapper values, normalized parameters, unit-list projection, flow
-  projection, and command generation.
+- Approved scope: grouped generic parameter-rule diagnostics through the
+  existing editor-feedback boundary, limited to shared filename-like,
+  byte-length, macro-variable-aware, and invalid-combination validation for
+  the remaining deferred coverage-matrix rows, including the small
+  refactoring needed to keep those rules on the existing
+  `buildSyntaxDiagnostics.ts` generic-rule path, while preserving raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation.
 
-Current implementation gate: grouped schedule-rule `sd` / `cy` compatibility
-diagnostics are approved and implemented inside the recorded scope.
+Current implementation gate: generic parameter-rule diagnostics are approved
+inside the recorded scope.
 
 ## Prior Approval Evidence
 
+- 2026-05-07: User replied "Approved. Proceed with implementation." after the
+  grouped generic parameter-rule diagnostics approval request. Approved
+  changes were limited to adding grouped application-level semantic
+  diagnostics for the remaining shared filename-like, byte-length, and
+  invalid-combination rules through the existing editor-feedback boundary;
+  including the small refactoring needed to keep those rules on the existing
+  `buildSyntaxDiagnostics.ts` generic-rule path; preserving documented
+  macro-variable and regular-expression allowance where already accepted;
+  preserving raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation; adding
+  focused regression evidence; updating SDD tracking; and running validation.
+  Parser grammar, domain default changes, generated artifacts, configuration,
+  dependency versions, and `engines.vscode` were out of scope.
 - 2026-05-07: User replied "Approved. Proceed with implementation." after the
   grouped schedule-rule `sd` / `cy` compatibility diagnostics approval
   request. Approved changes were limited to adding grouped application-level
@@ -667,6 +714,17 @@ diagnostics are approved and implemented inside the recorded scope.
   regression evidence.
 
 ## Validation
+
+- 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  generic parameter-rule diagnostics implementation
+- 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped generic
+  parameter-rule diagnostics implementation; the VS Code harness emitted the
+  existing macOS `task_name_for_pid` codesign noise line
+- 2026-05-07: `rtk pnpm run test:web` completed with exit code 0 after grouped
+  generic parameter-rule diagnostics implementation and emitted the existing
+  localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-07: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped generic parameter-rule diagnostics implementation
 
 - 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
   schedule-rule `sd` / `cy` compatibility diagnostics implementation

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -33,10 +33,10 @@ rules in `docs/specs/README.md`, not in this file.
   remaining partial or deferred gaps using the same user-meaningful grouping
   rule.
 - After re-checking the remaining partial and deferred gaps, the next
-  recommended JP1/AJS v13 candidate should stay inside the already-modeled
-  schedule-rule family and group the remaining `sd` / `cy` compatibility
-  rule around user-visible jobnet scheduling semantics, instead of opening a
-  new single-parameter micro-slice or a broader lower-evidence job family.
+  recommended JP1/AJS v13 candidate should re-group the deferred
+  filename-like, byte-length, macro-variable, and invalid-combination rules
+  into one shared parameter-family slice, instead of returning to isolated
+  job-type micro-slices that duplicate the same editor-feedback logic.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -54,10 +54,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Re-select the next grouped JP1/AJS3 v13 parameter-alignment slice from the
-   remaining partial or deferred gaps after the delivered `sd` / `cy`
-   compatibility diagnostics, keeping the grouping by job type or parameter
-   family.
+1. Record and approve the next grouped JP1/AJS3 v13 parameter-alignment
+   slice around shared filename-like, byte-length, macro-variable, and
+   invalid-combination rules in the existing editor-feedback boundary.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -70,38 +69,41 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/sd-cy-compatibility`
-- Objective: continue JP1/AJS v13 parameter alignment with a user-meaningful
-  grouped slice around jobnet schedule-rule `sd` / `cy` compatibility, so the
-  remaining follow-up stays inside the already-modeled schedule-rule family
-  rather than switching to a lower-evidence job family or a one-key fix.
-- Status: implemented and validated on `codex/sd-cy-compatibility`.
-- Scope: add focused semantic diagnostics through the existing
-  editor-feedback boundary when an explicit jobnet `cy=(n,w)` weekly cycle is
-  paired with an `sd` rule for the same schedule rule number that uses
-  open-day (`*`) or closed-day (`@`) scheduling semantics, while preserving
-  raw parser output, domain wrapper values, normalized parameters, unit-list
-  projection, flow projection, and command generation.
-- Out of scope: parser grammar changes, schedule-rule value-shape parsing and
-  range diagnostics already delivered, `sd` year/month/day range policy,
-  `sd=0,ud` product-decision handling, domain default changes, generated
-  artifacts, dependency changes, `engines.vscode`, and non-schedule parameter
-  validation.
-- Impact summary: the implemented slice affects
+- Branch: `codex/generic-parameter-rules`
+- Objective: prepare the next JP1/AJS v13 parameter-alignment slice by
+  regrouping the remaining generic validation gaps around shared
+  filename-like, byte-length, macro-variable, and invalid-combination rules
+  instead of continuing job-type-by-job-type follow-ups.
+- Status: approved for implementation and in progress on
+  `codex/generic-parameter-rules`; implementation and validation are now
+  complete in the approved scope.
+- Scope: update SDD artifacts for the planned shared editor-feedback slice
+  that would consolidate duplicated explicit-value validation patterns in
+  `buildSyntaxDiagnostics.ts`, include the small refactoring needed so the new
+  rules remain on that existing generic-rule path, and then extend the same
+  boundary to remaining deferred transfer/QUEUE-style generic rules without
+  changing parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, command generation, generated
+  artifacts, dependency versions, or `engines.vscode`.
+- Out of scope: runtime implementation before approval, parser grammar
+  changes, domain default changes, list/flow projection changes, command
+  generation changes, dependency changes, and any product-decision rule that
+  requires behavior beyond the documented generic validation categories.
+- Impact summary: the approved implementation candidate would affect
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
-  schedule-rule diagnostics tests, the schedule-rule alignment record, the
-  coverage matrix, and the editor-feedback behavior contract.
-- Risks and assumptions: this slice assumes the JP1/AJS3 v13 rule that
-  weekly-cycle `cy=(n,w)` must not be used when the matching `sd` rule is
-  based on open days or closed days should be enforced as an application-level
-  semantic diagnostic rather than as parser rejection or wrapper mutation. If
-  implementation investigation reveals additional coupled schedule semantics
-  beyond this rule, stop and re-approve before broadening scope.
-- Alternatives considered: switch to a different job type first, viable but
-  deferred because schedule rules already have shared parsing seams and test
-  coverage; broaden the slice to all remaining `sd` validation, rejected for
-  now because `SCHEDULELIMIT` and `sd=0,ud` policy raise separate product
-  questions that would make the slice less reviewable.
+  `buildSyntaxDiagnostics` regression tests, the parameter-alignment feature
+  docs, the parameter coverage matrix, and the editor-feedback behavior
+  contract.
+- Risks and assumptions: this regrouping assumes the remaining deferred rules
+  can stay in the shared application editor-feedback boundary without pushing
+  validation into parser or domain layers. Macro-variable allowance still
+  varies by parameter family, so any helper extraction must keep per-family
+  policy explicit instead of collapsing all string-shape checks into one rule.
+- Alternatives considered: continue picking one job type at a time, rejected
+  because the remaining gaps now cluster more strongly by validation rule than
+  by unit family; broaden the slice to all remaining parameter gaps, rejected
+  because that would mix generic-rule cleanup with unrelated category-specific
+  semantics.
 
 ## Build/Test Performance SDD
 
@@ -130,10 +132,10 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped `sd` / `cy` schedule-rule compatibility diagnostics for
-  jobnets is implemented; the next candidate should be re-selected from the
-  remaining partial/deferred gaps using the same user-meaningful grouping
-  rule.
+  slice: grouped generic parameter-rule diagnostics are implemented for shared
+  transfer/QUEUE byte-length and invalid-combination rules through the
+  existing editor-feedback boundary; remaining deferred gaps should be
+  re-selected from the updated coverage matrix.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -29,6 +29,16 @@ const fileMonitoringDiagnosticTargetTypes = new Set(["flwj", "rflwj"]);
 const eventSendingDiagnosticTargetTypes = new Set(["evsj", "revsj"]);
 const eventReceivingDiagnosticTargetTypes = new Set(["evwj", "revwj"]);
 const scheduleRuleDiagnosticTargetTypes = new Set(["g", "n"]);
+const transferOperationDiagnosticTargetTypes = new Set([
+  "j",
+  "rj",
+  "pj",
+  "rp",
+  "cj",
+  "rcj",
+]);
+const queueTransferFileDiagnosticTargetTypes = new Set(["qj", "rq"]);
+const transferFileIndexes = [1, 2, 3, 4] as const;
 
 const flattenUnits = (units: Unit[]): Unit[] =>
   units.reduce<Unit[]>(
@@ -72,6 +82,28 @@ const buildExplicitDecimalRangeRule = (
   message,
   isInvalid: (parameter) =>
     parseExplicitDecimalInRange(parameter, minimum, maximum) === undefined,
+});
+
+const buildExplicitByteLengthRule = (
+  key: string,
+  minimum: number,
+  maximum: number,
+  message: string,
+): UnitParameterDiagnosticRule => ({
+  key,
+  message,
+  isInvalid: (parameter) =>
+    !isValidExplicitByteLengthValue(parameter, minimum, maximum),
+});
+
+const buildRequiredParameterRule = (
+  key: string,
+  requiredKey: string,
+  message: string,
+): UnitParameterDiagnosticRule => ({
+  key,
+  message,
+  isInvalid: (_parameter, unit) => !findParameter(unit, requiredKey),
 });
 
 const parseExplicitDecimalInRange = (
@@ -172,8 +204,10 @@ const getByteLength = (value: string): number =>
 
 const hasWildcard = (value: string): boolean => value.includes("*");
 
-const isValidExplicitFileMonitoringFileName = (
+const isValidExplicitByteLengthValue = (
   parameter: UnitParameter | undefined,
+  minimum: number,
+  maximum: number,
 ): boolean => {
   const rawValue = parameter?.value;
   if (rawValue === undefined) {
@@ -181,20 +215,16 @@ const isValidExplicitFileMonitoringFileName = (
   }
 
   const byteLength = getByteLength(rawValue);
-  return byteLength >= 1 && byteLength <= 255;
+  return byteLength >= minimum && byteLength <= maximum;
 };
+
+const isValidExplicitFileMonitoringFileName = (
+  parameter: UnitParameter | undefined,
+): boolean => isValidExplicitByteLengthValue(parameter, 1, 255);
 
 const isValidExplicitEventHostValue = (
   parameter: UnitParameter | undefined,
-): boolean => {
-  const rawValue = parameter?.value;
-  if (rawValue === undefined) {
-    return false;
-  }
-
-  const byteLength = getByteLength(rawValue);
-  return byteLength >= 1 && byteLength <= 255;
-};
+): boolean => isValidExplicitByteLengthValue(parameter, 1, 255);
 
 const isValidExplicitFileMonitoringInterval = (
   parameter: UnitParameter | undefined,
@@ -525,6 +555,51 @@ const jobEndJudgmentNumericRangeRules = [
   ),
 ] as const;
 
+const transferFileByteLengthRules: readonly UnitParameterDiagnosticRule[] =
+  transferFileIndexes.flatMap((index) => [
+    buildExplicitByteLengthRule(
+      `ts${index}`,
+      1,
+      511,
+      `Transfer source file name (ts${index}) must be between 1 and 511 bytes.`,
+    ),
+    buildExplicitByteLengthRule(
+      `td${index}`,
+      1,
+      511,
+      `Transfer destination file name (td${index}) must be between 1 and 511 bytes.`,
+    ),
+  ]);
+
+const transferOperationDiagnosticRules: readonly UnitParameterDiagnosticRule[] =
+  [
+    ...transferFileByteLengthRules,
+    ...transferFileIndexes.flatMap((index) => [
+      buildRequiredParameterRule(
+        `td${index}`,
+        `ts${index}`,
+        `Transfer destination file name (td${index}) requires transfer source file name (ts${index}).`,
+      ),
+      buildRequiredParameterRule(
+        `top${index}`,
+        `ts${index}`,
+        `Transfer operation (top${index}) requires transfer source file name (ts${index}).`,
+      ),
+    ]),
+  ];
+
+const queueTransferFileDiagnosticRules: readonly UnitParameterDiagnosticRule[] =
+  [
+    ...transferFileByteLengthRules,
+    ...transferFileIndexes.map((index) =>
+      buildRequiredParameterRule(
+        `td${index}`,
+        `ts${index}`,
+        `Transfer destination file name (td${index}) requires transfer source file name (ts${index}).`,
+      ),
+    ),
+  ];
+
 const fileMonitoringDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
   {
     key: "flwf",
@@ -810,6 +885,20 @@ const buildFileMonitoringDiagnostics = (
     (unit) => collectRuleDiagnostics(unit, fileMonitoringDiagnosticRules),
   );
 
+const buildTransferOperationDiagnostics = (
+  rootUnits: Unit[],
+): SyntaxDiagnosticDto[] =>
+  findUnitsByTypes(rootUnits, transferOperationDiagnosticTargetTypes).flatMap(
+    (unit) => collectRuleDiagnostics(unit, transferOperationDiagnosticRules),
+  );
+
+const buildQueueTransferFileDiagnostics = (
+  rootUnits: Unit[],
+): SyntaxDiagnosticDto[] =>
+  findUnitsByTypes(rootUnits, queueTransferFileDiagnosticTargetTypes).flatMap(
+    (unit) => collectRuleDiagnostics(unit, queueTransferFileDiagnosticRules),
+  );
+
 const buildEventSendingDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
@@ -859,6 +948,8 @@ export const buildSyntaxDiagnostics = (
     ...buildScheduleRuleDiagnostics(result.rootUnits),
     ...buildJobEndJudgmentDiagnostics(result.rootUnits),
     ...buildFileMonitoringDiagnostics(result.rootUnits),
+    ...buildTransferOperationDiagnostics(result.rootUnits),
+    ...buildQueueTransferFileDiagnostics(result.rootUnits),
     ...buildEventSendingDiagnostics(result.rootUnits),
     ...buildEventReceivingDiagnostics(result.rootUnits),
   ];

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -848,6 +848,160 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("does not report transfer-file diagnostics for valid explicit values and macro variables", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=custom,cj,+160+0;",
+        "  el=queue1,qj,+320+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    ts1=?AJS2SRC1?;",
+        "    td1=?AJS2DST1?;",
+        "    top1=sav;",
+        "  }",
+        "  unit=custom,,jp1admin,;",
+        "  {",
+        "    ty=cj;",
+        "    ts1=source-1;",
+        "    top1=sav;",
+        "  }",
+        "  unit=queue1,,jp1admin,;",
+        "  {",
+        "    ty=qj;",
+        "    ts1=?AJS2QSRC1?;",
+        "    td1=?AJS2QDST1?;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports transfer-file byte-length diagnostics for explicit out-of-range values", () => {
+    const tooLongFileName = "a".repeat(512);
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=queue1,qj,+160+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        `    ts1=${tooLongFileName};`,
+        "  }",
+        "  unit=queue1,,jp1admin,;",
+        "  {",
+        "    ty=qj;",
+        "    ts1=queue-source;",
+        `    td1=${tooLongFileName};`,
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 2);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 3,
+          message:
+            "Transfer source file name (ts1) must be between 1 and 511 bytes.",
+        },
+        {
+          line: 15,
+          column: 4,
+          length: 3,
+          message:
+            "Transfer destination file name (td1) must be between 1 and 511 bytes.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error"],
+    );
+  });
+
+  test("reports transfer-file invalid-combination diagnostics when source files are omitted", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=queue1,qj,+160+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    td1=dest-only;",
+        "    top1=del;",
+        "  }",
+        "  unit=queue1,,jp1admin,;",
+        "  {",
+        "    ty=qj;",
+        "    td1=queue-dest-only;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 3);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 3,
+          message:
+            "Transfer destination file name (td1) requires transfer source file name (ts1).",
+        },
+        {
+          line: 10,
+          column: 4,
+          length: 4,
+          message:
+            "Transfer operation (top1) requires transfer source file name (ts1).",
+        },
+        {
+          line: 15,
+          column: 4,
+          length: 3,
+          message:
+            "Transfer destination file name (td1) requires transfer source file name (ts1).",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error"],
+    );
+  });
+
   test("does not report event sending diagnostics for omitted evsrt defaults", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [


### PR DESCRIPTION
## Summary
- keep the new JP1/AJS parameter checks on the existing buildSyntaxDiagnostics generic-rule path
- add transfer/QUEUE byte-length and source-dependency diagnostics with focused regression coverage
- sync SDD docs, coverage matrix, and approval records for the slice

## Validation
- rtk pnpm run qlty
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
- rtk pnpm run lint:md