### PR TITLE
[codex] align sd date diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -120,6 +120,17 @@ Scenario: Weekly schedule cycles must not use open-day or closed-day dates
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Schedule-rule execution-start dates must stay within documented rule
+  and day ranges
+  Given a syntactically valid JP1/AJS document with a jobnet
+  And explicit `sd` uses a schedule rule number outside `1..144`
+  Or explicit `sd` uses a documented day form with a day value outside the
+    JP1/AJS3 v13 allowed range
+  Or explicit `sd` uses a year outside `1994..SCHEDULELIMIT`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Event arrival check requires an event destination host
   Given a syntactically valid JP1/AJS document with a JP1 event sending job
   And effective `evsrt` is event-arrival checking enabled

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
@@ -2,8 +2,8 @@
 
 ## Purpose
 
-Track the JP1/AJS3 version 13 alignment slice for execution-interval control
-job defaults and unit-list group 13 projection.
+Record the delivered JP1/AJS3 version 13 alignment status for
+execution-interval control job defaults and unit-list group 13 projection.
 
 ## Reference
 
@@ -18,26 +18,15 @@ The reference defines omitted values as:
 - `etn`: `n`
 - `ets`: `kl`
 
-## Current Behavior
+## Delivered Alignment
 
-- `Tmwj.tmitv` delegates to `ParamFactory.tmitv`, and `ParamFactory.tmitv`
-  currently has no default value.
-- `Tmwj.etn` and `Tmwj.ets` delegate to factory builders that already use
-  `DEFAULTS.Etn` and `DEFAULTS.Ets`.
-- Unit-list group 13 currently reads normalized raw values for `tmitv` and
-  `etn`.
-- Unit-list group 13 now uses default-aware `ets` projection only for file
-  monitoring jobs, not for execution-interval control jobs.
-
-## Proposed Scope
-
-After human approval, align execution-interval control job behavior by:
-
-- adding a `tmitv` default of `10` at the domain parameter boundary;
-- projecting omitted `tmitv`, `etn`, and `ets` defaults for `tmwj` / `rtmwj`
-  in unit-list group 13;
-- preserving explicit normalized values;
-- leaving non-execution-interval-control jobs unchanged.
+- `Tmwj.tmitv`, `Tmwj.etn`, and `Tmwj.ets` now resolve omitted values through
+  `DEFAULTS.Tmitv`, `DEFAULTS.Etn`, and `DEFAULTS.Ets` at the domain parameter
+  boundary.
+- Unit-list group 13 now projects omitted `tmitv`, `etn`, and `ets` defaults
+  for `tmwj` / `rtmwj`.
+- Explicit normalized values remain visible.
+- Non-execution-interval-control jobs remain unchanged.
 
 ## Non-Goals
 
@@ -49,14 +38,19 @@ After human approval, align execution-interval control job behavior by:
 - `engines.vscode` changes
 - broad wait-job default reconciliation outside `tmwj` / `rtmwj`
 
-## Impact
+## Evidence
 
-- Domain behavior changes for omitted `Tmwj.tmitv`, because the wrapper would
-  return `10` instead of no value.
-- Unit-list group 13 output changes for omitted execution-interval control job
-  `tmitv`, `etn`, and `ets`, because the table would display defaults instead
-  of empty cells.
-- Raw parser output and normalized key/value storage should remain unchanged.
+- `src/test/suite/parameterFactory.test.ts` verifies omitted `tmitv`, `etn`,
+  and `ets` defaults through the wrapper facade.
+- `src/test/suite/buildUnitListRemainingGroups.test.ts` verifies group 13
+  projection for omitted and explicit execution-interval control job values.
+- `src/test/suite/buildUnitListView.test.ts` keeps the row-view projection
+  path covered.
+
+## Remaining Gap
+
+- Range validation and broader wait-job default reconciliation remain outside
+  this delivered slice.
 
 ## Alternatives
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -37,7 +37,11 @@ coverage.
   grouped range diagnostics are aligned for `ln`, `st`, `cy`, `shd`, `cftd`,
   `sy`, `ey`, `wc`, and `wt` through editor-feedback. Grouped `sd` / `cy`
   weekly-cycle compatibility for open-day and closed-day schedules is also
-  aligned through editor-feedback. `sd` date/rule range policy and any broader
+  aligned through editor-feedback. Grouped `sd` explicit rule/day diagnostics
+  are aligned through editor-feedback, preserving `sd=0,ud` as the documented
+  valid special case and enforcing the documented `1994..SCHEDULELIMIT` year
+  range with the official default `SCHEDULELIMIT=2036` in this slice.
+  Environment-specific `SCHEDULELIMIT` override support and any broader
   cross-parameter invalidation remain deferred. `wc` / `wt` effective-value
   pairing is aligned in the domain wrapper boundary and unit-list group 10
   projection.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SCHEDULE_RULE_ALIGNMENT.md
@@ -60,8 +60,9 @@ and `wt`.
   - Covered: repeatable schedule dates, rule numbers, root default `1,en`, and
     `sd=0,ud` preservation.
   - Seam: `parseScheduleDateValue`, `Sd`, and `resolveSdParameters`.
-  - Remaining gap: date and rule value ranges; product decision on collapsing
-    `sd=0,ud`.
+  - Remaining gap: explicit date and rule value ranges; `sd=0,ud` handling and
+    `SCHEDULELIMIT`-dependent year-range policy remain separate product-
+    decision follow-up items.
 - `ln`
   - Covered: nested jobnet parent-rule mapping; root-jobnet values ignored.
   - Seam: `parseParentScheduleRuleValue`, `Ln`, and the root-jobnet ignored
@@ -212,9 +213,12 @@ and `wt`.
   through `buildSyntaxDiagnostics.ts`. Explicit `cy=(n,w)` values now report a
   semantic diagnostic when the matching `sd` rule for the same schedule rule
   number uses open-day (`*`) or closed-day (`@`) scheduling semantics.
-- Revisit `sd` date/rule range policy separately because `sd=0,ud` handling
-  and the `SCHEDULELIMIT`-dependent year range still carry product-decision
-  notes outside this grouped compatibility slice.
+- Grouped explicit `sd` diagnostics are now aligned through
+  `buildSyntaxDiagnostics.ts`, including the documented valid `sd=0,ud`
+  special case and the documented `1994..SCHEDULELIMIT` year range using the
+  official default `SCHEDULELIMIT=2036` during this slice.
+- Revisit environment-specific `SCHEDULELIMIT` override support separately if
+  the repository later needs diagnostics against non-default site settings.
 - Revisit any broader schedule-rule cross-parameter invalidation separately if
   implementation investigation reveals rules beyond the approved `sd` / `cy`
   weekly-cycle restriction.
@@ -232,3 +236,17 @@ and `wt`.
 - The delivered slice intentionally does not broaden into `sd` date-range
   validation, `sd=0,ud` product policy, or broader schedule-rule
   cross-parameter invalidation.
+
+## Delivered SD Date/Rule Diagnostics
+
+- The editor-feedback boundary now reports semantic diagnostics for explicit
+  jobnet `sd` values when they use rule numbers outside `1..144`, except for
+  the documented valid special case `sd=0,ud`.
+- Explicit `sd` year values now report a semantic diagnostic when they fall
+  outside the documented `1994..SCHEDULELIMIT` range, using the official
+  default `SCHEDULELIMIT=2036` during this slice.
+- Explicit `sd` month/day forms now report a semantic diagnostic when they use
+  out-of-range month, day, end-of-month-offset, or weekday-occurrence values.
+- Diagnostics stay focused on explicit `sd` parameters and preserve raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -88,6 +88,20 @@ JP1/AJS3 version 13 reference documents.
   number uses open-day (`*`) or closed-day (`@`) scheduling semantics, and
   preserve raw parser output, domain wrapper values, normalized parameters,
   unit-list projection, flow projection, and command generation.
+- Schedule-rule `sd` explicit date/rule diagnostics remain approval-sensitive
+  because current behavior accepts supported `sd` value shapes through
+  `parseScheduleDateValue`, but editor feedback does not yet distinguish
+  explicit out-of-range schedule-rule numbers or day values. A focused
+  follow-up should stay inside application editor-feedback, reuse the existing
+  schedule-rule parsing seam, report explicit `sd` parameters when rule
+  numbers fall outside `1..144` or day tokens fall outside the documented
+  JP1/AJS3 v13 day ranges, and preserve raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation. The approved expanded scope may also keep `sd=0,ud` as
+  the one valid rule-`0` special case and may enforce the documented
+  `1994..SCHEDULELIMIT` year range using the official default
+  `SCHEDULELIMIT=2036` during this slice, as long as parser output, wrapper
+  values, normalized parameters, and projection boundaries remain unchanged.
 - Unit-list group 10 `wc` / `wt` projection is a separate approval-sensitive
   boundary from domain interpretation because it is user-visible table output.
   If approved, it should consume the existing paired effective-value semantics

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -131,6 +131,21 @@
       macro-variable-aware, and invalid-combination validation in the
       approved parameter families
 - [x] Run required code-change validation after implementation
+- [x] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
+      delivered generic-rule slice and select the next candidate using a
+      user-meaningful job-type or parameter-family grouping rule
+- [x] Sync the stale execution-interval alignment note to the already
+      delivered runtime and regression evidence so the remaining backlog does
+      not point at completed work
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      schedule-rule `sd` explicit date/rule diagnostics
+- [x] Implement grouped schedule-rule `sd` explicit date/rule diagnostics
+      only after approval
+- [x] Add focused regression evidence for explicit out-of-range `sd` rule
+      numbers and day values while preserving raw parser output and the
+      approved `sd=0,ud` special-case boundary
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -424,25 +439,56 @@
   range transfer file values while preserving raw parser output, domain
   wrapper values, normalized parameters, unit-list projection, flow
   projection, and command generation.
+- 2026-05-07: Remaining partial and deferred JP1/AJS v13 gaps were re-checked
+  again after the delivered generic-rule slice. The next recommended
+  approval-gated candidate is grouped schedule-rule `sd` explicit date/rule
+  diagnostics because it stays inside the already-modeled jobnet schedule
+  family, reuses `parseScheduleDateValue`, and is more user-meaningful than
+  smaller default-only follow-ups.
+- 2026-05-07: Investigation confirmed that execution-interval control job
+  defaults and group 13 projection are already delivered in runtime and
+  regression tests. `EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md` was stale
+  and is now treated as documentation-sync work, not as remaining backlog.
+- 2026-05-07: User approved an expanded scope for the `sd` follow-up so it can
+  keep `sd=0,ud` as the documented valid special case and enforce the
+  `1994..SCHEDULELIMIT` year range using the official default value during
+  this slice, instead of leaving those decisions outside the slice.
+- 2026-05-07: Grouped schedule-rule `sd` diagnostics now report explicit
+  invalid rule/day values on jobnets, preserve `sd=0,ud` as the one valid
+  rule-`0` special case, and enforce the documented `1994..SCHEDULELIMIT`
+  year range using the official default value `2036`. Raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation remain unchanged.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-07
-- Approved scope: grouped generic parameter-rule diagnostics through the
-  existing editor-feedback boundary, limited to shared filename-like,
-  byte-length, macro-variable-aware, and invalid-combination validation for
-  the remaining deferred coverage-matrix rows, including the small
-  refactoring needed to keep those rules on the existing
-  `buildSyntaxDiagnostics.ts` generic-rule path, while preserving raw parser
-  output, domain wrapper values, normalized parameters, unit-list projection,
-  flow projection, and command generation.
+- Approved scope: grouped schedule-rule `sd` explicit date/rule diagnostics
+  through the existing editor-feedback boundary, limited to explicit
+  out-of-range schedule-rule numbers and day values on jobnets, while
+  preserving raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation. Expanded
+  approval also includes preserving `sd=0,ud` as the documented valid special
+  case and enforcing the documented `1994..SCHEDULELIMIT` year upper bound
+  using the official default value `2036` for this slice. Parser grammar,
+  schedule-rule projection behavior, unrelated domain default behavior,
+  generated artifacts, dependency versions, and `engines.vscode` remain out
+  of scope.
 
-Current implementation gate: generic parameter-rule diagnostics are approved
-inside the recorded scope.
+Current implementation gate: schedule-rule `sd` explicit date/rule
+diagnostics are approved inside the recorded expanded scope.
 
 ## Prior Approval Evidence
 
+- 2026-05-07: User replied
+  "`sd=0,ud と SCHEDULELIMIT 依存 year range も含めて拡張スコープで承認します`"
+  after the follow-up scope discussion. Approved changes were broadened to
+  include the documented valid `sd=0,ud` special case and the documented
+  `1994..SCHEDULELIMIT` year-range rule, interpreted with the official
+  default value `2036` for this slice, while preserving raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation.
 - 2026-05-07: User replied "Approved. Proceed with implementation." after the
   grouped generic parameter-rule diagnostics approval request. Approved
   changes were limited to adding grouped application-level semantic
@@ -760,6 +806,21 @@ inside the recorded scope.
   docs-only event-host regrouping investigation
 - 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after the
   docs-only event-host regrouping investigation
+- 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  schedule-rule `sd` explicit date/rule diagnostics implementation
+- 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped
+  schedule-rule `sd` explicit date/rule diagnostics implementation; the VS
+  Code harness emitted the existing macOS `task_name_for_pid` codesign noise
+  line
+- 2026-05-07: `rtk pnpm run test:web` completed with exit code 0 after grouped
+  schedule-rule `sd` explicit date/rule diagnostics implementation and
+  emitted the existing localhost dev-extension `package.nls.json` 404 plus
+  shutdown-time `ECONNRESET` / premature-close noise
+- 2026-05-07: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped schedule-rule `sd` explicit date/rule diagnostics
+  implementation
+- 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after grouped
+  schedule-rule `sd` explicit date/rule diagnostics implementation
 - 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
   job end-judgment threshold-ordering diagnostics implementation
 - 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped job

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -37,6 +37,11 @@ rules in `docs/specs/README.md`, not in this file.
   filename-like, byte-length, macro-variable, and invalid-combination rules
   into one shared parameter-family slice, instead of returning to isolated
   job-type micro-slices that duplicate the same editor-feedback logic.
+- After the delivered grouped generic parameter-rule slice, the next
+  recommended JP1/AJS v13 candidate should return to the already-modeled
+  schedule-rule family and align explicit `sd` rule/day diagnostics before
+  revisiting smaller default-only gaps such as HTTP Connection `eu` or
+  file-monitoring `ets`.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -55,8 +60,9 @@ rules in `docs/specs/README.md`, not in this file.
 ## Next Priority Tasks
 
 1. Record and approve the next grouped JP1/AJS3 v13 parameter-alignment
-   slice around shared filename-like, byte-length, macro-variable, and
-   invalid-combination rules in the existing editor-feedback boundary.
+   slice around explicit schedule-rule `sd` rule/day diagnostics in the
+   existing editor-feedback boundary, while keeping `sd=0,ud` policy and
+   `SCHEDULELIMIT`-dependent year-range decisions out of scope.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -69,41 +75,42 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Current Branch Plan
 
-- Branch: `codex/generic-parameter-rules`
-- Objective: prepare the next JP1/AJS v13 parameter-alignment slice by
-  regrouping the remaining generic validation gaps around shared
-  filename-like, byte-length, macro-variable, and invalid-combination rules
-  instead of continuing job-type-by-job-type follow-ups.
-- Status: approved for implementation and in progress on
-  `codex/generic-parameter-rules`; implementation and validation are now
-  complete in the approved scope.
-- Scope: update SDD artifacts for the planned shared editor-feedback slice
-  that would consolidate duplicated explicit-value validation patterns in
-  `buildSyntaxDiagnostics.ts`, include the small refactoring needed so the new
-  rules remain on that existing generic-rule path, and then extend the same
-  boundary to remaining deferred transfer/QUEUE-style generic rules without
-  changing parser output, domain wrapper values, normalized parameters,
-  unit-list projection, flow projection, command generation, generated
-  artifacts, dependency versions, or `engines.vscode`.
+- Branch: `main`; a dedicated implementation branch was attempted but could
+  not be created from the sandboxed session after approval
+- Objective: prepare the next JP1/AJS v13 parameter-alignment slice around
+  explicit jobnet `sd` rule/day diagnostics, and sync the stale
+  execution-interval alignment note so the backlog reflects delivered work.
+- Status: approved implementation and validation are complete in the recorded
+  scope.
+- Scope: update SDD artifacts for a focused schedule-rule follow-up that would
+  keep ownership in `buildSyntaxDiagnostics.ts`, reuse the existing
+  `parseScheduleDateValue` seam for explicit `sd` interpretation, add user-
+  visible diagnostics for out-of-range schedule-rule numbers or day values,
+  treat the `SCHEDULELIMIT` year upper bound as the official default value
+  during this slice, and preserve parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, command
+  generation, generated artifacts, dependency versions, and `engines.vscode`.
 - Out of scope: runtime implementation before approval, parser grammar
-  changes, domain default changes, list/flow projection changes, command
-  generation changes, dependency changes, and any product-decision rule that
-  requires behavior beyond the documented generic validation categories.
+  changes, domain default changes, schedule-rule projection changes, broader
+  schedule-rule cross-parameter invalidation, dependency changes, and
+  unrelated default-only follow-ups.
 - Impact summary: the approved implementation candidate would affect
-  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
-  `buildSyntaxDiagnostics` regression tests, the parameter-alignment feature
-  docs, the parameter coverage matrix, and the editor-feedback behavior
-  contract.
-- Risks and assumptions: this regrouping assumes the remaining deferred rules
-  can stay in the shared application editor-feedback boundary without pushing
-  validation into parser or domain layers. Macro-variable allowance still
-  varies by parameter family, so any helper extraction must keep per-family
-  policy explicit instead of collapsing all string-shape checks into one rule.
-- Alternatives considered: continue picking one job type at a time, rejected
-  because the remaining gaps now cluster more strongly by validation rule than
-  by unit family; broaden the slice to all remaining parameter gaps, rejected
-  because that would mix generic-rule cleanup with unrelated category-specific
-  semantics.
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
+  `src/domain/models/parameters/scheduleRuleHelpers.ts`, focused
+  schedule-rule and diagnostics regression tests, the parameter-alignment
+  feature docs, and the editor-feedback behavior contract.
+- Risks and assumptions: this slice assumes explicit `sd` range validation can
+  remain in the shared application editor-feedback boundary without changing
+  parser acceptance or wrapper normalization. `sd=0,ud` must stay as a
+  documented special valid case, and the `SCHEDULELIMIT`-dependent year range
+  is currently interpreted using the official default value `2036`, because
+  this slice does not yet have a repository-approved environment-specific
+  input source.
+- Alternatives considered: switch to a smaller default-only gap such as HTTP
+  Connection `eu` or file-monitoring `ets`, rejected because those are less
+  user-visible and too fine-grained for the next slice; broaden the schedule
+  slice to all remaining `sd` policy questions, rejected because that would
+  mix straightforward diagnostics with unresolved product decisions.
 
 ## Build/Test Performance SDD
 
@@ -132,10 +139,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped generic parameter-rule diagnostics are implemented for shared
-  transfer/QUEUE byte-length and invalid-combination rules through the
-  existing editor-feedback boundary; remaining deferred gaps should be
-  re-selected from the updated coverage matrix.
+  slice: grouped schedule-rule `sd` explicit date/rule diagnostics are
+  implemented using the official default `SCHEDULELIMIT=2036`; remaining
+  gaps should be re-selected from the updated coverage matrix.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -1,5 +1,6 @@
 import { parseAjs } from "../../domain/services/parser/AjsParser";
 import { DEFAULTS } from "../../domain/models/parameters/Defaults";
+import { parseScheduleDateValue } from "../../domain/models/parameters/scheduleRuleHelpers";
 import type { Unit, UnitParameter } from "../../domain/values/Unit";
 
 export type SyntaxDiagnosticDto = {
@@ -9,6 +10,12 @@ export type SyntaxDiagnosticDto = {
   message: string;
   severity: "error";
 };
+
+export type BuildSyntaxDiagnosticsOptions = {
+  scheduleLimitYear?: number;
+};
+
+const DEFAULT_SCHEDULE_LIMIT_YEAR = 2036;
 
 type UnitParameterDiagnosticRule = {
   key: string;
@@ -264,6 +271,14 @@ type ParsedExplicitScheduleRuleValue = {
   value: string;
 };
 
+type ParsedExplicitScheduleDateValue = {
+  hasExplicitRuleNumber: boolean;
+  ruleNumber: number;
+  year?: number;
+  month?: number;
+  dayValue: string;
+};
+
 const parseExplicitScheduleRuleValue = (
   rawValue: string | undefined,
 ): ParsedExplicitScheduleRuleValue | undefined => {
@@ -285,6 +300,152 @@ const isValidScheduleRuleNumber = (
   parsedValue !== undefined &&
   (!parsedValue.hasExplicitRuleNumber ||
     (parsedValue.ruleNumber >= 1 && parsedValue.ruleNumber <= 144));
+
+const normalizeScheduleLimitYear = (
+  scheduleLimitYear: number | undefined,
+): number | undefined =>
+  Number.isInteger(scheduleLimitYear) &&
+  scheduleLimitYear !== undefined &&
+  scheduleLimitYear >= 2036 &&
+  scheduleLimitYear <= 2099
+    ? scheduleLimitYear
+    : undefined;
+
+const parseExplicitScheduleDateDiagnosticValue = (
+  rawValue: string | undefined,
+): ParsedExplicitScheduleDateValue | undefined => {
+  const parsed = parseScheduleDateValue(rawValue);
+  if (!parsed?.day) {
+    return undefined;
+  }
+
+  const yearMonthMatch = /^((\d{4})\/)?(\d{2})\/$/.exec(parsed.yearMonth ?? "");
+  return {
+    hasExplicitRuleNumber: /^\d{1,3},/.test(rawValue ?? ""),
+    ruleNumber: parsed.rule,
+    year: yearMonthMatch?.[2] ? Number(yearMonthMatch[2]) : undefined,
+    month: yearMonthMatch ? Number(yearMonthMatch[3]) : undefined,
+    dayValue: parsed.day,
+  };
+};
+
+const getCalendarMonthDayLimit = (
+  year: number | undefined,
+  month: number | undefined,
+): number => {
+  if (month === undefined) {
+    return 31;
+  }
+
+  if (year === undefined) {
+    return month === 2 ? 29 : new Date(2000, month, 0).getDate();
+  }
+
+  return new Date(year, month, 0).getDate();
+};
+
+const isValidScheduleDateYear = (
+  year: number | undefined,
+  scheduleLimitYear: number | undefined,
+): boolean =>
+  year === undefined ||
+  (year >= 1994 &&
+    (scheduleLimitYear === undefined || year <= scheduleLimitYear));
+
+const isValidScheduleDateMonth = (month: number | undefined): boolean =>
+  month === undefined || (month >= 1 && month <= 12);
+
+const isValidScheduleDateDayToken = (
+  parsed: ParsedExplicitScheduleDateValue,
+): boolean => {
+  if (parsed.dayValue === "en") {
+    return parsed.month === undefined;
+  }
+
+  if (parsed.dayValue === "ud") {
+    return parsed.month === undefined;
+  }
+
+  const explicitDayMatch = /^(\d{2})$/.exec(parsed.dayValue);
+  if (explicitDayMatch) {
+    const day = Number(explicitDayMatch[1]);
+    return (
+      day >= 1 && day <= getCalendarMonthDayLimit(parsed.year, parsed.month)
+    );
+  }
+
+  const relativeDayMatch = /^([+*@])(\d{2})$/.exec(parsed.dayValue);
+  if (relativeDayMatch) {
+    const day = Number(relativeDayMatch[2]);
+    return day >= 1 && day <= 35;
+  }
+
+  const backwardDayMatch = /^([+*@])?b(?:-(\d{2}))?$/.exec(parsed.dayValue);
+  if (backwardDayMatch) {
+    const direction = backwardDayMatch[1];
+    const offset = backwardDayMatch[2]
+      ? Number(backwardDayMatch[2])
+      : undefined;
+
+    if (offset === undefined) {
+      return true;
+    }
+
+    if (direction) {
+      return offset >= 0 && offset <= 34;
+    }
+
+    return (
+      offset >= 0 &&
+      offset <= getCalendarMonthDayLimit(parsed.year, parsed.month) - 1
+    );
+  }
+
+  const weekdayMatch = /^\+(su|mo|tu|we|th|fr|sa)(?::(\d|b))?$/.exec(
+    parsed.dayValue,
+  );
+  if (weekdayMatch) {
+    const occurrence = weekdayMatch[2];
+    return (
+      occurrence === undefined ||
+      occurrence === "b" ||
+      (Number(occurrence) >= 1 && Number(occurrence) <= 5)
+    );
+  }
+
+  return false;
+};
+
+const isValidExplicitScheduleDate = (
+  parameter: UnitParameter,
+  scheduleLimitYear: number | undefined,
+): boolean => {
+  const parsed = parseExplicitScheduleDateDiagnosticValue(parameter.value);
+  if (!parsed) {
+    return false;
+  }
+
+  if (parsed.dayValue === "ud") {
+    return (
+      parsed.hasExplicitRuleNumber &&
+      parsed.ruleNumber === 0 &&
+      parsed.month === undefined
+    );
+  }
+
+  if (
+    parsed.hasExplicitRuleNumber &&
+    (parsed.ruleNumber < 1 || parsed.ruleNumber > 144)
+  ) {
+    return false;
+  }
+
+  return (
+    isValidScheduleDateMonth(parsed.month) &&
+    isValidScheduleDateYear(parsed.year, scheduleLimitYear) &&
+    isValidScheduleDateDayToken(parsed)
+  );
+};
 
 const parseHourMinuteValue = (
   rawValue: string,
@@ -709,9 +870,24 @@ const eventReceivingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
 
 const buildScheduleRuleDiagnostics = (
   rootUnits: Unit[],
+  options: BuildSyntaxDiagnosticsOptions,
 ): SyntaxDiagnosticDto[] =>
   findUnitsByTypes(rootUnits, scheduleRuleDiagnosticTargetTypes).flatMap(
     (unit) => [
+      ...findParameters(unit, "sd").flatMap((parameter) =>
+        isValidExplicitScheduleDate(
+          parameter,
+          normalizeScheduleLimitYear(options.scheduleLimitYear) ??
+            DEFAULT_SCHEDULE_LIMIT_YEAR,
+        )
+          ? []
+          : [
+              buildDiagnostic(
+                parameter,
+                "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+              ),
+            ],
+      ),
       ...collectRuleDiagnostics(unit, [
         {
           key: "ln",
@@ -930,6 +1106,7 @@ const buildEventReceivingDiagnostics = (
 
 export const buildSyntaxDiagnostics = (
   content: string,
+  options: BuildSyntaxDiagnosticsOptions = {},
 ): SyntaxDiagnosticDto[] => {
   const result = parseAjs(content);
   const syntaxDiagnostics = result.errors.map((error) => ({
@@ -945,7 +1122,7 @@ export const buildSyntaxDiagnostics = (
 
   return [
     ...syntaxDiagnostics,
-    ...buildScheduleRuleDiagnostics(result.rootUnits),
+    ...buildScheduleRuleDiagnostics(result.rootUnits, options),
     ...buildJobEndJudgmentDiagnostics(result.rootUnits),
     ...buildFileMonitoringDiagnostics(result.rootUnits),
     ...buildTransferOperationDiagnostics(result.rootUnits),

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -52,6 +52,28 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(diagnostics, []);
   });
 
+  test("does not report sd diagnostics for valid explicit dates including sd=0,ud", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  sd=0,ud;",
+        "  sd=1,1994/01/01;",
+        "  sd=2,2036/12/31;",
+        "  sd=3,02/29;",
+        "  sd=4,+su:b;",
+        "  sd=5,b-30;",
+        "  sd=6,@35;",
+        "}",
+        "",
+      ].join("\n"),
+      { scheduleLimitYear: 2036 },
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
   test("reports schedule-rule diagnostics for explicit out-of-range values", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [
@@ -155,6 +177,127 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(
       diagnostics.map((diagnostic) => diagnostic.severity),
       [
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+        "error",
+      ],
+    );
+  });
+
+  test("reports sd diagnostics for explicit out-of-range rule and date values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  sd=ud;",
+        "  sd=0,15;",
+        "  sd=1,1993/12/31;",
+        "  sd=2,2037/01/01;",
+        "  sd=3,2025/02/29;",
+        "  sd=4,04/31;",
+        "  sd=5,+36;",
+        "  sd=6,+su:6;",
+        "  sd=7,b-31;",
+        "  sd=8,2026/13/01;",
+        "  sd=0,2026/04/ud;",
+        "}",
+        "",
+      ].join("\n"),
+      { scheduleLimitYear: 2036 },
+    );
+
+    assert.strictEqual(diagnostics.length, 10);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 4,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+        {
+          line: 5,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+        {
+          line: 6,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+        {
+          line: 7,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+        {
+          line: 8,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+        {
+          line: 9,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+        {
+          line: 10,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+        {
+          line: 11,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+        {
+          line: 12,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+        {
+          line: 13,
+          column: 2,
+          length: 2,
+          message:
+            "Execution-start date (sd) must use schedule rule numbers 1..144, except sd=0,ud, and its explicit year/day values must stay within the JP1/AJS3 v13 schedule and SCHEDULELIMIT ranges.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      [
+        "error",
         "error",
         "error",
         "error",


### PR DESCRIPTION
## Summary
- add grouped `sd` schedule-rule diagnostics in the editor-feedback boundary
- preserve `sd=0,ud` as the documented valid special case
- enforce the documented `1994..SCHEDULELIMIT` year range using the official default value `2036` for this slice
- sync the SDD records and coverage notes for the delivered schedule-rule slice
- refresh the stale execution-interval alignment note so it reflects already-delivered behavior

## Why
The remaining JP1/AJS v13 schedule-rule gap was user-visible: explicit `sd` values could remain invalid without editor feedback. This PR closes that gap without changing parser output, wrapper values, normalized parameters, or list/flow projections.

## Impact
Users now get semantic diagnostics for explicit jobnet `sd` values when rule numbers, month/day forms, or year values fall outside the approved JP1/AJS v13 scope. The special case `sd=0,ud` remains accepted.

## Validation
- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`
