### PR TITLE
Add transfer-file value shape diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -195,6 +195,15 @@ Scenario: Shared filename-like rules stay explicit across parameter families
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Transfer-file parameters must use documented explicit string forms
+  Given a syntactically valid JP1/AJS document with a UNIX/PC job,
+    UNIX/PC custom job, QUEUE job, or recovery QUEUE job
+  And explicit `tsN` or `tdN` uses a bare string that is neither a quoted
+    transfer-file value nor an accepted macro-variable form
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Shared string diagnostics preserve documented macro-variable allowance
   Given a syntactically valid JP1/AJS document with a parameter family that
     explicitly allows macro-variable or regular-expression forms

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -59,9 +59,11 @@ coverage.
 - Remaining gap:
   editor-feedback now aligns `tsN` / `tdN` byte-length diagnostics and
   `tdN` / `topN` source-file dependency diagnostics for the currently modeled
-  transfer-operation parameters. Full filename/path-shape validation and
-  macro-variable syntax validation remain deferred under
-  `GENERIC_PARAMETER_RULE_ALIGNMENT.md`
+  transfer-operation parameters. Explicit transfer-file value-shape
+  diagnostics for non-macro bare strings are now aligned through
+  editor-feedback; broader filename/path semantics and macro-variable syntax
+  tightening remain deferred under
+  `TRANSFER_FILE_VALUE_SHAPE_ALIGNMENT.md`
 
 ### QUEUE Transfer Files
 
@@ -74,9 +76,10 @@ coverage.
   group 15 unit-type-aware projection now hides `topN` on QUEUE jobs.
   Editor-feedback now aligns `tsN` / `tdN` byte-length diagnostics and `tdN`
   source-file dependency diagnostics for the currently modeled QUEUE
-  transfer-file parameters. Full filename/path-shape validation and
-  macro-variable syntax validation remain deferred under
-  `GENERIC_PARAMETER_RULE_ALIGNMENT.md`
+  transfer-file parameters. Explicit transfer-file value-shape diagnostics for
+  non-macro bare strings are now aligned through editor-feedback; broader
+  filename/path semantics and macro-variable syntax tightening remain deferred
+  under `TRANSFER_FILE_VALUE_SHAPE_ALIGNMENT.md`
 
 ### Job End Judgment
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -252,6 +252,16 @@ JP1/AJS3 version 13 reference documents.
   per-family macro-variable allowances explicit so shared helpers do not
   accidentally collapse distinct JP1/AJS3 v13 rules into one generic string
   policy.
+- Transfer-file `tsN` / `tdN` string-shape diagnostics are approval-sensitive
+  because current behavior preserves arbitrary explicit bare strings such as
+  `ts1=source-1;` as raw parsed values without editor feedback, even though
+  the currently modeled wrapper comments document quoted transfer-file values.
+  A focused follow-up should stay inside application editor-feedback, report
+  explicit transfer-file values on UNIX/PC, UNIX/PC custom, and QUEUE-family
+  units when they are neither quoted transfer-file strings nor already
+  accepted macro-variable forms, and preserve raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -146,6 +146,17 @@
       numbers and day values while preserving raw parser output and the
       approved `sd=0,ud` special-case boundary
 - [x] Run required code-change validation after implementation
+- [x] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
+      delivered schedule-rule `sd` slice and re-select the next candidate
+      using the same user-meaningful grouping rule
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      transfer-file explicit value-shape diagnostics
+- [x] Implement grouped transfer-file explicit value-shape diagnostics only
+      after approval
+- [x] Add focused regression evidence for quoted transfer-file values,
+      accepted macro-variable forms, and explicit bare-string violations
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -459,28 +470,67 @@
   year range using the official default value `2036`. Raw parser output,
   domain wrapper values, normalized parameters, unit-list projection, flow
   projection, and command generation remain unchanged.
+- 2026-05-07: Remaining partial and deferred JP1/AJS v13 gaps were re-checked
+  after the delivered `sd` diagnostics slice. The next recommended
+  approval-gated candidate is grouped transfer-file explicit value-shape
+  diagnostics for `tsN` / `tdN`, because it stays inside the existing
+  editor-feedback generic-rule path, reuses the already-delivered transfer
+  byte-length and dependency seams, and is more user-meaningful than smaller
+  default-only follow-ups.
+- 2026-05-07: Grouped transfer-file explicit value-shape diagnostics now
+  report explicit `tsN` / `tdN` bare strings on UNIX/PC, UNIX/PC custom,
+  QUEUE, and recovery QUEUE jobs when the value is neither a quoted
+  transfer-file string nor an accepted macro-variable form. Existing
+  byte-length and invalid-combination diagnostics remain on the same generic
+  rule path, and raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation
+  remain unchanged.
+- 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  transfer-file explicit value-shape diagnostics implementation.
+- 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped
+  transfer-file explicit value-shape diagnostics implementation; the VS Code
+  harness emitted the existing macOS `task_name_for_pid` codesign noise line.
+- 2026-05-07: `rtk pnpm run test:web` completed with exit code 0 after grouped
+  transfer-file explicit value-shape diagnostics implementation and emitted
+  the existing localhost dev-extension `package.nls.json` 404 noise.
+- 2026-05-07: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped transfer-file explicit value-shape diagnostics
+  implementation.
+- 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after grouped
+  transfer-file explicit value-shape diagnostics implementation.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-07
-- Approved scope: grouped schedule-rule `sd` explicit date/rule diagnostics
-  through the existing editor-feedback boundary, limited to explicit
-  out-of-range schedule-rule numbers and day values on jobnets, while
+- Approved scope: grouped transfer-file explicit value-shape diagnostics
+  through the existing editor-feedback boundary, limited to explicit `ts1` to
+  `ts4` and `td1` to `td4` values on UNIX/PC jobs, UNIX/PC custom jobs,
+  QUEUE jobs, and recovery QUEUE jobs when the value is neither a quoted
+  transfer-file string nor an already accepted macro-variable form, while
   preserving raw parser output, domain wrapper values, normalized parameters,
-  unit-list projection, flow projection, and command generation. Expanded
-  approval also includes preserving `sd=0,ud` as the documented valid special
-  case and enforcing the documented `1994..SCHEDULELIMIT` year upper bound
-  using the official default value `2036` for this slice. Parser grammar,
-  schedule-rule projection behavior, unrelated domain default behavior,
-  generated artifacts, dependency versions, and `engines.vscode` remain out
-  of scope.
+  unit-list projection, flow projection, and command generation. Parser
+  grammar, transfer-operation `topN` behavior, byte-length rules already
+  delivered, generated artifacts, dependency versions, configuration, and
+  `engines.vscode` remain out of scope.
 
-Current implementation gate: schedule-rule `sd` explicit date/rule
-diagnostics are approved inside the recorded expanded scope.
+Current implementation gate: transfer-file explicit value-shape diagnostics
+are implemented and validated inside the recorded scope.
 
 ## Prior Approval Evidence
 
+- 2026-05-07: User replied "Approved. Proceed with implementation." after the
+  grouped transfer-file explicit value-shape diagnostics approval request.
+  Approved changes were limited to adding grouped application-level semantic
+  diagnostics for explicit `ts1` to `ts4` and `td1` to `td4` values when the
+  value is neither a quoted transfer-file string nor an already accepted
+  macro-variable form, through the existing editor-feedback boundary;
+  preserving raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation; adding
+  focused regression evidence; updating SDD tracking; and running validation.
+  Parser grammar, transfer-operation `topN` behavior, byte-length rules
+  already delivered, generated artifacts, dependency versions,
+  configuration, and `engines.vscode` were out of scope.
 - 2026-05-07: User replied
   "`sd=0,ud と SCHEDULELIMIT 依存 year range も含めて拡張スコープで承認します`"
   after the follow-up scope discussion. Approved changes were broadened to

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TRANSFER_FILE_VALUE_SHAPE_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TRANSFER_FILE_VALUE_SHAPE_ALIGNMENT.md
@@ -1,0 +1,130 @@
+# Transfer-File Value-Shape Alignment
+
+## Purpose
+
+Record the next JP1/AJS3 version 13 parameter-alignment candidate around
+explicit transfer-file value shapes for UNIX/PC jobs, UNIX/PC custom jobs,
+QUEUE jobs, and recovery QUEUE jobs.
+
+This investigation narrows the remaining transfer-related generic backlog to
+one user-meaningful slice: explicit `ts1` to `ts4` and `td1` to `td4` values
+should follow the documented transfer-file string shape instead of accepting
+arbitrary bare strings without feedback.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual sections:
+  - Command Reference, `5.2.6 UNIX/PC job definition`
+  - Command Reference, `5.2.7 QUEUE job definition`
+  - Command Reference, `5.2.24 UNIX/PC custom job definition`
+- Source URLs:
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0221.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0222.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0239.HTM>
+
+## Slice Boundary
+
+- Application seam:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`
+- Existing consumers:
+  `src/extension/diagnostics/registerDiagnostics.ts` plus transfer-file-owning
+  unit types `J`, `Cj`, `Qj`, and `Rq`
+- Existing reference points:
+  `src/domain/models/units/J.ts`,
+  `src/domain/models/units/Cj.ts`, and
+  `src/domain/models/units/Qj.ts` all document `tsN` and `tdN` as quoted
+  transfer-file values, while current editor feedback already preserves
+  explicit macro-variable forms such as `?AJS2SRC1?`
+- Regression evidence:
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`
+- Out of scope:
+  parser grammar changes, transfer-operation `topN` default behavior,
+  filename byte-length rules already delivered, path existence checks,
+  platform-specific path normalization, macro-variable expansion semantics,
+  unit-list projection, flow projection, command generation, generated
+  artifacts, dependency changes, and `engines.vscode`
+
+## Investigation Notes
+
+- Current editor feedback already reports transfer-file byte-length and
+  invalid-combination diagnostics, but it still accepts arbitrary explicit
+  bare strings such as `ts1=source-1;` without semantic feedback.
+- The wrapper comments in `J.ts`, `Cj.ts`, and `Qj.ts` describe `tsN` and
+  `tdN` using quoted value forms, which makes explicit string-shape feedback a
+  better next slice than smaller default-only gaps such as HTTP Connection
+  `eu` or file-monitoring `ets`.
+- The existing generic diagnostics path is already set up for transfer-file
+  rules through `transferOperationDiagnosticRules` and
+  `queueTransferFileDiagnosticRules`, so this slice can stay in
+  `buildSyntaxDiagnostics.ts` without widening domain or projection
+  responsibilities.
+- Existing regression tests already demonstrate the current preservation rule:
+  quoted file names and macro-variable values are accepted, while invalid
+  combinations and out-of-range byte lengths produce diagnostics.
+- Macro-variable allowance should remain explicit and preserved. The candidate
+  slice is about rejecting non-documented bare explicit strings, not about
+  tightening or reinterpreting already accepted macro-variable forms.
+
+## Planned Alignment
+
+After approval:
+
+- keep ownership in the shared application editor-feedback boundary;
+- add grouped diagnostics for explicit `tsN` / `tdN` values on `j`, `rj`,
+  `pj`, `rp`, `cj`, `rcj`, `qj`, and `rq` when the value is neither a quoted
+  transfer-file string nor an already accepted explicit macro-variable form;
+- reuse the existing transfer-file rule arrays so the new checks stay on the
+  current generic-rule path beside the delivered byte-length and dependency
+  rules;
+- preserve raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
+
+## Affected Backlog Rows
+
+- Transfer Operation:
+  remaining filename/path-shape and macro-variable-aware validation
+- QUEUE Transfer Files:
+  remaining filename/path-shape and macro-variable-aware validation
+
+## Alternatives
+
+- Pick a smaller default-only slice such as HTTP Connection `eu` or
+  file-monitoring `ets`:
+  rejected because those are less visible to users and smaller than the
+  requested slice size.
+- Broaden the slice to full path syntax, regular-expression handling, or
+  platform-aware path validation:
+  rejected because that would mix a simple documented value-shape gap with
+  higher-risk product interpretation.
+- Move transfer-file validation into domain wrappers:
+  rejected because the current policy preserves raw explicit invalid values and
+  surfaces them through editor feedback.
+
+## Follow-up
+
+- If approval is given, perform a reference-impact pass on the transfer-file
+  helper/rule-array path in `buildSyntaxDiagnostics.ts` and the focused
+  transfer-file tests in `buildSyntaxDiagnostics.test.ts` before editing
+  runtime code.
+- If implementation reveals that quoted transfer-file syntax differs by unit
+  family or conflicts with existing macro-variable preservation, stop and
+  request re-approval with the broadened scope.
+
+## Delivered Behavior
+
+- Editor feedback now reports a semantic diagnostic for explicit `tsN` and
+  `tdN` values on `j`, `rj`, `pj`, `rp`, `cj`, `rcj`, `qj`, and `rq` when the
+  raw explicit value is neither a quoted transfer-file string nor an accepted
+  macro-variable form such as `?AJS2SRC1?`.
+- The new checks stay on the existing transfer-file generic-rule path beside
+  the already delivered byte-length and invalid-combination rules.
+- Quoted transfer-file values and already accepted macro-variable forms remain
+  non-diagnostic in this slice.
+- Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.
+
+## Remaining Gap
+
+- Broader filename/path semantics, platform-specific path interpretation, and
+  any family-specific macro-variable syntax tightening remain deferred.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -42,6 +42,16 @@ rules in `docs/specs/README.md`, not in this file.
   schedule-rule family and align explicit `sd` rule/day diagnostics before
   revisiting smaller default-only gaps such as HTTP Connection `eu` or
   file-monitoring `ets`.
+- After the delivered grouped schedule-rule `sd` explicit date/rule
+  diagnostics slice, the next recommended JP1/AJS v13 candidate should return
+  to the remaining transfer-related generic backlog and align explicit
+  transfer-file value shapes before revisiting smaller default-only gaps such
+  as HTTP Connection `eu`, file-monitoring `ets`, or broader wait-job
+  reconciliation.
+- After the delivered grouped transfer-file explicit value-shape slice, the
+  next recommended JP1/AJS v13 candidate should be re-selected from the
+  remaining partial or deferred gaps using the same user-meaningful grouping
+  rule, instead of defaulting immediately to smaller default-only follow-ups.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -59,10 +69,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Record and approve the next grouped JP1/AJS3 v13 parameter-alignment
-   slice around explicit schedule-rule `sd` rule/day diagnostics in the
-   existing editor-feedback boundary, while keeping `sd=0,ud` policy and
-   `SCHEDULELIMIT`-dependent year-range decisions out of scope.
+1. Re-check the remaining partial or deferred JP1/AJS3 v13 parameter-alignment
+   gaps after the delivered transfer-file value-shape slice and record the
+   next approval-gated candidate using the same user-meaningful grouping rule.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -78,39 +87,31 @@ rules in `docs/specs/README.md`, not in this file.
 - Branch: `main`; a dedicated implementation branch was attempted but could
   not be created from the sandboxed session after approval
 - Objective: prepare the next JP1/AJS v13 parameter-alignment slice around
-  explicit jobnet `sd` rule/day diagnostics, and sync the stale
-  execution-interval alignment note so the backlog reflects delivered work.
+  explicit transfer-file value-shape diagnostics for `tsN` / `tdN` across
+  UNIX/PC, UNIX/PC custom, and QUEUE-family units.
 - Status: approved implementation and validation are complete in the recorded
   scope.
-- Scope: update SDD artifacts for a focused schedule-rule follow-up that would
-  keep ownership in `buildSyntaxDiagnostics.ts`, reuse the existing
-  `parseScheduleDateValue` seam for explicit `sd` interpretation, add user-
-  visible diagnostics for out-of-range schedule-rule numbers or day values,
-  treat the `SCHEDULELIMIT` year upper bound as the official default value
-  during this slice, and preserve parser output, domain wrapper values,
-  normalized parameters, unit-list projection, flow projection, command
-  generation, generated artifacts, dependency versions, and `engines.vscode`.
-- Out of scope: runtime implementation before approval, parser grammar
-  changes, domain default changes, schedule-rule projection changes, broader
-  schedule-rule cross-parameter invalidation, dependency changes, and
-  unrelated default-only follow-ups.
-- Impact summary: the approved implementation candidate would affect
-  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
-  `src/domain/models/parameters/scheduleRuleHelpers.ts`, focused
-  schedule-rule and diagnostics regression tests, the parameter-alignment
-  feature docs, and the editor-feedback behavior contract.
-- Risks and assumptions: this slice assumes explicit `sd` range validation can
-  remain in the shared application editor-feedback boundary without changing
-  parser acceptance or wrapper normalization. `sd=0,ud` must stay as a
-  documented special valid case, and the `SCHEDULELIMIT`-dependent year range
-  is currently interpreted using the official default value `2036`, because
-  this slice does not yet have a repository-approved environment-specific
-  input source.
-- Alternatives considered: switch to a smaller default-only gap such as HTTP
-  Connection `eu` or file-monitoring `ets`, rejected because those are less
-  user-visible and too fine-grained for the next slice; broaden the schedule
-  slice to all remaining `sd` policy questions, rejected because that would
-  mix straightforward diagnostics with unresolved product decisions.
+- Scope: grouped transfer-file explicit value-shape diagnostics were added in
+  `buildSyntaxDiagnostics.ts` for explicit `tsN` / `tdN` values that are
+  neither quoted transfer-file strings nor already accepted macro-variable
+  forms, while preserving parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, command generation,
+  generated artifacts, dependency versions, and `engines.vscode`.
+- Out of scope: parser grammar changes, domain default changes,
+  transfer-operation `topN` behavior, platform-specific path interpretation,
+  projection changes, dependency changes, and unrelated default-only
+  follow-ups.
+- Impact summary: the implemented slice affected
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
+  transfer-file diagnostics regression tests, the parameter-alignment feature
+  docs, and the editor-feedback behavior contract.
+- Risks and assumptions: the slice keeps transfer-file validation at the
+  application editor-feedback boundary and preserves existing macro-variable
+  allowance. Broader path semantics remain deferred and should be reconsidered
+  only in a separate approved slice.
+- Alternatives considered: smaller default-only gaps remained rejected as less
+  user-meaningful; broader path semantics remained rejected as higher-risk
+  product interpretation.
 
 ## Build/Test Performance SDD
 
@@ -139,9 +140,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped schedule-rule `sd` explicit date/rule diagnostics are
-  implemented using the official default `SCHEDULELIMIT=2036`; remaining
-  gaps should be re-selected from the updated coverage matrix.
+  slice: grouped transfer-file `tsN` / `tdN` explicit value-shape diagnostics
+  are implemented across transfer-operation and QUEUE transfer-file families;
+  the next candidate should be re-selected from the updated coverage matrix.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -237,6 +237,23 @@ const isValidExplicitFileMonitoringInterval = (
   parameter: UnitParameter | undefined,
 ): boolean => parseExplicitDecimalInRange(parameter, 1, 600) !== undefined;
 
+const isExplicitMacroVariable = (value: string): boolean =>
+  /^\?[^?\r\n]+\?$/.test(value);
+
+const isQuotedStringLiteral = (value: string): boolean =>
+  /^"(?:\\.|[^"\\])*"$/.test(value);
+
+const isValidExplicitTransferFileValue = (
+  parameter: UnitParameter | undefined,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (!rawValue) {
+    return false;
+  }
+
+  return isQuotedStringLiteral(rawValue) || isExplicitMacroVariable(rawValue);
+};
+
 const hasInvalidWildcardWithShortMonitoringInterval = (
   parameter: UnitParameter,
   unit: Unit,
@@ -732,9 +749,24 @@ const transferFileByteLengthRules: readonly UnitParameterDiagnosticRule[] =
     ),
   ]);
 
+const transferFileValueShapeRules: readonly UnitParameterDiagnosticRule[] =
+  transferFileIndexes.flatMap((index) => [
+    {
+      key: `ts${index}`,
+      message: `Transfer source file name (ts${index}) must be a quoted transfer-file value or macro-variable form.`,
+      isInvalid: (parameter) => !isValidExplicitTransferFileValue(parameter),
+    },
+    {
+      key: `td${index}`,
+      message: `Transfer destination file name (td${index}) must be a quoted transfer-file value or macro-variable form.`,
+      isInvalid: (parameter) => !isValidExplicitTransferFileValue(parameter),
+    },
+  ]);
+
 const transferOperationDiagnosticRules: readonly UnitParameterDiagnosticRule[] =
   [
     ...transferFileByteLengthRules,
+    ...transferFileValueShapeRules,
     ...transferFileIndexes.flatMap((index) => [
       buildRequiredParameterRule(
         `td${index}`,
@@ -752,6 +784,7 @@ const transferOperationDiagnosticRules: readonly UnitParameterDiagnosticRule[] =
 const queueTransferFileDiagnosticRules: readonly UnitParameterDiagnosticRule[] =
   [
     ...transferFileByteLengthRules,
+    ...transferFileValueShapeRules,
     ...transferFileIndexes.map((index) =>
       buildRequiredParameterRule(
         `td${index}`,

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -1004,19 +1004,19 @@ suite("Build Syntax Diagnostics", () => {
         "  {",
         "    ty=j;",
         "    ts1=?AJS2SRC1?;",
-        "    td1=?AJS2DST1?;",
+        '    td1="dest-1";',
         "    top1=sav;",
         "  }",
         "  unit=custom,,jp1admin,;",
         "  {",
         "    ty=cj;",
-        "    ts1=source-1;",
+        '    ts1="source-1";',
         "    top1=sav;",
         "  }",
         "  unit=queue1,,jp1admin,;",
         "  {",
         "    ty=qj;",
-        "    ts1=?AJS2QSRC1?;",
+        '    ts1="queue-source";',
         "    td1=?AJS2QDST1?;",
         "  }",
         "}",
@@ -1080,6 +1080,68 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(
       diagnostics.map((diagnostic) => diagnostic.severity),
       ["error", "error"],
+    );
+  });
+
+  test("reports transfer-file value-shape diagnostics for explicit bare strings", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=queue1,qj,+160+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        "    ts1=source-1;",
+        "    td1=dest-1;",
+        "  }",
+        "  unit=queue1,,jp1admin,;",
+        "  {",
+        "    ty=qj;",
+        "    ts1=queue-source;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 3);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 3,
+          message:
+            "Transfer source file name (ts1) must be a quoted transfer-file value or macro-variable form.",
+        },
+        {
+          line: 10,
+          column: 4,
+          length: 3,
+          message:
+            "Transfer destination file name (td1) must be a quoted transfer-file value or macro-variable form.",
+        },
+        {
+          line: 15,
+          column: 4,
+          length: 3,
+          message:
+            "Transfer source file name (ts1) must be a quoted transfer-file value or macro-variable form.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error"],
     );
   });
 


### PR DESCRIPTION
## Summary
- add editor-feedback diagnostics for transfer-file values that are neither quoted strings nor accepted macro-variable forms
- add regression coverage for quoted values, macro-variable values, and invalid bare strings
- sync SDD plans, tasks, coverage, and use-case docs for the completed slice

## Validation
- rtk pnpm run qlty
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
- rtk pnpm run lint:md