### PR TITLE
[codex] align ets timeout diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -186,6 +186,15 @@ Scenario: Event host values must stay within documented byte-length rules
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Event timeout actions must stay within documented values
+  Given a syntactically valid JP1/AJS document with a file monitoring job or
+    execution-interval control job
+  And explicit `ets` is outside the JP1/AJS3 v13 value set
+    `{kl|nr|wr|an}`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Shared filename-like rules stay explicit across parameter families
   Given a syntactically valid JP1/AJS document with a parameter family that
     uses documented filename-like or host-like values

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_TIMEOUT_ACTION_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_TIMEOUT_ACTION_ALIGNMENT.md
@@ -1,0 +1,102 @@
+# Event Timeout Action Alignment
+
+## Purpose
+
+Record the delivered JP1/AJS3 version 13 parameter-alignment slice around
+grouped explicit `ets` timeout-action diagnostics.
+
+This slice groups the remaining user-visible `ets` gap across file monitoring
+jobs and execution-interval control jobs instead of reopening one job family at
+a time.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual sections:
+  - Command Reference, `5.2.10 File monitoring job definition`
+  - Command Reference, `5.2.20 Execution-interval control job definition`
+- Parameter in scope:
+  `ets={kl|nr|wr|an}`
+
+## Slice Boundary
+
+- Domain seams kept unchanged:
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`,
+  `src/domain/models/parameters/Defaults.ts`,
+  `src/domain/models/units/Flwj.ts`, and
+  `src/domain/models/units/Tmwj.ts`
+- Implementation seam:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`
+- Existing consumer kept unchanged:
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`
+- Regression evidence:
+  focused `src/test/suite/buildSyntaxDiagnostics.test.ts`
+- Out of scope:
+  parser grammar changes, domain default changes, unit-list projection changes,
+  `tmitv` validation, `etn` validation, broader wait-job default
+  reconciliation, other `ets`-bearing unit families, generated artifacts,
+  configuration, dependency versions, and `engines.vscode`
+
+## Investigation Notes
+
+- `DEFAULTS.Ets` is already `kl`, and current wrapper or group 13 projection
+  behavior for omitted `ets` is already aligned for `flwj` / `rflwj` and
+  `tmwj` / `rtmwj`.
+- `buildSyntaxDiagnostics.ts` currently has no explicit `ets` validation path,
+  so syntactically valid but manual-invalid explicit values remain
+  non-diagnostic.
+- The same `ets` parameter accessor is exposed by additional wrappers such as
+  `Evwj`, `Lfwj`, `Mlwj`, `Mqwj`, `Mswj`, and `Ntwj`, but those families do not
+  yet have feature-local alignment records for timeout-action validation.
+- Because the current backlog already has two partial rows that share both the
+  `ets` parameter and the group 13 `eventTimeoutAction` presentation concept,
+  this grouped slice is more user-meaningful than returning to a smaller
+  default-only gap such as HTTP Connection `eu`.
+
+## Delivered Alignment
+
+- The editor-feedback boundary now reports a semantic diagnostic when an
+  explicit file-monitoring job or recovery file-monitoring job sets `ets`
+  outside `{kl|nr|wr|an}`.
+- The editor-feedback boundary now reports a semantic diagnostic when an
+  explicit execution-interval control job or recovery execution-interval
+  control job sets `ets` outside `{kl|nr|wr|an}`.
+- Omitted `ets` remains non-diagnostic because existing default behavior is
+  already aligned and valid.
+- Diagnostics stay at the application editor-feedback boundary, so parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation remain unchanged.
+- A small helper extraction now keeps shared explicit allowed-value validation
+  on the existing `buildSyntaxDiagnostics.ts` helper/rule-array path instead of
+  creating a separate timeout-rule path.
+
+## Impact
+
+- User-visible diagnostics would change for syntactically valid JP1/AJS
+  documents containing explicit invalid `ets` values on `flwj`, `rflwj`,
+  `tmwj`, or `rtmwj`.
+- Existing parsed parameter source-location metadata should be enough to point
+  diagnostics at the explicit `ets` parameter, so no parser or DTO shape
+  change is expected.
+- The application diagnostics boundary remains the owner of this validation;
+  domain defaults and projection defaults remain as delivered in earlier
+  slices.
+
+## Alternatives
+
+- Revisit only file-monitoring `ets` first; rejected because the remaining
+  backlog already has another partial row with the same user-facing timeout
+  action concept.
+- Broaden the slice to every `ets`-bearing wrapper immediately; rejected
+  because that would exceed the currently investigated feature rows and widen
+  product interpretation risk.
+- Revisit execution-interval `tmitv` / `etn` range behavior in the same slice;
+  rejected because the current evidence set and rules are not the same as the
+  shared explicit `ets` allowed-value rule.
+
+## Follow-up
+
+- File monitoring can now be treated as `Aligned` for the currently modeled
+  `flwf`, `flwc`, `flwi`, `flco`, and `ets` scope.
+- Execution-interval control still retains separate follow-up for `tmitv` /
+  `etn` validation and broader wait-job reconciliation.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
@@ -49,8 +49,10 @@ The reference defines omitted values as:
 
 ## Remaining Gap
 
-- Range validation and broader wait-job default reconciliation remain outside
-  this delivered slice.
+- Explicit `ets` timeout-action diagnostics are now aligned through the shared
+  editor-feedback boundary for `tmwj` / `rtmwj`.
+- `tmitv` / `etn` validation and broader wait-job default reconciliation
+  remain outside the delivered slices.
 
 ## Alternatives
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/FILE_MONITORING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/FILE_MONITORING_JOB_ALIGNMENT.md
@@ -84,6 +84,17 @@ This document focuses on the currently modeled file monitoring job parameters
 - Diagnostics point at the explicit `flwf` or `flwi` parameter, so parser and
   DTO shapes remain unchanged.
 
+## Delivered Timeout-Action Validation
+
+- Editor feedback now reports a semantic diagnostic when an explicit
+  file-monitoring job or recovery file-monitoring job sets `ets` outside the
+  documented JP1/AJS3 v13 value set `{kl|nr|wr|an}`.
+- Omitted `ets` remains non-diagnostic because the existing default value
+  `kl` is already aligned and valid.
+- The implementation stays in `buildSyntaxDiagnostics.ts`, preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation.
+
 ## Impact
 
 - User-visible diagnostics would change for syntactically valid JP1/AJS
@@ -116,5 +127,5 @@ This document focuses on the currently modeled file monitoring job parameters
 
 ## Follow-up
 
-- Revisit `ets` timeout behavior now that the grouped `flwf` / `flwi`
-  validation slice is implemented.
+- none for the currently modeled file-monitoring parameters in this feature
+  scope

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -129,21 +129,15 @@ coverage.
 
 - Keys: `flwf`, `flwc`, `flwi`, `flco`, and `ets`
 - Unit scope: file monitoring jobs and recovery file monitoring jobs
-- Status: partial
+- Status: aligned
 - Owning seam: `Flwj.ts`, `optionalScalarParameterBuilders.ts`, and
   `Defaults.ts`
 - Evidence:
   `parameterFactory.test.ts` for existing domain default seams and
   `buildUnitListRemainingGroups.test.ts` for group 13 projection
 - Remaining gap:
-  unit-list group 13 default-aware projection is aligned for these defaults,
-  `flwc` / `flco` invalid-combination diagnostics are aligned through
-  editor-feedback, and `flwf` / `flwi` target-pattern validation is aligned
-  through editor-feedback for byte-length, numeric range, and
-  wildcard-with-short-interval rules. `ets` timeout behavior remains
-  deferred. The delivered file-monitoring diagnostics now serve as one reuse
-  reference for the shared generic-rule slice recorded in
-  `GENERIC_PARAMETER_RULE_ALIGNMENT.md`.
+  none for the currently modeled file-monitoring parameters in this feature
+  scope
 
 ### Execution-Interval Control Job Defaults
 
@@ -159,8 +153,9 @@ coverage.
   `buildUnitListRemainingGroups.test.ts` for group 13 projection
 - Remaining gap:
   execution-interval control job defaults and unit-list group 13 projection
-  are aligned for these values; range validation and broader wait-job default
-  reconciliation are deferred
+  are aligned for these values, and explicit `ets` timeout-action
+  diagnostics are aligned through editor-feedback. `tmitv` / `etn`
+  validation and broader wait-job default reconciliation remain deferred
 
 ### Event Reception Monitoring Job Search Scope
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -133,6 +133,25 @@ JP1/AJS3 version 13 reference documents.
   `flwi` value is in the JP1/AJS3 v13 restricted range `1..9`, while
   preserving raw parser output, domain wrapper values, normalized parameters,
   unit-list projection, flow projection, and command generation.
+- Shared `ets` timeout-action diagnostics are approval-sensitive because
+  `ParamFactory.ets` and group 13 `eventTimeoutAction` projection are shared
+  across multiple wait or event job families, while only file monitoring and
+  execution-interval control jobs remain as feature-local partial rows. A
+  focused follow-up should stay inside application editor-feedback, report
+  explicit `ets` values outside the documented set `{kl|nr|wr|an}` for
+  `flwj` / `rflwj` and `tmwj` / `rtmwj`, include only the small helper
+  extraction needed to keep explicit allowed-value validation on the existing
+  `buildSyntaxDiagnostics.ts` rule-array path, and preserve raw parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation. Broader `ets`-bearing unit families,
+  `tmitv` or `etn` validation, and wait-job default reconciliation remain
+  separate approval-sensitive work.
+- Shared `ets` timeout-action diagnostics are aligned through application
+  editor-feedback for explicit `flwj` / `rflwj` and `tmwj` / `rtmwj` values
+  that fall outside `{kl|nr|wr|an}`, while raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation remain unchanged. Broader `ets`-bearing unit families and
+  `tmitv` / `etn` validation remain deferred.
 - Execution-interval control job defaults are approval-sensitive because
   JP1/AJS3 version 13 defines omitted `tmitv`, `etn`, and `ets` behavior for
   `tmwj` / `rtmwj`, while current code only has generic defaults for `etn` and

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -157,6 +157,21 @@
 - [x] Add focused regression evidence for quoted transfer-file values,
       accepted macro-variable forms, and explicit bare-string violations
 - [x] Run required code-change validation after implementation
+- [x] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
+      delivered transfer-file explicit value-shape slice and select the next
+      candidate using the same user-meaningful grouping rule
+- [ ] Record human approval before changing editor-feedback diagnostics,
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      `ets` timeout-action diagnostics
+- [x] Implement grouped `ets` timeout-action diagnostics only after approval
+- [x] Refactor `buildSyntaxDiagnostics.ts` within the approved scope so shared
+      explicit allowed-value validation for `ets` stays on the existing
+      helper/rule-array path
+- [x] Add focused regression evidence for omitted defaults, valid explicit
+      `ets`, and explicit invalid `ets` values on file monitoring and
+      execution-interval control jobs
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -485,6 +500,32 @@
   rule path, and raw parser output, domain wrapper values, normalized
   parameters, unit-list projection, flow projection, and command generation
   remain unchanged.
+- 2026-05-08: Remaining partial and deferred JP1/AJS v13 gaps were re-checked
+  after the delivered transfer-file explicit value-shape slice. The next
+  recommended approval-gated candidate is grouped explicit `ets`
+  timeout-action diagnostics across file monitoring and execution-interval
+  control jobs, because the remaining user-visible gap now clusters around
+  one shared parameter family and one shared group 13 presentation concept.
+- 2026-05-08: Investigation confirmed that `DEFAULTS.Ets`, wrapper defaults,
+  and group 13 projection are already aligned for `flwj` / `rflwj` and
+  `tmwj` / `rtmwj`; the remaining gap is limited to explicit invalid `ets`
+  values that currently pass through editor feedback without semantic
+  diagnostics.
+- 2026-05-08: Investigation also confirmed that `ParamFactory.ets` is reused
+  by additional wait or event job families beyond the two current partial
+  rows, so the proposed slice must stay scoped to file monitoring and
+  execution-interval control jobs unless a later approval explicitly broadens
+  that boundary.
+- 2026-05-08: Grouped `ets` timeout-action diagnostics now report explicit
+  invalid `ets` values on `flwj` / `rflwj` and `tmwj` / `rtmwj` through the
+  existing editor-feedback boundary. Shared allowed-value validation stays on
+  the current `buildSyntaxDiagnostics.ts` rule-array path, and raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation remain unchanged.
+- 2026-05-08: `PARAMETER_COVERAGE_MATRIX.md` now marks file monitoring as
+  aligned for the currently modeled `flwf`, `flwc`, `flwi`, `flco`, and `ets`
+  scope. Execution-interval control remains partial because `tmitv` / `etn`
+  validation and broader wait-job reconciliation are still deferred.
 - 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
   transfer-file explicit value-shape diagnostics implementation.
 - 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped
@@ -498,27 +539,56 @@
   implementation.
 - 2026-05-07: `rtk pnpm run lint:md` completed with exit code 0 after grouped
   transfer-file explicit value-shape diagnostics implementation.
+- 2026-05-08: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  `ets` timeout-action diagnostics implementation.
+- 2026-05-08: `rtk pnpm test` completed with exit code 0 after grouped `ets`
+  timeout-action diagnostics implementation; the VS Code harness emitted the
+  existing macOS `task_name_for_pid` codesign noise line.
+- 2026-05-08: `rtk pnpm run test:web` completed with exit code 0 after
+  grouped `ets` timeout-action diagnostics implementation and emitted the
+  existing localhost dev-extension `package.nls.json` 404 noise.
+- 2026-05-08: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped `ets` timeout-action diagnostics implementation.
+- 2026-05-08: `rtk pnpm run lint:md` completed with exit code 0 after grouped
+  `ets` timeout-action diagnostics implementation.
 
 ## Human Approval
 
 - Status: Approved
-- Approved at: 2026-05-07
-- Approved scope: grouped transfer-file explicit value-shape diagnostics
-  through the existing editor-feedback boundary, limited to explicit `ts1` to
-  `ts4` and `td1` to `td4` values on UNIX/PC jobs, UNIX/PC custom jobs,
-  QUEUE jobs, and recovery QUEUE jobs when the value is neither a quoted
-  transfer-file string nor an already accepted macro-variable form, while
-  preserving raw parser output, domain wrapper values, normalized parameters,
-  unit-list projection, flow projection, and command generation. Parser
-  grammar, transfer-operation `topN` behavior, byte-length rules already
-  delivered, generated artifacts, dependency versions, configuration, and
-  `engines.vscode` remain out of scope.
+- Approved at: 2026-05-08
+- Approved scope: grouped explicit `ets` timeout-action diagnostics through
+  the existing editor-feedback boundary, limited to explicit `ets` values on
+  file monitoring jobs (`flwj` / `rflwj`) and execution-interval control jobs
+  (`tmwj` / `rtmwj`) that fall outside the documented JP1/AJS3 v13 set
+  `{kl|nr|wr|an}`, plus the smallest refactor needed to keep shared
+  allowed-value validation on the current `buildSyntaxDiagnostics.ts`
+  helper/rule-array path, while preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation. Parser grammar, domain default changes, unit-list
+  projection changes, `tmitv` / `etn` validation, broader wait-job
+  reconciliation, other `ets`-bearing unit families, generated artifacts,
+  dependency versions, configuration, and `engines.vscode` remain out of
+  scope.
 
-Current implementation gate: transfer-file explicit value-shape diagnostics
-are implemented and validated inside the recorded scope.
+Current implementation gate: grouped `ets` timeout-action diagnostics are
+implemented and validated inside the recorded scope.
 
 ## Prior Approval Evidence
 
+- 2026-05-08: User replied "Approved. Proceed with implementation." after the
+  grouped `ets` timeout-action diagnostics approval request. Approved changes
+  were limited to adding grouped application-level semantic diagnostics for
+  explicit invalid `ets` values on file monitoring jobs and
+  execution-interval control jobs through the existing editor-feedback
+  boundary, plus the smallest refactor needed to keep shared allowed-value
+  validation on the current `buildSyntaxDiagnostics.ts` helper/rule-array
+  path; preserving raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation;
+  adding focused regression evidence; updating SDD tracking; and running
+  validation. Parser grammar, domain default changes, unit-list projection
+  changes, `tmitv` / `etn` validation, broader wait-job reconciliation, other
+  `ets`-bearing unit families, generated artifacts, configuration, dependency
+  versions, and `engines.vscode` were out of scope.
 - 2026-05-07: User replied "Approved. Proceed with implementation." after the
   grouped transfer-file explicit value-shape diagnostics approval request.
   Approved changes were limited to adding grouped application-level semantic

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -52,6 +52,10 @@ rules in `docs/specs/README.md`, not in this file.
   next recommended JP1/AJS v13 candidate should be re-selected from the
   remaining partial or deferred gaps using the same user-meaningful grouping
   rule, instead of defaulting immediately to smaller default-only follow-ups.
+- After the delivered grouped `ets` timeout-action diagnostics slice, the next
+  recommended JP1/AJS v13 candidate should be re-selected from the remaining
+  partial or deferred gaps using the same user-meaningful grouping rule,
+  instead of defaulting immediately to smaller default-only follow-ups.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -86,32 +90,35 @@ rules in `docs/specs/README.md`, not in this file.
 
 - Branch: `main`; a dedicated implementation branch was attempted but could
   not be created from the sandboxed session after approval
-- Objective: prepare the next JP1/AJS v13 parameter-alignment slice around
-  explicit transfer-file value-shape diagnostics for `tsN` / `tdN` across
-  UNIX/PC, UNIX/PC custom, and QUEUE-family units.
+- Objective: prepare the next JP1/AJS v13 parameter-alignment candidate after
+  the delivered grouped `ets` timeout-action diagnostics slice.
 - Status: approved implementation and validation are complete in the recorded
   scope.
-- Scope: grouped transfer-file explicit value-shape diagnostics were added in
-  `buildSyntaxDiagnostics.ts` for explicit `tsN` / `tdN` values that are
-  neither quoted transfer-file strings nor already accepted macro-variable
-  forms, while preserving parser output, domain wrapper values, normalized
-  parameters, unit-list projection, flow projection, command generation,
-  generated artifacts, dependency versions, and `engines.vscode`.
-- Out of scope: parser grammar changes, domain default changes,
-  transfer-operation `topN` behavior, platform-specific path interpretation,
-  projection changes, dependency changes, and unrelated default-only
-  follow-ups.
+- Scope: grouped explicit `ets` timeout-action diagnostics were added in
+  `buildSyntaxDiagnostics.ts` for explicit `ets` values outside
+  `{kl|nr|wr|an}` on `flwj` / `rflwj` and `tmwj` / `rtmwj`, including the
+  smallest helper/rule refactor needed to keep shared allowed-value
+  validation on the existing rule-array path, while preserving parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, command generation, generated artifacts, dependency versions,
+  and `engines.vscode`.
+- Out of scope: parser grammar changes, domain defaults, unit-list
+  projection changes, `tmitv` or `etn` validation, broader wait-job
+  reconciliation, other `ets`-bearing unit families, and unrelated
+  default-only follow-ups.
 - Impact summary: the implemented slice affected
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
-  transfer-file diagnostics regression tests, the parameter-alignment feature
-  docs, and the editor-feedback behavior contract.
-- Risks and assumptions: the slice keeps transfer-file validation at the
-  application editor-feedback boundary and preserves existing macro-variable
-  allowance. Broader path semantics remain deferred and should be reconsidered
-  only in a separate approved slice.
-- Alternatives considered: smaller default-only gaps remained rejected as less
-  user-meaningful; broader path semantics remained rejected as higher-risk
-  product interpretation.
+  diagnostics regression tests, the parameter-alignment feature docs, and the
+  editor-feedback behavior contract.
+- Risks and assumptions: `ParamFactory.ets` is shared by more wrappers than
+  the two implemented rows, so the delivered diagnostics stay scoped to the
+  investigated file-monitoring and execution-interval control job families.
+  Broader `ets` semantics remain deferred and should be reconsidered only in a
+  separate approved slice.
+- Alternatives considered: the remaining HTTP Connection `eu` conflict stayed
+  less user-visible, while broadening to every `ets`-bearing unit family or
+  folding `tmitv` / `etn` validation into the same slice would have exceeded
+  the shared-rule boundary that justified this grouped implementation.
 
 ## Build/Test Performance SDD
 
@@ -140,9 +147,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped transfer-file `tsN` / `tdN` explicit value-shape diagnostics
-  are implemented across transfer-operation and QUEUE transfer-file families;
-  the next candidate should be re-selected from the updated coverage matrix.
+  slice: grouped `ets` timeout-action diagnostics are implemented for
+  file-monitoring and execution-interval control jobs; the next candidate
+  should be re-selected from the updated coverage matrix.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -33,6 +33,10 @@ const jobEndJudgmentDiagnosticTargetTypes = new Set([
 ]);
 const jobEndJudgmentRetryParameterKeys = ["rjs", "rje", "rec", "rei"];
 const fileMonitoringDiagnosticTargetTypes = new Set(["flwj", "rflwj"]);
+const executionIntervalControlDiagnosticTargetTypes = new Set([
+  "tmwj",
+  "rtmwj",
+]);
 const eventSendingDiagnosticTargetTypes = new Set(["evsj", "revsj"]);
 const eventReceivingDiagnosticTargetTypes = new Set(["evwj", "revwj"]);
 const scheduleRuleDiagnosticTargetTypes = new Set(["g", "n"]);
@@ -101,6 +105,16 @@ const buildExplicitByteLengthRule = (
   message,
   isInvalid: (parameter) =>
     !isValidExplicitByteLengthValue(parameter, minimum, maximum),
+});
+
+const buildExplicitAllowedValuesRule = (
+  key: string,
+  allowedValues: ReadonlySet<string>,
+  message: string,
+): UnitParameterDiagnosticRule => ({
+  key,
+  message,
+  isInvalid: (parameter) => !allowedValues.has(parameter.value),
 });
 
 const buildRequiredParameterRule = (
@@ -694,6 +708,8 @@ const isValidExplicitWaitTime = (parameter: UnitParameter): boolean => {
   );
 };
 
+const eventTimeoutActionAllowedValues = new Set(["kl", "nr", "wr", "an"]);
+
 const jobEndJudgmentNumericRangeRules = [
   buildExplicitDecimalRangeRule(
     "wth",
@@ -730,6 +746,14 @@ const jobEndJudgmentNumericRangeRules = [
     1,
     10,
     "Retry interval (rei) must be between 1 and 10.",
+  ),
+] as const;
+
+const eventTimeoutActionDiagnosticRules = [
+  buildExplicitAllowedValuesRule(
+    "ets",
+    eventTimeoutActionAllowedValues,
+    "Event timeout action (ets) must be one of kl, nr, wr, or an.",
   ),
 ] as const;
 
@@ -829,7 +853,11 @@ const fileMonitoringDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
       return !splitFileMonitoringConditions(effectiveFlwc).has("c");
     },
   },
+  ...eventTimeoutActionDiagnosticRules,
 ];
+
+const executionIntervalControlDiagnosticRules: readonly UnitParameterDiagnosticRule[] =
+  [...eventTimeoutActionDiagnosticRules];
 
 const eventSendingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
   {
@@ -1094,6 +1122,16 @@ const buildFileMonitoringDiagnostics = (
     (unit) => collectRuleDiagnostics(unit, fileMonitoringDiagnosticRules),
   );
 
+const buildExecutionIntervalControlDiagnostics = (
+  rootUnits: Unit[],
+): SyntaxDiagnosticDto[] =>
+  findUnitsByTypes(
+    rootUnits,
+    executionIntervalControlDiagnosticTargetTypes,
+  ).flatMap((unit) =>
+    collectRuleDiagnostics(unit, executionIntervalControlDiagnosticRules),
+  );
+
 const buildTransferOperationDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
@@ -1158,6 +1196,7 @@ export const buildSyntaxDiagnostics = (
     ...buildScheduleRuleDiagnostics(result.rootUnits, options),
     ...buildJobEndJudgmentDiagnostics(result.rootUnits),
     ...buildFileMonitoringDiagnostics(result.rootUnits),
+    ...buildExecutionIntervalControlDiagnostics(result.rootUnits),
     ...buildTransferOperationDiagnostics(result.rootUnits),
     ...buildQueueTransferFileDiagnostics(result.rootUnits),
     ...buildEventSendingDiagnostics(result.rootUnits),

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -991,6 +991,96 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("does not report event timeout action diagnostics for omitted defaults and valid explicit values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=file1,flwj,+0+0;",
+        "  el=file2,rflwj,+160+0;",
+        "  el=interval1,tmwj,+320+0;",
+        "  el=interval2,rtmwj,+480+0;",
+        "  unit=file1,,jp1admin,;",
+        "  {",
+        "    ty=flwj;",
+        "  }",
+        "  unit=file2,,jp1admin,;",
+        "  {",
+        "    ty=rflwj;",
+        "    ets=wr;",
+        "  }",
+        "  unit=interval1,,jp1admin,;",
+        "  {",
+        "    ty=tmwj;",
+        "  }",
+        "  unit=interval2,,jp1admin,;",
+        "  {",
+        "    ty=rtmwj;",
+        "    ets=an;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports event timeout action diagnostics for explicit invalid values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=file1,flwj,+0+0;",
+        "  el=interval1,tmwj,+160+0;",
+        "  unit=file1,,jp1admin,;",
+        "  {",
+        "    ty=flwj;",
+        "    ets=xx;",
+        "  }",
+        "  unit=interval1,,jp1admin,;",
+        "  {",
+        "    ty=tmwj;",
+        "    ets=yy;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 2);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 3,
+          message:
+            "Event timeout action (ets) must be one of kl, nr, wr, or an.",
+        },
+        {
+          line: 14,
+          column: 4,
+          length: 3,
+          message:
+            "Event timeout action (ets) must be one of kl, nr, wr, or an.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error"],
+    );
+  });
+
   test("does not report transfer-file diagnostics for valid explicit values and macro variables", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [


### PR DESCRIPTION
## What changed

- added JP1/AJS v13 semantic diagnostics for explicit invalid `ets` values on file monitoring jobs (`flwj` / `rflwj`) and execution-interval control jobs (`tmwj` / `rtmwj`)
- kept the validation on the existing `buildSyntaxDiagnostics.ts` rule-array path by introducing a shared allowed-values helper instead of a separate timeout-specific path
- added focused regression coverage for omitted defaults, valid explicit `ets`, and invalid explicit `ets` values
- synced the SDD artifacts, coverage matrix, and editor-feedback use case for the delivered slice

## Why

The remaining user-visible gap clustered around one shared parameter family: `ets` timeout-action values. Existing defaults and group 13 projection were already aligned for the investigated job families, but explicit manual-invalid `ets` values still passed through editor feedback without semantic diagnostics.

## Impact

Users now get semantic diagnostics when explicit `ets` values fall outside the JP1/AJS3 v13 set `{kl|nr|wr|an}` for the approved file-monitoring and execution-interval-control scope. Parser output, domain wrapper values, normalized parameters, unit-list projection, flow projection, and command generation remain unchanged.

## Validation

- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`
