### PR TITLE
[codex] add execution-interval control diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -195,6 +195,16 @@ Scenario: Event timeout actions must stay within documented values
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Execution-interval control job values must stay within documented
+  ranges
+  Given a syntactically valid JP1/AJS document with an execution-interval
+    control job
+  And explicit `tmitv` is outside the JP1/AJS3 v13 range `1..1440`
+  Or explicit `etn` is outside the JP1/AJS3 v13 value set `{y|n}`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Shared filename-like rules stay explicit across parameter families
   Given a syntactically valid JP1/AJS document with a parameter family that
     uses documented filename-like or host-like values

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
@@ -51,8 +51,13 @@ The reference defines omitted values as:
 
 - Explicit `ets` timeout-action diagnostics are now aligned through the shared
   editor-feedback boundary for `tmwj` / `rtmwj`.
-- `tmitv` / `etn` validation and broader wait-job default reconciliation
-  remain outside the delivered slices.
+- Explicit `tmitv` range diagnostics are now aligned through the shared
+  editor-feedback boundary for `tmwj` / `rtmwj`.
+- Explicit `etn` allowed-value diagnostics are now aligned through the shared
+  editor-feedback boundary for `tmwj` / `rtmwj`.
+- Broader `etn=y` start-condition semantics, compatible-ISAM restrictions,
+  and wait-job default reconciliation remain outside the smallest meaningful
+  validation slice.
 
 ## Alternatives
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -154,8 +154,11 @@ coverage.
 - Remaining gap:
   execution-interval control job defaults and unit-list group 13 projection
   are aligned for these values, and explicit `ets` timeout-action
-  diagnostics are aligned through editor-feedback. `tmitv` / `etn`
-  validation and broader wait-job default reconciliation remain deferred
+  diagnostics are aligned through editor-feedback. Explicit `tmitv` range
+  diagnostics and explicit `etn` allowed-value diagnostics are also aligned
+  through editor-feedback. Context-sensitive `etn=y` start-condition
+  semantics, compatible-ISAM restrictions, and broader wait-job default
+  reconciliation remain deferred
 
 ### Event Reception Monitoring Job Search Scope
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -162,6 +162,17 @@ JP1/AJS3 version 13 reference documents.
   table output. If approved, it should consume execution-interval defaults for
   `tmitv`, `etn`, and `ets` while preserving explicit normalized values,
   parser output, and normalized raw parameter storage.
+- Execution-interval control job `tmitv` / `etn` diagnostics are approval-
+  sensitive because existing behavior preserves explicit invalid wait-time and
+  end-timing values as raw parsed data without editor feedback. A focused
+  follow-up should stay inside application editor-feedback, report explicit
+  `tmitv` values outside the JP1/AJS3 v13 range `1..1440` and explicit `etn`
+  values outside `{y|n}` for `tmwj` / `rtmwj`, reuse the existing decimal-
+  range and allowed-value rule helpers where practical, and preserve raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation. Context-sensitive
+  `etn=y` start-condition semantics and compatible-ISAM restrictions remain
+  separate approval-sensitive work.
 - Job end-judgment `jd` / `abr` diagnostics are approval-sensitive because
   existing behavior preserves explicit invalid combinations as raw parsed
   values without editor feedback. A diagnostic slice must preserve raw parser

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -160,7 +160,6 @@
 - [x] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
       delivered transfer-file explicit value-shape slice and select the next
       candidate using the same user-meaningful grouping rule
-- [ ] Record human approval before changing editor-feedback diagnostics,
 - [x] Record human approval before changing editor-feedback diagnostics,
       runtime code, tests, generated artifacts, or configuration for grouped
       `ets` timeout-action diagnostics
@@ -171,6 +170,19 @@
 - [x] Add focused regression evidence for omitted defaults, valid explicit
       `ets`, and explicit invalid `ets` values on file monitoring and
       execution-interval control jobs
+- [x] Run required code-change validation after implementation
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      execution-interval control job `tmitv` / `etn` diagnostics
+- [x] Implement grouped execution-interval control job `tmitv` / `etn`
+      diagnostics only after approval
+- [x] Refactor `buildSyntaxDiagnostics.ts` within the approved scope so the
+      execution-interval rules reuse the existing decimal-range and
+      allowed-value helper/rule-array path without creating a separate
+      diagnostic layer
+- [x] Add focused regression evidence for omitted defaults, valid explicit
+      values, explicit out-of-range `tmitv`, and explicit invalid `etn`
+      values on execution-interval control jobs
 - [x] Run required code-change validation after implementation
 
 ## Notes
@@ -526,6 +538,29 @@
   aligned for the currently modeled `flwf`, `flwc`, `flwi`, `flco`, and `ets`
   scope. Execution-interval control remains partial because `tmitv` / `etn`
   validation and broader wait-job reconciliation are still deferred.
+- 2026-05-08: Remaining partial and deferred JP1/AJS v13 gaps were re-checked
+  after the delivered grouped `ets` timeout-action diagnostics slice. The
+  next recommended approval-gated candidate is grouped execution-interval
+  control job validation for explicit `tmitv` and `etn`, because both gaps
+  remain in the same job definition, the same editor-feedback rule array, and
+  the same group 13 user-facing concept.
+- 2026-05-08: Investigation confirmed from the JP1/AJS3 v13 execution-
+  interval control job definition that explicit `tmitv` values must stay
+  within `1..1440` minutes and explicit `etn` values must stay within
+  `{y|n}`. The same reference also documents additional `etn=y` start-
+  condition and compatible-ISAM restrictions, but those remain out of scope
+  for the smallest user-meaningful validation slice because current code does
+  not yet model those broader context gates in the editor-feedback boundary.
+- 2026-05-08: Grouped execution-interval control job diagnostics now report
+  explicit invalid `tmitv` and `etn` values on `tmwj` / `rtmwj` through the
+  existing editor-feedback boundary. The implementation reuses the current
+  decimal-range and allowed-value rule helpers on the existing rule-array
+  path, and raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation remain
+  unchanged.
+- 2026-05-08: Remaining partial and deferred JP1/AJS v13 gaps should now be
+  re-checked from the updated coverage matrix before selecting the next
+  approval-gated candidate.
 - 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
   transfer-file explicit value-shape diagnostics implementation.
 - 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped
@@ -556,22 +591,22 @@
 
 - Status: Approved
 - Approved at: 2026-05-08
-- Approved scope: grouped explicit `ets` timeout-action diagnostics through
-  the existing editor-feedback boundary, limited to explicit `ets` values on
-  file monitoring jobs (`flwj` / `rflwj`) and execution-interval control jobs
-  (`tmwj` / `rtmwj`) that fall outside the documented JP1/AJS3 v13 set
-  `{kl|nr|wr|an}`, plus the smallest refactor needed to keep shared
-  allowed-value validation on the current `buildSyntaxDiagnostics.ts`
-  helper/rule-array path, while preserving raw parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection, and
-  command generation. Parser grammar, domain default changes, unit-list
-  projection changes, `tmitv` / `etn` validation, broader wait-job
-  reconciliation, other `ets`-bearing unit families, generated artifacts,
-  dependency versions, configuration, and `engines.vscode` remain out of
-  scope.
+- Approved scope: grouped execution-interval control job diagnostics through
+  the existing editor-feedback boundary, limited to explicit `tmitv` values
+  on `tmwj` / `rtmwj` that fall outside the documented JP1/AJS3 v13 range
+  `1..1440` minutes and explicit `etn` values on `tmwj` / `rtmwj` that fall
+  outside `{y|n}`, plus the smallest refactor needed to keep these checks on
+  the current `buildSyntaxDiagnostics.ts` decimal-range / allowed-value
+  helper and rule-array path, while preserving raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation. Parser grammar, domain default changes,
+  unit-list projection changes, `etn=y` start-condition semantics,
+  compatible-ISAM restrictions, broader wait-job reconciliation, other wait-
+  job families, generated artifacts, dependency versions, configuration, and
+  `engines.vscode` remain out of scope.
 
-Current implementation gate: grouped `ets` timeout-action diagnostics are
-implemented and validated inside the recorded scope.
+Current implementation gate: grouped execution-interval control job `tmitv` /
+`etn` diagnostics are implemented and validated inside the recorded scope.
 
 ## Prior Approval Evidence
 
@@ -881,6 +916,22 @@ implemented and validated inside the recorded scope.
 
 ## Validation
 
+- 2026-05-08: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  execution-interval control job `tmitv` / `etn` diagnostics implementation
+- 2026-05-08: `npm test` completed with exit code 0 after grouped
+  execution-interval control job `tmitv` / `etn` diagnostics implementation;
+  the VS Code harness emitted the existing macOS `task_name_for_pid` codesign
+  noise line
+- 2026-05-08: `rtk pnpm run test:web` completed with exit code 0 after
+  grouped execution-interval control job `tmitv` / `etn` diagnostics
+  implementation and emitted the existing localhost dev-extension
+  `package.nls.json` 404 noise
+- 2026-05-08: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped execution-interval control job `tmitv` / `etn`
+  diagnostics implementation
+- 2026-05-08: `rtk pnpm run lint:md` completed with exit code 0 after
+  grouped execution-interval control job `tmitv` / `etn` diagnostics
+  implementation
 - 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
   generic parameter-rule diagnostics implementation
 - 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped generic

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -52,10 +52,11 @@ rules in `docs/specs/README.md`, not in this file.
   next recommended JP1/AJS v13 candidate should be re-selected from the
   remaining partial or deferred gaps using the same user-meaningful grouping
   rule, instead of defaulting immediately to smaller default-only follow-ups.
-- After the delivered grouped `ets` timeout-action diagnostics slice, the next
-  recommended JP1/AJS v13 candidate should be re-selected from the remaining
-  partial or deferred gaps using the same user-meaningful grouping rule,
-  instead of defaulting immediately to smaller default-only follow-ups.
+- After the delivered grouped execution-interval control job `tmitv` / `etn`
+  diagnostics slice, the next recommended JP1/AJS v13 candidate should be
+  re-selected from the remaining partial or deferred gaps using the same
+  user-meaningful grouping rule, instead of defaulting immediately to smaller
+  default-only follow-ups.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -74,8 +75,9 @@ rules in `docs/specs/README.md`, not in this file.
 ## Next Priority Tasks
 
 1. Re-check the remaining partial or deferred JP1/AJS3 v13 parameter-alignment
-   gaps after the delivered transfer-file value-shape slice and record the
-   next approval-gated candidate using the same user-meaningful grouping rule.
+   gaps after the delivered execution-interval control job validation slice
+   and record the next approval-gated candidate using the same user-meaningful
+   grouping rule.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -94,31 +96,32 @@ rules in `docs/specs/README.md`, not in this file.
   the delivered grouped `ets` timeout-action diagnostics slice.
 - Status: approved implementation and validation are complete in the recorded
   scope.
-- Scope: grouped explicit `ets` timeout-action diagnostics were added in
-  `buildSyntaxDiagnostics.ts` for explicit `ets` values outside
-  `{kl|nr|wr|an}` on `flwj` / `rflwj` and `tmwj` / `rtmwj`, including the
-  smallest helper/rule refactor needed to keep shared allowed-value
-  validation on the existing rule-array path, while preserving parser output,
-  domain wrapper values, normalized parameters, unit-list projection, flow
-  projection, command generation, generated artifacts, dependency versions,
-  and `engines.vscode`.
-- Out of scope: parser grammar changes, domain defaults, unit-list
-  projection changes, `tmitv` or `etn` validation, broader wait-job
-  reconciliation, other `ets`-bearing unit families, and unrelated
-  default-only follow-ups.
+- Scope: grouped explicit execution-interval control job diagnostics were
+  added in `buildSyntaxDiagnostics.ts` for explicit `tmitv` values outside the
+  documented `1..1440` minute range and explicit `etn` values outside
+  `{y|n}` on `tmwj` / `rtmwj`, including only the smallest helper/rule-array
+  refactor needed to keep these checks on the existing execution-interval
+  editor-feedback path, while preserving parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection,
+  command generation, generated artifacts, dependency versions, and
+  `engines.vscode`.
+- Out of scope: parser grammar changes, domain default changes, unit-list
+  projection changes, `etn=y` start-condition semantics, compatible-ISAM
+  environment restrictions, broader wait-job reconciliation, other wait-job
+  families, and unrelated default-only follow-ups.
 - Impact summary: the implemented slice affected
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
   diagnostics regression tests, the parameter-alignment feature docs, and the
   editor-feedback behavior contract.
-- Risks and assumptions: `ParamFactory.ets` is shared by more wrappers than
-  the two implemented rows, so the delivered diagnostics stay scoped to the
-  investigated file-monitoring and execution-interval control job families.
-  Broader `ets` semantics remain deferred and should be reconsidered only in a
-  separate approved slice.
-- Alternatives considered: the remaining HTTP Connection `eu` conflict stayed
-  less user-visible, while broadening to every `ets`-bearing unit family or
-  folding `tmitv` / `etn` validation into the same slice would have exceeded
-  the shared-rule boundary that justified this grouped implementation.
+- Risks and assumptions: `etn` has documented context-sensitive restrictions
+  beyond the base `{y|n}` value set, but those require broader start-
+  condition or environment modeling than the current slice. The delivered
+  slice therefore stays limited to explicit value-shape validation plus
+  `tmitv` range enforcement.
+- Alternatives considered: the remaining HTTP Connection `eu` note is less
+  user-visible, while broadening immediately into `etn=y` start-condition
+  semantics or broader wait-job reconciliation would exceed the smallest
+  meaningful execution-interval slice.
 
 ## Build/Test Performance SDD
 
@@ -147,9 +150,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped `ets` timeout-action diagnostics are implemented for
-  file-monitoring and execution-interval control jobs; the next candidate
-  should be re-selected from the updated coverage matrix.
+  slice: grouped execution-interval control job `tmitv` / `etn` diagnostics
+  are implemented and validated; the next candidate should be re-selected
+  from the updated coverage matrix.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -857,7 +857,20 @@ const fileMonitoringDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
 ];
 
 const executionIntervalControlDiagnosticRules: readonly UnitParameterDiagnosticRule[] =
-  [...eventTimeoutActionDiagnosticRules];
+  [
+    buildExplicitDecimalRangeRule(
+      "tmitv",
+      1,
+      1440,
+      "Execution interval (tmitv) must be between 1 and 1440.",
+    ),
+    buildExplicitAllowedValuesRule(
+      "etn",
+      new Set(["y", "n"]),
+      "End timing (etn) must be y or n.",
+    ),
+    ...eventTimeoutActionDiagnosticRules,
+  ];
 
 const eventSendingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
   {

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -1081,6 +1081,99 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("does not report execution-interval control diagnostics for omitted defaults and valid explicit values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=intervalDefault,tmwj,+0+0;",
+        "  el=intervalExplicit,rtmwj,+160+0;",
+        "  unit=intervalDefault,,jp1admin,;",
+        "  {",
+        "    ty=tmwj;",
+        "  }",
+        "  unit=intervalExplicit,,jp1admin,;",
+        "  {",
+        "    ty=rtmwj;",
+        "    tmitv=1440;",
+        "    etn=y;",
+        "    ets=wr;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports execution-interval control diagnostics for explicit invalid tmitv and etn values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=interval1,tmwj,+0+0;",
+        "  el=interval2,rtmwj,+160+0;",
+        "  unit=interval1,,jp1admin,;",
+        "  {",
+        "    ty=tmwj;",
+        "    tmitv=0;",
+        "    etn=maybe;",
+        "  }",
+        "  unit=interval2,,jp1admin,;",
+        "  {",
+        "    ty=rtmwj;",
+        "    tmitv=1441;",
+        "    etn=Y;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 4);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 5,
+          message: "Execution interval (tmitv) must be between 1 and 1440.",
+        },
+        {
+          line: 10,
+          column: 4,
+          length: 3,
+          message: "End timing (etn) must be y or n.",
+        },
+        {
+          line: 15,
+          column: 4,
+          length: 5,
+          message: "Execution interval (tmitv) must be between 1 and 1440.",
+        },
+        {
+          line: 16,
+          column: 4,
+          length: 3,
+          message: "End timing (etn) must be y or n.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error", "error"],
+    );
+  });
+
   test("does not report transfer-file diagnostics for valid explicit values and macro variables", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [


### PR DESCRIPTION
## What changed
- added execution-interval control job diagnostics for explicit `tmitv` values outside `1..1440` and explicit `etn` values outside `{y|n}` on `tmwj` / `rtmwj`
- kept the checks on the existing `buildSyntaxDiagnostics.ts` rule-array path and added focused regression coverage
- synced the SDD artifacts, coverage matrix, and editor-feedback use case to record the delivered slice

## Why
- JP1/AJS v13 parameter alignment still had an execution-interval control gap after `ets` validation was completed
- `tmwj` / `rtmwj` still accepted invalid explicit `tmitv` and `etn` values without semantic editor feedback

## Impact
- users now get semantic diagnostics for invalid execution-interval control values without changing parser output, wrapper values, normalized parameters, projections, or command generation
- desktop and web extension behavior stays aligned because the change remains inside shared application diagnostics

## Validation
- `rtk pnpm run qlty`
- `npm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`
