### PR TITLE
Align transfer-file path diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -223,6 +223,17 @@ Scenario: Transfer-file parameters must use documented explicit string forms
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Transfer-file parameters must preserve documented shared
+  filename/path constraints
+  Given a syntactically valid JP1/AJS document with a UNIX/PC job,
+    UNIX/PC custom job, QUEUE job, or recovery QUEUE job
+  And explicit `tsN` or `tdN` uses a quoted transfer-file value
+  And that value violates a JP1/AJS3 v13 filename/path rule that is shared
+    across the approved transfer-file family scope
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Shared string diagnostics preserve documented macro-variable allowance
   Given a syntactically valid JP1/AJS document with a parameter family that
     explicitly allows macro-variable or regular-expression forms

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -61,9 +61,10 @@ coverage.
   `tdN` / `topN` source-file dependency diagnostics for the currently modeled
   transfer-operation parameters. Explicit transfer-file value-shape
   diagnostics for non-macro bare strings are now aligned through
-  editor-feedback; broader filename/path semantics and macro-variable syntax
-  tightening remain deferred under
-  `TRANSFER_FILE_VALUE_SHAPE_ALIGNMENT.md`
+  editor-feedback. Explicit quoted `tsN` full-path diagnostics are now also
+  aligned through editor-feedback for the shared transfer-file family.
+  Platform-specific path interpretation and macro-variable syntax tightening
+  remain deferred under `TRANSFER_FILE_FILENAME_PATH_ALIGNMENT.md`
 
 ### QUEUE Transfer Files
 
@@ -77,9 +78,11 @@ coverage.
   Editor-feedback now aligns `tsN` / `tdN` byte-length diagnostics and `tdN`
   source-file dependency diagnostics for the currently modeled QUEUE
   transfer-file parameters. Explicit transfer-file value-shape diagnostics for
-  non-macro bare strings are now aligned through editor-feedback; broader
-  filename/path semantics and macro-variable syntax tightening remain deferred
-  under `TRANSFER_FILE_VALUE_SHAPE_ALIGNMENT.md`
+  non-macro bare strings are now aligned through editor-feedback, and
+  explicit quoted `tsN` full-path diagnostics are aligned through the shared
+  transfer-file rule path. Platform-specific path interpretation and
+  macro-variable syntax tightening remain deferred under
+  `TRANSFER_FILE_FILENAME_PATH_ALIGNMENT.md`
 
 ### Job End Judgment
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -292,6 +292,25 @@ JP1/AJS3 version 13 reference documents.
   accepted macro-variable forms, and preserve raw parser output, domain
   wrapper values, normalized parameters, unit-list projection, flow
   projection, and command generation.
+- Transfer-file `tsN` / `tdN` filename/path semantics remain approval-
+  sensitive because current behavior now distinguishes bare strings from
+  quoted or macro-variable forms, but still preserves any quoted explicit
+  transfer-file value without checking the remaining documented shared
+  filename/path constraints. The next grouped follow-up should stay inside
+  application editor-feedback, cover the shared `tsN` / `tdN` family across
+  UNIX/PC, UNIX/PC custom, and QUEUE-family jobs, include only the smallest
+  helper/rule-array refactor needed to keep transfer diagnostics on the
+  existing shared path, and preserve raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation unless broader platform-specific path interpretation
+  proves unavoidable and triggers re-approval.
+- Shared transfer-file filename/path alignment is now implemented through
+  application editor-feedback for explicit quoted `tsN` values that do not
+  use a full-path form on UNIX/PC jobs, UNIX/PC custom jobs, QUEUE jobs, and
+  recovery QUEUE jobs. Existing `tdN` handling remains on the already aligned
+  value-shape, byte-length, and dependency path because the focused reference
+  pass did not identify a stronger shared `tdN` path rule that could be
+  enforced without broadening into platform-specific interpretation.
 
 ## Reference Documents
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -184,6 +184,19 @@
       values, explicit out-of-range `tmitv`, and explicit invalid `etn`
       values on execution-interval control jobs
 - [x] Run required code-change validation after implementation
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      transfer-file filename/path semantics across UNIX/PC, UNIX/PC custom,
+      and QUEUE-family jobs
+- [x] Implement grouped transfer-file filename/path semantics only after
+      approval
+- [x] Refactor `buildSyntaxDiagnostics.ts` within the approved scope so
+      transfer-operation and QUEUE transfer-file diagnostics continue to share
+      the existing helper/rule-array path
+- [x] Add focused regression evidence for the approved shared transfer-file
+      filename/path constraints while preserving existing quoted-string and
+      macro-variable acceptance outside the newly aligned rules
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -561,6 +574,37 @@
 - 2026-05-08: Remaining partial and deferred JP1/AJS v13 gaps should now be
   re-checked from the updated coverage matrix before selecting the next
   approval-gated candidate.
+- 2026-05-08: Remaining partial and deferred JP1/AJS v13 gaps were re-checked
+  after the delivered grouped execution-interval control job `tmitv` / `etn`
+  diagnostics slice. The next recommended approval-gated candidate is grouped
+  transfer-file filename/path semantics across UNIX/PC, UNIX/PC custom, and
+  QUEUE-family jobs because the remaining gap sits in one shared `tsN` /
+  `tdN` parameter family, one shared editor-feedback seam, and one shared
+  refactoring path inside `buildSyntaxDiagnostics.ts`.
+- 2026-05-08: Investigation confirmed that transfer-file value-shape,
+  byte-length, and `tdN` / `topN` dependency diagnostics are already aligned
+  on the current shared transfer rule path; the remaining transfer-related gap
+  is limited to still-deferred shared filename/path semantics for explicit
+  quoted transfer-file values.
+- 2026-05-08: The next transfer-file candidate was recorded in
+  `TRANSFER_FILE_FILENAME_PATH_ALIGNMENT.md` with scope limited to shared
+  application-level diagnostics plus the smallest helper/rule-array refactor
+  needed to keep UNIX/PC and QUEUE-family transfer diagnostics on the current
+  shared path. Parser grammar, domain normalization, projection changes, and
+  platform-specific path interpretation remain out of scope pending approval.
+- 2026-05-08: Reference-impact verification during implementation confirmed
+  that explicit quoted `tsN` values carry the only clearly shared full-path
+  rule across the approved UNIX/PC, UNIX/PC custom, and QUEUE-family
+  transfer-file scope. No stronger shared `tdN` path rule was enforced in
+  this slice because that would require broader platform-specific
+  interpretation than the approved boundary allows.
+- 2026-05-08: Grouped transfer-file filename/path diagnostics now report
+  explicit quoted relative `tsN` values through the existing shared
+  transfer-operation and QUEUE transfer-file editor-feedback path. Existing
+  `tdN` handling remains on the already delivered value-shape, byte-length,
+  and dependency path, and raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation remain unchanged.
 - 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
   transfer-file explicit value-shape diagnostics implementation.
 - 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped
@@ -591,25 +635,38 @@
 
 - Status: Approved
 - Approved at: 2026-05-08
-- Approved scope: grouped execution-interval control job diagnostics through
-  the existing editor-feedback boundary, limited to explicit `tmitv` values
-  on `tmwj` / `rtmwj` that fall outside the documented JP1/AJS3 v13 range
-  `1..1440` minutes and explicit `etn` values on `tmwj` / `rtmwj` that fall
-  outside `{y|n}`, plus the smallest refactor needed to keep these checks on
-  the current `buildSyntaxDiagnostics.ts` decimal-range / allowed-value
-  helper and rule-array path, while preserving raw parser output, domain
-  wrapper values, normalized parameters, unit-list projection, flow
-  projection, and command generation. Parser grammar, domain default changes,
-  unit-list projection changes, `etn=y` start-condition semantics,
-  compatible-ISAM restrictions, broader wait-job reconciliation, other wait-
-  job families, generated artifacts, dependency versions, configuration, and
-  `engines.vscode` remain out of scope.
+- Approved scope: grouped transfer-file filename/path semantics through the
+  existing editor-feedback boundary, limited to explicit `ts1` to `ts4` and
+  `td1` to `td4` values on UNIX/PC jobs, UNIX/PC custom jobs, QUEUE jobs, and
+  recovery QUEUE jobs, plus the smallest refactor needed to keep
+  transfer-operation and QUEUE transfer-file checks on the current
+  `buildSyntaxDiagnostics.ts` helper and rule-array path, while preserving
+  raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation. Parser grammar,
+  domain normalization changes, transfer-operation `topN` behavior,
+  projection changes, platform-specific path normalization, generated
+  artifacts, dependency versions, configuration, and `engines.vscode` remain
+  out of scope unless re-approved.
 
-Current implementation gate: grouped execution-interval control job `tmitv` /
-`etn` diagnostics are implemented and validated inside the recorded scope.
+Current implementation gate: grouped transfer-file filename/path semantics are
+implemented and validated inside the recorded scope.
 
 ## Prior Approval Evidence
 
+- 2026-05-08: User replied "Approved. Proceed with implementation." after the
+  grouped transfer-file filename/path semantics approval request. Approved
+  changes were limited to adding grouped application-level semantic
+  diagnostics for the shared transfer-file family through the existing
+  editor-feedback boundary, plus the smallest refactor needed to keep
+  transfer-operation and QUEUE transfer-file checks on the current
+  `buildSyntaxDiagnostics.ts` helper/rule-array path; preserving raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation; adding focused regression
+  evidence; updating SDD tracking; and running validation. Parser grammar,
+  domain normalization changes, transfer-operation `topN` behavior,
+  projection changes, platform-specific path normalization, generated
+  artifacts, dependency versions, configuration, and `engines.vscode` were
+  out of scope.
 - 2026-05-08: User replied "Approved. Proceed with implementation." after the
   grouped `ets` timeout-action diagnostics approval request. Approved changes
   were limited to adding grouped application-level semantic diagnostics for
@@ -916,6 +973,21 @@ Current implementation gate: grouped execution-interval control job `tmitv` /
 
 ## Validation
 
+- 2026-05-08: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  transfer-file filename/path diagnostics implementation
+- 2026-05-08: `rtk pnpm test` completed with exit code 0 after grouped
+  transfer-file filename/path diagnostics implementation; the VS Code harness
+  emitted the existing macOS `task_name_for_pid` codesign noise line
+- 2026-05-08: `rtk pnpm run test:web` completed with exit code 0 after
+  grouped transfer-file filename/path diagnostics implementation and emitted
+  the existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-08: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped transfer-file filename/path diagnostics
+  implementation
+- 2026-05-08: `rtk pnpm run qlty` completed with exit code 0 after SDD sync
+  for grouped transfer-file filename/path diagnostics implementation
+- 2026-05-08: `rtk pnpm run lint:md` completed with exit code 0 after SDD
+  sync for grouped transfer-file filename/path diagnostics implementation
 - 2026-05-08: `rtk pnpm run qlty` completed with exit code 0 after grouped
   execution-interval control job `tmitv` / `etn` diagnostics implementation
 - 2026-05-08: `npm test` completed with exit code 0 after grouped

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TRANSFER_FILE_FILENAME_PATH_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TRANSFER_FILE_FILENAME_PATH_ALIGNMENT.md
@@ -1,0 +1,124 @@
+# Transfer-File Filename/Path Alignment
+
+## Purpose
+
+Record the JP1/AJS3 version 13 parameter-alignment slice around the remaining
+shared transfer-file filename/path semantics for UNIX/PC jobs, UNIX/PC custom
+jobs, QUEUE jobs, and recovery QUEUE jobs.
+
+This investigation keeps the backlog grouped at a user-meaningful size:
+users work with one transfer-file parameter family across these job types, and
+the current implementation already routes those diagnostics through the same
+shared editor-feedback seams.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual sections:
+  - Command Reference, `5.2.6 UNIX/PC job definition`
+  - Command Reference, `5.2.7 QUEUE job definition`
+  - Command Reference, `5.2.24 UNIX/PC custom job definition`
+- Source URLs:
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0221.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0222.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0239.HTM>
+
+## Slice Boundary
+
+- Application seam:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`
+- Existing consumers:
+  `src/extension/diagnostics/registerDiagnostics.ts` plus transfer-file-owning
+  unit types `J`, `Cj`, `Qj`, and `Rq`
+- Existing reference points:
+  `transferFileByteLengthRules`,
+  `transferFileValueShapeRules`,
+  `transferOperationDiagnosticRules`, and
+  `queueTransferFileDiagnosticRules`
+- Regression evidence:
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`
+- Out of scope:
+  parser grammar changes, domain wrapper normalization changes,
+  transfer-operation `topN` behavior, unit-list projection, flow projection,
+  command generation, path existence checks, platform-specific path
+  normalization, macro-variable expansion semantics, generated artifacts,
+  dependency changes, configuration changes, and `engines.vscode`
+
+## Investigation Notes
+
+- The delivered transfer-file value-shape slice already aligned the first
+  explicit-string boundary: bare strings are rejected unless the value is a
+  quoted transfer-file literal or an accepted macro-variable form.
+- `buildSyntaxDiagnostics.ts` now has one shared transfer-file rule path for
+  UNIX/PC and QUEUE-family diagnostics. Any remaining transfer-file work
+  should preserve that shared structure instead of reopening one job type at a
+  time.
+- The remaining documented gap is no longer about whether `tsN` / `tdN`
+  values are quoted; it is about the still-deferred filename/path semantics
+  inside that shared quoted-value family.
+- This candidate is preferable to HTTP Connection `eu` because it closes
+  backlog across two partial matrix rows at once, and it is preferable to a
+  broader wait-job slice because it stays within one already-shared parameter
+  family and one already-shared refactoring seam.
+
+## Planned Alignment
+
+Delivered implementation:
+
+- kept ownership in the shared application editor-feedback boundary;
+- performed a focused reference pass on the current transfer-file helper/rule
+  arrays before editing runtime code;
+- implemented the smallest manual-backed shared path rule that could be
+  enforced uniformly without introducing platform-specific interpretation:
+  explicit quoted `tsN` values must use a full-path form;
+- kept the existing transfer-operation and QUEUE transfer-file rule
+  composition on one shared helper/rule-array structure;
+- preserved raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
+
+## Affected Backlog Rows
+
+- Transfer Operation:
+  remaining filename/path semantics after value-shape, byte-length, and
+  invalid-combination alignment
+- QUEUE Transfer Files:
+  remaining filename/path semantics after value-shape, byte-length, and
+  invalid-combination alignment
+
+## Alternatives
+
+- Pick HTTP Connection `eu` next:
+  rejected because it is smaller and less user-visible than the requested
+  slice size.
+- Broaden immediately into platform-aware path interpretation:
+  rejected because that would exceed the smallest reviewable slice and pull
+  environment-specific behavior into a rule family that is currently
+  application-level only.
+- Re-open transfer rules one job type at a time:
+  rejected because the current code already shares rule arrays and helper
+  seams across UNIX/PC and QUEUE-family transfer-file diagnostics.
+
+## Follow-up
+
+- The reference pass confirmed that `tsN` carries the only clearly shared
+  full-path requirement across the approved transfer-file family scope.
+- The same pass did not find a stronger shared path rule for `tdN` that could
+  be enforced without broadening into platform-specific path interpretation,
+  so explicit quoted `tdN` values stay on the already delivered
+  value-shape/byte-length/dependency path in this slice.
+
+## Delivered Behavior
+
+- Editor feedback now reports a semantic diagnostic when explicit quoted
+  `ts1` to `ts4` values on UNIX/PC jobs, UNIX/PC custom jobs, QUEUE jobs, and
+  recovery QUEUE jobs use an apparent relative path instead of a full path.
+- Existing quoted `td1` to `td4` values remain accepted unless they violate
+  already delivered value-shape, byte-length, or dependency rules.
+- Macro-variable forms remain accepted on the existing transfer-file path.
+- The implementation stays on the shared transfer-operation and QUEUE
+  transfer-file helper/rule-array path in `buildSyntaxDiagnostics.ts`.
+
+## Remaining Gap
+
+- Platform-specific path interpretation, any broader path normalization, and
+  any family-specific macro-variable syntax tightening remain deferred.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -57,6 +57,17 @@ rules in `docs/specs/README.md`, not in this file.
   re-selected from the remaining partial or deferred gaps using the same
   user-meaningful grouping rule, instead of defaulting immediately to smaller
   default-only follow-ups.
+- After re-checking the updated matrix and feature-local deferred notes, the
+  next recommended JP1/AJS v13 candidate should group the remaining
+  transfer-file filename/path semantics across UNIX/PC, UNIX/PC custom, and
+  QUEUE-family jobs, because those rows share the same `tsN` / `tdN`
+  parameter family, the same editor-feedback rule arrays, and the same
+  refactoring seam inside `buildSyntaxDiagnostics.ts`.
+- After the delivered grouped transfer-file filename/path slice, the next
+  recommended JP1/AJS v13 candidate should be re-selected from the remaining
+  partial or deferred gaps using the same user-meaningful grouping rule,
+  rather than broadening immediately into platform-specific path semantics or
+  unrelated default-only follow-ups.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -75,9 +86,9 @@ rules in `docs/specs/README.md`, not in this file.
 ## Next Priority Tasks
 
 1. Re-check the remaining partial or deferred JP1/AJS3 v13 parameter-alignment
-   gaps after the delivered execution-interval control job validation slice
-   and record the next approval-gated candidate using the same user-meaningful
-   grouping rule.
+   gaps after the delivered transfer-file filename/path slice and record the
+   next approval-gated candidate using the same user-meaningful grouping
+   rule.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -93,31 +104,34 @@ rules in `docs/specs/README.md`, not in this file.
 - Branch: `main`; a dedicated implementation branch was attempted but could
   not be created from the sandboxed session after approval
 - Objective: prepare the next JP1/AJS v13 parameter-alignment candidate after
-  the delivered grouped `ets` timeout-action diagnostics slice.
+  the delivered grouped execution-interval control job `tmitv` / `etn`
+  diagnostics slice.
 - Status: approved implementation and validation are complete in the recorded
   scope.
-- Scope: grouped explicit execution-interval control job diagnostics were
-  added in `buildSyntaxDiagnostics.ts` for explicit `tmitv` values outside the
-  documented `1..1440` minute range and explicit `etn` values outside
-  `{y|n}` on `tmwj` / `rtmwj`, including only the smallest helper/rule-array
-  refactor needed to keep these checks on the existing execution-interval
-  editor-feedback path, while preserving parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection,
-  command generation, generated artifacts, dependency versions, and
-  `engines.vscode`.
-- Out of scope: parser grammar changes, domain default changes, unit-list
-  projection changes, `etn=y` start-condition semantics, compatible-ISAM
-  environment restrictions, broader wait-job reconciliation, other wait-job
-  families, and unrelated default-only follow-ups.
-- Impact summary: the implemented slice affected
+- Scope: grouped transfer-file filename/path diagnostics were added in
+  `buildSyntaxDiagnostics.ts` for explicit quoted `ts1` to `ts4` values on
+  UNIX/PC jobs, UNIX/PC custom jobs, QUEUE jobs, and recovery QUEUE jobs that
+  do not use a full-path form, including only the smallest helper/rule-array
+  refactor needed to keep transfer-operation and QUEUE transfer-file
+  diagnostics on the current shared path while preserving parser output,
+  domain wrapper values, normalized parameters, unit-list projection, flow
+  projection, command generation, generated artifacts, dependency versions,
+  and `engines.vscode`.
+- Out of scope: parser grammar changes, domain wrapper normalization changes,
+  transfer-operation `topN` behavior, unit-list projection changes,
+  platform-specific path normalization, path existence checks, macro-variable
+  expansion semantics, generated artifacts, dependency changes,
+  configuration, `engines.vscode`, and unrelated default-only follow-ups such
+  as HTTP Connection `eu`.
+- Impact summary: the implemented scope affected
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
   diagnostics regression tests, the parameter-alignment feature docs, and the
   editor-feedback behavior contract.
-- Risks and assumptions: `etn` has documented context-sensitive restrictions
-  beyond the base `{y|n}` value set, but those require broader start-
-  condition or environment modeling than the current slice. The delivered
-  slice therefore stays limited to explicit value-shape validation plus
-  `tmitv` range enforcement.
+- Risks and assumptions: the implementation reference pass confirmed that
+  `tsN` carries the only clearly shared full-path rule inside the approved
+  scope. Broader platform-specific path interpretation, `tdN`-specific path
+  behavior, or stronger macro-variable tightening remain deferred and should
+  trigger re-approval if they become necessary.
 - Alternatives considered: the remaining HTTP Connection `eu` note is less
   user-visible, while broadening immediately into `etn=y` start-condition
   semantics or broader wait-job reconciliation would exceed the smallest
@@ -150,9 +164,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped execution-interval control job `tmitv` / `etn` diagnostics
-  are implemented and validated; the next candidate should be re-selected
-  from the updated coverage matrix.
+  slice: grouped transfer-file filename/path diagnostics are implemented and
+  validated; the next candidate should be re-selected from the updated
+  coverage matrix.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -254,8 +254,15 @@ const isValidExplicitFileMonitoringInterval = (
 const isExplicitMacroVariable = (value: string): boolean =>
   /^\?[^?\r\n]+\?$/.test(value);
 
-const isQuotedStringLiteral = (value: string): boolean =>
-  /^"(?:\\.|[^"\\])*"$/.test(value);
+const parseQuotedStringLiteralContent = (value: string): string | undefined => {
+  const matched = /^"((?:\\.|[^"\\])*)"$/.exec(value);
+  return matched?.[1];
+};
+
+const isAbsoluteTransferFilePath = (value: string): boolean =>
+  value.startsWith("/") ||
+  value.startsWith("\\") ||
+  /^[A-Za-z]:[\\/]/.test(value);
 
 const isValidExplicitTransferFileValue = (
   parameter: UnitParameter | undefined,
@@ -265,7 +272,22 @@ const isValidExplicitTransferFileValue = (
     return false;
   }
 
-  return isQuotedStringLiteral(rawValue) || isExplicitMacroVariable(rawValue);
+  return (
+    parseQuotedStringLiteralContent(rawValue) !== undefined ||
+    isExplicitMacroVariable(rawValue)
+  );
+};
+
+const hasInvalidExplicitTransferSourcePath = (
+  parameter: UnitParameter | undefined,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (!rawValue) {
+    return false;
+  }
+
+  const quotedContent = parseQuotedStringLiteralContent(rawValue);
+  return quotedContent ? !isAbsoluteTransferFilePath(quotedContent) : false;
 };
 
 const hasInvalidWildcardWithShortMonitoringInterval = (
@@ -787,10 +809,18 @@ const transferFileValueShapeRules: readonly UnitParameterDiagnosticRule[] =
     },
   ]);
 
+const transferSourceFilePathRules: readonly UnitParameterDiagnosticRule[] =
+  transferFileIndexes.map((index) => ({
+    key: `ts${index}`,
+    message: `Transfer source file name (ts${index}) must use a full path when specified as a quoted transfer-file value.`,
+    isInvalid: (parameter) => hasInvalidExplicitTransferSourcePath(parameter),
+  }));
+
 const transferOperationDiagnosticRules: readonly UnitParameterDiagnosticRule[] =
   [
     ...transferFileByteLengthRules,
     ...transferFileValueShapeRules,
+    ...transferSourceFilePathRules,
     ...transferFileIndexes.flatMap((index) => [
       buildRequiredParameterRule(
         `td${index}`,
@@ -809,6 +839,7 @@ const queueTransferFileDiagnosticRules: readonly UnitParameterDiagnosticRule[] =
   [
     ...transferFileByteLengthRules,
     ...transferFileValueShapeRules,
+    ...transferSourceFilePathRules,
     ...transferFileIndexes.map((index) =>
       buildRequiredParameterRule(
         `td${index}`,

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -1193,13 +1193,13 @@ suite("Build Syntax Diagnostics", () => {
         "  unit=custom,,jp1admin,;",
         "  {",
         "    ty=cj;",
-        '    ts1="source-1";',
+        '    ts1="/var/custom/source-1";',
         "    top1=sav;",
         "  }",
         "  unit=queue1,,jp1admin,;",
         "  {",
         "    ty=qj;",
-        '    ts1="queue-source";',
+        '    ts1="C:/queue/source";',
         "    td1=?AJS2QDST1?;",
         "  }",
         "}",
@@ -1257,6 +1257,62 @@ suite("Build Syntax Diagnostics", () => {
           length: 3,
           message:
             "Transfer destination file name (td1) must be between 1 and 511 bytes.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error"],
+    );
+  });
+
+  test("reports transfer-source path diagnostics for quoted relative paths", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=job1,j,+0+0;",
+        "  el=queue1,qj,+160+0;",
+        "  unit=job1,,jp1admin,;",
+        "  {",
+        "    ty=j;",
+        '    ts1="relative/source-1";',
+        '    td1="dest-1";',
+        "  }",
+        "  unit=queue1,,jp1admin,;",
+        "  {",
+        "    ty=qj;",
+        '    ts1="queue-source";',
+        '    td1="queue-dest";',
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 2);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 3,
+          message:
+            "Transfer source file name (ts1) must use a full path when specified as a quoted transfer-file value.",
+        },
+        {
+          line: 15,
+          column: 4,
+          length: 3,
+          message:
+            "Transfer source file name (ts1) must use a full path when specified as a quoted transfer-file value.",
         },
       ],
     );


### PR DESCRIPTION
## Summary
- align shared transfer-file path diagnostics for quoted tsN values across UNIX/PC, UNIX/PC custom, and QUEUE-family jobs
- add focused transfer-file diagnostics regression coverage and simplify quoted-string parsing helpers
- sync SDD artifacts, coverage notes, and editor-feedback use-case docs for the delivered slice

## Testing
- rtk pnpm run qlty
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
- rtk pnpm run lint:md