### PR TITLE
[codex] Align execution-interval start-condition diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -205,6 +205,17 @@ Scenario: Execution-interval control job values must stay within documented
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Execution-interval control end timing must preserve documented
+  context rules
+  Given a syntactically valid JP1/AJS document with an execution-interval
+    control job
+  And explicit `etn=y` is specified
+  And the surrounding execution-interval context violates the documented
+    JP1/AJS3 v13 start-condition restriction
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Shared filename-like rules stay explicit across parameter families
   Given a syntactically valid JP1/AJS document with a parameter family that
     uses documented filename-like or host-like values
@@ -247,6 +258,9 @@ Scenario: Shared string diagnostics preserve documented macro-variable allowance
 
 - desktop and web extension entry points continue to share the same
   application logic for diagnostics and hover decisions
+- compatible-ISAM-specific semantic diagnostics require an explicit host or
+  workspace configuration input because the JP1/AJS definition file alone does
+  not identify the database mode
 
 ## Risks Or Edge Cases
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
@@ -3,7 +3,8 @@
 ## Purpose
 
 Record the delivered JP1/AJS3 version 13 alignment status for
-execution-interval control job defaults and unit-list group 13 projection.
+execution-interval control job defaults, unit-list group 13 projection, and
+the remaining context-sensitive validation candidate for `tmwj` / `rtmwj`.
 
 ## Reference
 
@@ -17,6 +18,10 @@ The reference defines omitted values as:
 - `tmitv`: `10`
 - `etn`: `n`
 - `ets`: `kl`
+
+The same reference also documents context-sensitive behavior around
+`etn=y`, including start-condition semantics and compatible-ISAM
+restrictions that are not yet modeled in editor feedback.
 
 ## Delivered Alignment
 
@@ -32,7 +37,6 @@ The reference defines omitted values as:
 
 - parser grammar changes
 - command generation changes
-- diagnostics or range validation
 - generated artifact changes
 - dependency or configuration changes
 - `engines.vscode` changes
@@ -55,9 +59,39 @@ The reference defines omitted values as:
   editor-feedback boundary for `tmwj` / `rtmwj`.
 - Explicit `etn` allowed-value diagnostics are now aligned through the shared
   editor-feedback boundary for `tmwj` / `rtmwj`.
-- Broader `etn=y` start-condition semantics, compatible-ISAM restrictions,
-  and wait-job default reconciliation remain outside the smallest meaningful
-  validation slice.
+- Explicit `etn=y` now reports a semantic diagnostic when a `tmwj` / `rtmwj`
+  unit is not defined in a start-condition context.
+- Compatible-ISAM-specific `etn` restrictions remain deferred because the
+  current editor-feedback boundary has no host-configuration input that can
+  identify database mode from the JP1/AJS definition alone.
+- Broader wait-job default reconciliation also remains outside the smallest
+  meaningful validation slice.
+
+## Delivered Context Slice
+
+- Delivered scope:
+  grouped execution-interval control context diagnostics for `tmwj` /
+  `rtmwj`, limited to the documented start-condition restriction for explicit
+  `etn=y`.
+- Ownership boundary:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, reusing the
+  current `executionIntervalControlDiagnosticRules` path and any small helper
+  extraction needed to keep context-sensitive checks on the existing
+  rule-array structure.
+- Evidence:
+  `src/test/suite/buildSyntaxDiagnostics.test.ts` now covers both valid
+  start-condition-context `etn=y` usage and invalid non-start-condition
+  usage. Existing `parameterFactory` and unit-list evidence remain unchanged
+  because this slice preserves domain defaults and presentation projection.
+- Preserved boundaries:
+  raw parser output, domain wrapper values, normalized parameters, unit-list
+  group 13 projection, flow projection, command generation, generated
+  artifacts, configuration, dependency versions, and `engines.vscode`.
+- Refactoring note:
+  the current execution-interval diagnostics are still simple value-local
+  rules. This slice added only a sibling-context helper so the new semantic
+  check stays beside the existing execution-interval rule path rather than on
+  a separate implementation branch.
 
 ## Alternatives
 
@@ -67,3 +101,12 @@ The reference defines omitted values as:
   semantics inconsistent.
 - Defer the slice until all wait-job defaults are reconciled. This is broader
   than the current focused manual-backed behavior gap.
+- Jump directly to platform-specific transfer-file path interpretation:
+  rejected for now because the remaining execution-interval gap is still more
+  self-contained, already sits behind one diagnostic seam, and keeps the
+  backlog grouped by one job definition instead of by environment-specific
+  file-path behavior.
+- Model compatible-ISAM as a hard-coded global assumption:
+  rejected because the current repository has no explicit source of truth for
+  database mode, and inferring one inside editor feedback would hide a new
+  environment dependency.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -105,13 +105,14 @@ coverage.
   `eu` plus currently modeled `htknd`, `htexm`, `htspt`, `jd`, `abr`, `ha`,
   `mm`, `nmg`, `ega`, and `uem`
 - Unit scope: HTTP Connection jobs and recovery HTTP Connection jobs
-- Status: partial
+- Status: aligned
 - Owning seam: `Htpj.ts`, `optionalScalarParameterBuilders.ts`, and
   `Defaults.ts`
 - Evidence: `parameterFactory.test.ts`
 - Remaining gap:
-  future reconciliation may be needed if the definition section and
-  `ajsprint -a` default table conflict for `eu`
+  none for the currently modeled defaults in this feature scope; future
+  manual reconciliation may still be needed if the definition section and
+  `ajsprint -a` default table for `eu` are reinterpreted
 
 ### JP1 Event Sending Job Arrival Check
 
@@ -156,12 +157,12 @@ coverage.
   `buildUnitListRemainingGroups.test.ts` for group 13 projection
 - Remaining gap:
   execution-interval control job defaults and unit-list group 13 projection
-  are aligned for these values, and explicit `ets` timeout-action
-  diagnostics are aligned through editor-feedback. Explicit `tmitv` range
-  diagnostics and explicit `etn` allowed-value diagnostics are also aligned
-  through editor-feedback. Context-sensitive `etn=y` start-condition
-  semantics, compatible-ISAM restrictions, and broader wait-job default
-  reconciliation remain deferred
+  are aligned for these values, explicit `ets` timeout-action diagnostics are
+  aligned through editor-feedback, explicit `tmitv` range diagnostics and
+  explicit `etn` allowed-value diagnostics are aligned through
+  editor-feedback, and explicit `etn=y` start-condition diagnostics are now
+  aligned through editor-feedback. Compatible-ISAM-specific restrictions and
+  broader wait-job default reconciliation remain deferred
 
 ### Event Reception Monitoring Job Search Scope
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -173,6 +173,28 @@ JP1/AJS3 version 13 reference documents.
   projection, flow projection, and command generation. Context-sensitive
   `etn=y` start-condition semantics and compatible-ISAM restrictions remain
   separate approval-sensitive work.
+- Execution-interval control contextual diagnostics remain approval-sensitive
+  after the value-local `tmitv` / `etn` slice because current behavior still
+  preserves explicit `etn=y` combinations even when the surrounding
+  execution-interval control context violates the documented start-condition
+  or compatible-ISAM restrictions. The next focused follow-up should stay
+  inside application editor-feedback for `tmwj` / `rtmwj`, reuse the current
+  execution-interval rule-array path plus only the smallest helper extraction
+  needed for context-aware checks, and preserve raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation. Broader wait-job default reconciliation
+  remains separate approval-sensitive work.
+- Execution-interval control start-condition diagnostics are now aligned
+  through application editor-feedback. Explicit `etn=y` on `tmwj` / `rtmwj`
+  now reports a semantic diagnostic when the unit is not defined in a
+  start-condition context, while raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation remain unchanged.
+- Execution-interval control compatible-ISAM restrictions remain approval-
+  sensitive because the current repository has no explicit runtime input that
+  identifies database mode for editor-feedback decisions. Any future slice
+  should introduce that environment/configuration seam deliberately instead of
+  inferring compatible-ISAM mode from JP1/AJS definition text alone.
 - Job end-judgment `jd` / `abr` diagnostics are approval-sensitive because
   existing behavior preserves explicit invalid combinations as raw parsed
   values without editor feedback. A diagnostic slice must preserve raw parser

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -605,6 +605,41 @@
   and dependency path, and raw parser output, domain wrapper values,
   normalized parameters, unit-list projection, flow projection, and command
   generation remain unchanged.
+- 2026-05-09: Coverage-matrix re-check after the delivered transfer-file
+  filename/path slice found one stale status note: HTTP Connection job
+  `eu` is already aligned in runtime and regression evidence, so the matrix
+  row is now treated as documentation-sync work rather than remaining
+  implementation backlog.
+- 2026-05-09: Remaining actionable JP1/AJS v13 gaps were re-grouped again by
+  user-meaningful job type and shared implementation seam. The next
+  recommended approval-gated candidate is grouped execution-interval control
+  context diagnostics for `tmwj` / `rtmwj`, centered on explicit `etn=y`
+  combinations that violate documented start-condition or compatible-ISAM
+  restrictions through the existing editor-feedback boundary.
+- 2026-05-09: Investigation confirmed that `Tmwj` is the only currently
+  modeled unit wrapper exposing `etn`, so this context-sensitive slice stays
+  user-meaningful without broadening into unrelated `ets`-bearing wait-job
+  families. The remaining refactor need is limited to the smallest helper
+  extraction that keeps context-aware checks on the current
+  `executionIntervalControlDiagnosticRules` path instead of adding a separate
+  one-off implementation branch.
+- 2026-05-09: `EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`, and
+  `uc-provide-editor-feedback.md` now record the pending execution-interval
+  context slice and the synchronized HTTP Connection coverage status.
+- 2026-05-09: Grouped execution-interval control context diagnostics now
+  report explicit `etn=y` on `tmwj` / `rtmwj` when the unit is not defined in
+  a start-condition context, through the existing editor-feedback boundary.
+  Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.
+- 2026-05-09: Implementation confirmed that the current editor-feedback
+  boundary has no host or workspace input that identifies compatible-ISAM
+  mode, so that environment-specific restriction remains deferred instead of
+  being guessed from JP1/AJS definition text.
+- 2026-05-09: `EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
+  `TASKS.md`, and `uc-provide-editor-feedback.md` now record the delivered
+  start-condition slice and the deferred compatible-ISAM note.
 - 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
   transfer-file explicit value-shape diagnostics implementation.
 - 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped
@@ -634,22 +669,21 @@
 ## Human Approval
 
 - Status: Approved
-- Approved at: 2026-05-08
-- Approved scope: grouped transfer-file filename/path semantics through the
-  existing editor-feedback boundary, limited to explicit `ts1` to `ts4` and
-  `td1` to `td4` values on UNIX/PC jobs, UNIX/PC custom jobs, QUEUE jobs, and
-  recovery QUEUE jobs, plus the smallest refactor needed to keep
-  transfer-operation and QUEUE transfer-file checks on the current
-  `buildSyntaxDiagnostics.ts` helper and rule-array path, while preserving
-  raw parser output, domain wrapper values, normalized parameters, unit-list
-  projection, flow projection, and command generation. Parser grammar,
-  domain normalization changes, transfer-operation `topN` behavior,
-  projection changes, platform-specific path normalization, generated
-  artifacts, dependency versions, configuration, and `engines.vscode` remain
-  out of scope unless re-approved.
+- Approved at: 2026-05-09
+- Approved scope: grouped execution-interval control context diagnostics for
+  explicit `etn=y` combinations on `tmwj` / `rtmwj`, limited to documented
+  start-condition and compatible-ISAM restrictions through the existing
+  editor-feedback boundary, plus the smallest helper/rule-array refactor
+  needed to keep the checks on the current
+  `buildSyntaxDiagnostics.ts` execution-interval path, while preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, command generation, generated artifacts,
+  dependency versions, configuration, and `engines.vscode`.
 
-Current implementation gate: grouped transfer-file filename/path semantics are
-implemented and validated inside the recorded scope.
+Current implementation gate: the approved grouped execution-interval control
+context slice is implemented and validated for the file-local detectable
+start-condition restriction. Compatible-ISAM detection remains deferred
+because the current editor-feedback boundary has no database-mode input.
 
 ## Prior Approval Evidence
 
@@ -973,6 +1007,29 @@ implemented and validated inside the recorded scope.
 
 ## Validation
 
+- 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  execution-interval control start-condition diagnostics implementation
+- 2026-05-09: `rtk pnpm test` completed with exit code 0 after grouped
+  execution-interval control start-condition diagnostics implementation; the
+  VS Code harness emitted the existing macOS `task_name_for_pid` codesign
+  noise line
+- 2026-05-09: `rtk pnpm run test:web` completed with exit code 0 after
+  grouped execution-interval control start-condition diagnostics
+  implementation and emitted the existing localhost dev-extension
+  `package.nls.json` 404 noise
+- 2026-05-09: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped execution-interval control start-condition
+  diagnostics implementation
+- 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after final SDD
+  sync for grouped execution-interval control start-condition diagnostics
+- 2026-05-09: `rtk pnpm run lint:md` completed with exit code 0 after final
+  SDD sync for grouped execution-interval control start-condition diagnostics
+- 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after the
+  docs-only execution-interval context investigation and HTTP Connection
+  coverage sync
+- 2026-05-09: `rtk pnpm run lint:md` completed with exit code 0 after the
+  docs-only execution-interval context investigation and HTTP Connection
+  coverage sync
 - 2026-05-08: `rtk pnpm run qlty` completed with exit code 0 after grouped
   transfer-file filename/path diagnostics implementation
 - 2026-05-08: `rtk pnpm test` completed with exit code 0 after grouped

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -68,6 +68,11 @@ rules in `docs/specs/README.md`, not in this file.
   partial or deferred gaps using the same user-meaningful grouping rule,
   rather than broadening immediately into platform-specific path semantics or
   unrelated default-only follow-ups.
+- After the delivered grouped execution-interval control start-condition
+  diagnostics slice, the next recommended JP1/AJS v13 candidate should again
+  be re-selected from the remaining partial or deferred gaps using the same
+  user-meaningful grouping rule, rather than broadening immediately into a
+  new environment-configuration seam for compatible-ISAM.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -103,39 +108,31 @@ rules in `docs/specs/README.md`, not in this file.
 
 - Branch: `main`; a dedicated implementation branch was attempted but could
   not be created from the sandboxed session after approval
-- Objective: prepare the next JP1/AJS v13 parameter-alignment candidate after
-  the delivered grouped execution-interval control job `tmitv` / `etn`
-  diagnostics slice.
-- Status: approved implementation and validation are complete in the recorded
-  scope.
-- Scope: grouped transfer-file filename/path diagnostics were added in
-  `buildSyntaxDiagnostics.ts` for explicit quoted `ts1` to `ts4` values on
-  UNIX/PC jobs, UNIX/PC custom jobs, QUEUE jobs, and recovery QUEUE jobs that
-  do not use a full-path form, including only the smallest helper/rule-array
-  refactor needed to keep transfer-operation and QUEUE transfer-file
-  diagnostics on the current shared path while preserving parser output,
-  domain wrapper values, normalized parameters, unit-list projection, flow
-  projection, command generation, generated artifacts, dependency versions,
-  and `engines.vscode`.
+- Objective: deliver the approved JP1/AJS v13 execution-interval control
+  context slice after the grouped transfer-file filename/path slice.
+- Status: implementation and validation are complete in the recorded scope.
+- Scope: grouped execution-interval control context diagnostics were added in
+  `buildSyntaxDiagnostics.ts` for explicit `etn=y` on `tmwj` / `rtmwj` when
+  the unit is not defined in a start-condition context, including only the
+  smallest helper needed to keep the check on the existing
+  execution-interval diagnostics path.
 - Out of scope: parser grammar changes, domain wrapper normalization changes,
-  transfer-operation `topN` behavior, unit-list projection changes,
-  platform-specific path normalization, path existence checks, macro-variable
-  expansion semantics, generated artifacts, dependency changes,
-  configuration, `engines.vscode`, and unrelated default-only follow-ups such
-  as HTTP Connection `eu`.
+  unit-list projection changes, compatible-ISAM environment detection,
+  broader wait-job default reconciliation, transfer-file platform-specific
+  path interpretation, generated artifacts, dependency changes,
+  configuration, and `engines.vscode`.
 - Impact summary: the implemented scope affected
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
   diagnostics regression tests, the parameter-alignment feature docs, and the
-  editor-feedback behavior contract.
-- Risks and assumptions: the implementation reference pass confirmed that
-  `tsN` carries the only clearly shared full-path rule inside the approved
-  scope. Broader platform-specific path interpretation, `tdN`-specific path
-  behavior, or stronger macro-variable tightening remain deferred and should
-  trigger re-approval if they become necessary.
-- Alternatives considered: the remaining HTTP Connection `eu` note is less
-  user-visible, while broadening immediately into `etn=y` start-condition
-  semantics or broader wait-job reconciliation would exceed the smallest
-  meaningful execution-interval slice.
+  editor-feedback behavior contract. The stale HTTP Connection coverage row
+  was also synchronized to the already delivered `eu=def` behavior.
+- Risks and assumptions: the delivered slice assumes that the file-local
+  detectable part of the JP1/AJS3 v13 rule is the start-condition context.
+  Compatible-ISAM restrictions remain visible as deferred work because the
+  current editor-feedback inputs do not identify database mode.
+- Alternatives considered: expanding immediately into compatible-ISAM support
+  would require a new environment/configuration seam; broad wait-job
+  reconciliation would exceed the current reviewable boundary.
 
 ## Build/Test Performance SDD
 
@@ -164,9 +161,9 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped transfer-file filename/path diagnostics are implemented and
-  validated; the next candidate should be re-selected from the updated
-  coverage matrix.
+  slice: grouped execution-interval control start-condition diagnostics are
+  implemented and validated; remaining candidates should be re-selected from
+  the updated coverage matrix.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -162,6 +162,11 @@ const hasInvalidExplicitThresholdOrdering = (unit: Unit): boolean => {
   return warningThreshold >= abnormalThreshold;
 };
 
+const hasStartConditionContext = (unit: Unit): boolean =>
+  unit.parent?.children.some(
+    (sibling) => findParameter(sibling, "ty")?.value === "rc",
+  ) ?? false;
+
 const parseExplicitHexadecimalInRange = (
   value: string | undefined,
   minimum: number,
@@ -1172,9 +1177,24 @@ const buildExecutionIntervalControlDiagnostics = (
   findUnitsByTypes(
     rootUnits,
     executionIntervalControlDiagnosticTargetTypes,
-  ).flatMap((unit) =>
-    collectRuleDiagnostics(unit, executionIntervalControlDiagnosticRules),
-  );
+  ).flatMap((unit) => {
+    const diagnostics = collectRuleDiagnostics(
+      unit,
+      executionIntervalControlDiagnosticRules,
+    );
+    const endTimingParameter = findParameter(unit, "etn");
+
+    if (endTimingParameter?.value === "y" && !hasStartConditionContext(unit)) {
+      diagnostics.push(
+        buildDiagnostic(
+          endTimingParameter,
+          "End timing (etn=y) can be specified only for execution-interval control jobs defined as start conditions.",
+        ),
+      );
+    }
+
+    return diagnostics;
+  });
 
 const buildTransferOperationDiagnostics = (
   rootUnits: Unit[],

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -1081,14 +1081,19 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
-  test("does not report execution-interval control diagnostics for omitted defaults and valid explicit values", () => {
+  test("does not report execution-interval control diagnostics for valid start-condition values", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [
         "unit=root,,jp1admin,;",
         "{",
         "  ty=g;",
+        "  el=.CONDITION,rc,+0+0;",
         "  el=intervalDefault,tmwj,+0+0;",
         "  el=intervalExplicit,rtmwj,+160+0;",
+        "  unit=.CONDITION,,jp1admin,;",
+        "  {",
+        "    ty=rc;",
+        "  }",
         "  unit=intervalDefault,,jp1admin,;",
         "  {",
         "    ty=tmwj;",
@@ -1106,6 +1111,46 @@ suite("Build Syntax Diagnostics", () => {
     );
 
     assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports execution-interval control diagnostics when etn=y is used outside start-condition context", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=interval,tmwj,+0+0;",
+        "  unit=interval,,jp1admin,;",
+        "  {",
+        "    ty=tmwj;",
+        "    etn=y;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 8,
+          column: 4,
+          length: 3,
+          message:
+            "End timing (etn=y) can be specified only for execution-interval control jobs defined as start conditions.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error"],
+    );
   });
 
   test("reports execution-interval control diagnostics for explicit invalid tmitv and etn values", () => {


### PR DESCRIPTION
## Summary
- add JP1/AJS v13 diagnostics for explicit `etn=y` outside start-condition context on `tmwj` / `rtmwj`
- extend regression coverage for valid and invalid execution-interval control job contexts
- sync SDD docs, coverage status, and deferred compatible-ISAM follow-up notes

## Why
The remaining execution-interval alignment gap was a user-visible context rule: `etn=y` should not silently pass when the execution-interval control job is not defined in a start-condition context.

## Impact
Users now get focused editor feedback for invalid `etn=y` usage without changing parser output, wrapper defaults, list/flow projection, or command generation.

## Deferred
- compatible-ISAM-specific `etn` restrictions remain deferred because the current editor-feedback boundary has no database-mode input

## Validation
- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`
