### PR TITLE
[codex] Add event receiving string filter diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -177,6 +177,21 @@ Scenario: Event reception monitoring identifiers must stay within documented
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Event reception monitoring string filters must stay within documented
+  explicit forms
+  Given a syntactically valid JP1/AJS document with a JP1 event reception
+    monitoring job
+  And explicit `evusr`, `evgrp`, `evwms`, or `evdet` is outside that
+    parameter's JP1/AJS3 v13 byte-length range
+  Or explicit `evwfr` is outside the documented
+    `optional-extended-attribute-name:"value"` form or total byte-length
+    range
+  Or explicit `evtmc` is outside the documented allowed forms or file-name
+    byte-length range
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Event host values must stay within documented byte-length rules
   Given a syntactically valid JP1/AJS document with a JP1 event sending job
     or JP1 event reception monitoring job

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
@@ -123,5 +123,7 @@ slices plus the remaining grouped follow-up for `Evwj` / `Revwj`.
 - Shared grouped event-host validation now aligns explicit `evhst`
   byte-length diagnostics through the existing editor-feedback boundary while
   preserving regular-expression and macro-variable allowance.
-- Revisit broader event reception monitoring job string-filter validation as a
-  separate later slice now that the shared `evhst` follow-up is complete.
+- Grouped event-receiving string-filter validation is now aligned in
+  `EVENT_RECEIVING_STRING_FILTER_ALIGNMENT.md`.
+- Revisit numeric identifier and timeout-oriented event reception monitoring
+  validation as separate later slices.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_STRING_FILTER_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_STRING_FILTER_ALIGNMENT.md
@@ -1,0 +1,111 @@
+# Event Receiving String-Filter Alignment
+
+## Purpose
+
+Record the next JP1/AJS3 version 13 parameter-alignment candidate around the
+remaining event-reception monitoring filter parameters that still pass through
+editor feedback without semantic validation.
+
+This keeps the backlog grouped at a user-meaningful size: users configure one
+JP1 event reception monitoring job definition, and the remaining validation
+gaps all sit on the same `evwj` / `revwj` diagnostic seam.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual section:
+  Command Reference, `5.2.9 Job definition for monitoring JP1 event reception`
+- Source URL:
+  <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0224.HTM>
+
+## Slice Boundary
+
+- Application seam:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`
+- Existing consumers:
+  `src/extension/diagnostics/registerDiagnostics.ts` plus
+  `src/domain/models/units/Evwj.ts` and `Revwj` via inheritance
+- Regression evidence:
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`
+- Preservation evidence:
+  existing raw projection coverage in `src/test/suite/buildUnitListView.test.ts`
+- Out of scope:
+  parser grammar changes, domain wrapper normalization changes, unit-list
+  projection changes, flow projection changes, command generation,
+  generated artifacts, dependency changes, configuration changes,
+  compatible-ISAM or host-environment inputs, and `engines.vscode`
+
+## Investigation Notes
+
+- The current event-receiving diagnostic path only validates `evhst`,
+  `evwid`, `evipa`, and `evesc`, even though `Evwj` already exposes the
+  remaining filter family through the same `ParamFactory` facade.
+- The manual-backed remaining explicit filter family is still concentrated in
+  one job definition: `evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and
+  `evtmc`.
+- The official JP1/AJS3 v13 command reference states:
+  - `evusr` and `evgrp` accept `1..20` bytes and allow regular expressions.
+  - `evwms` and `evdet` accept `1..1024` bytes and allow regular expressions.
+  - `evwfr` accepts the `optional-extended-attribute-name:"value"` form with
+    total content up to `2048` bytes, and allows regular expressions and
+    macro variables in the attribute-name part.
+  - `evtmc` accepts only `n`, `a`, `n:"file-name"`, `a:"file-name"`,
+    `d:"file-name"`, or `b:"file-name"`, and the file-name part accepts
+    `1..256` bytes.
+- This candidate is preferable to a default-only cleanup such as HTTP
+  Connection `eu`, because it closes multiple still-visible filter gaps in
+  one job family at once.
+- This candidate is preferable to broader compatible-ISAM or transfer-path
+  work because it stays inside one existing diagnostic seam and one existing
+  regression file.
+
+## Delivered Alignment
+
+- kept ownership in the shared application editor-feedback boundary;
+- added grouped semantic diagnostics for explicit invalid event-receiving
+  string-filter values on `evwj` / `revwj`;
+- extracted only the smallest helper and rule-array refactor needed to keep
+  shared quoted-string and byte-length checks on the current
+  event-receiving diagnostics path;
+- preserved raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
+
+## Affected Backlog
+
+- Event reception monitoring job:
+  remaining string-filter validation outside the already aligned `evhst`,
+  `evwid`, `evipa`, and `evesc` keys
+
+## Alternatives
+
+- Pick HTTP Connection `eu` next:
+  rejected because it is smaller and less user-visible than the grouped
+  filter-family slice.
+- Broaden immediately to `evuid`, `evgid`, `evpid`, `etm`, or `fd`:
+  rejected for now because those numeric or timeout-oriented rules are a
+  different validation shape from the remaining string-filter family.
+- Move the validation into domain wrappers:
+  rejected because the current alignment policy preserves raw explicit manual-
+  invalid values and surfaces them through editor feedback.
+
+## Delivered Behavior
+
+- Editor feedback now reports semantic diagnostics when explicit `evusr` or
+  `evgrp` values are not quoted strings within `1..20` bytes.
+- Editor feedback now reports semantic diagnostics when explicit `evwms` or
+  `evdet` values are not quoted strings within `1..1024` bytes.
+- Editor feedback now reports semantic diagnostics when explicit `evwfr`
+  values do not use `optional-extended-attribute-name:"value"` format within
+  `2048` bytes.
+- Editor feedback now reports semantic diagnostics when explicit `evtmc`
+  values are outside the documented allowed forms or use a quoted file name
+  outside `1..256` bytes.
+- Existing `evhst`, `evwid`, `evipa`, and `evesc` diagnostics remain on the
+  same event-receiving rule path.
+
+## Remaining Gap
+
+- Numeric identifier validation for `evuid`, `evgid`, and `evpid`, plus
+  timeout or start-condition rules such as `etm`, `fd`, `ha`, and `ets`,
+  remain separate future slices because they are a different validation shape
+  from the delivered string-filter family.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -179,6 +179,21 @@ coverage.
   broader event reception monitoring string-filter validation outside the
   search-scope keys in this row remains deferred
 
+### Event Reception Monitoring String Filters
+
+- Keys: `evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and `evtmc`
+- Unit scope:
+  JP1 event reception monitoring jobs and recovery JP1 event reception
+  monitoring jobs
+- Status: aligned
+- Owning seam:
+  `buildSyntaxDiagnostics.ts` and `Evwj.ts`
+- Evidence: `buildSyntaxDiagnostics.test.ts`
+- Remaining gap:
+  numeric identifier validation for `evuid`, `evgid`, and `evpid`, plus
+  timeout- or start-condition-oriented validation outside this string-filter
+  family, remain deferred
+
 ## Boundary Decisions
 
 - This matrix covers only categories with feature-local investigation records.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -274,6 +274,13 @@ JP1/AJS3 version 13 reference documents.
   decimal values in the JP1/AJS3 v13 range `1..720`, while raw parser output,
   domain wrapper values, normalized parameters, unit-list projection, flow
   projection, and command generation remain unchanged.
+- JP1 event reception monitoring job string-filter diagnostics are aligned
+  through application editor-feedback. Explicit `evusr`, `evgrp`, `evwms`,
+  `evdet`, `evwfr`, and `evtmc` values on `evwj` / `revwj` now report a
+  semantic diagnostic when they violate the documented JP1/AJS3 v13
+  byte-length or allowed-format rules, while raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation remain unchanged.
 - JP1 event reception monitoring job `evwid` and `evipa` validation are
   aligned through application editor-feedback. Explicit `evwid` values on
   `evwj` / `revwj` now report a semantic diagnostic when they are not

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -198,6 +198,25 @@
       macro-variable acceptance outside the newly aligned rules
 - [x] Run required code-change validation after implementation
 
+## Next Candidate
+
+- [x] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
+      delivered execution-interval control start-condition slice and select
+      the next candidate using the same user-meaningful grouping rule
+- [x] Record the next grouped JP1 event reception monitoring string-filter
+      slice in feature-local investigation docs with manual-backed scope,
+      affected seams, alternatives, and regression evidence
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      JP1 event reception monitoring string-filter diagnostics
+- [x] Implement grouped JP1 event reception monitoring string-filter
+      diagnostics only after approval
+- [x] Refactor `buildSyntaxDiagnostics.ts` within the approved scope so the
+      new event-receiving filter checks stay on the existing rule-array path
+- [x] Add focused regression evidence for valid and invalid explicit
+      `evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and `evtmc` values
+- [x] Run required code-change validation after implementation
+
 ## Notes
 
 - 2026-04-18: normative parameter and command sources were fixed to the user
@@ -640,6 +659,49 @@
   `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
   `TASKS.md`, and `uc-provide-editor-feedback.md` now record the delivered
   start-condition slice and the deferred compatible-ISAM note.
+- 2026-05-09: Remaining actionable JP1/AJS v13 gaps were re-checked after the
+  delivered execution-interval control start-condition slice. The next
+  recommended approval-gated candidate is grouped JP1 event reception
+  monitoring string-filter diagnostics for `evwj` / `revwj`, because the
+  remaining explicit validation gap clusters around one job definition, one
+  existing editor-feedback seam, and one regression-test file.
+- 2026-05-09: Investigation confirmed from the JP1/AJS3 v13 event reception
+  monitoring definition that the remaining grouped string-filter family is
+  `evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and `evtmc`, while numeric
+  identifiers such as `evuid`, `evgid`, and `evpid` are a separate future
+  validation shape.
+- 2026-05-09: `EVENT_RECEIVING_STRING_FILTER_ALIGNMENT.md`, `SPECS.md`,
+  `docs/specs/plans.md`, `TASKS.md`, and `uc-provide-editor-feedback.md` now
+  record the pending event-receiving string-filter slice and its approval
+  boundary.
+- 2026-05-09: Grouped JP1 event reception monitoring string-filter
+  diagnostics now report explicit invalid `evusr`, `evgrp`, `evwms`,
+  `evdet`, `evwfr`, and `evtmc` values on `evwj` / `revwj` through the
+  existing editor-feedback boundary. Raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection, and
+  command generation remain unchanged.
+- 2026-05-09: `buildSyntaxDiagnostics.ts` now keeps the new event-receiving
+  filter checks on the existing rule-array path, and `collectRuleDiagnostics`
+  now evaluates all explicit occurrences for a key so repeated `evwfr`
+  parameters can be diagnosed without a separate implementation branch.
+- 2026-05-09:
+  `PARAMETER_COVERAGE_MATRIX.md`, `EVENT_RECEIVING_JOB_ALIGNMENT.md`,
+  `EVENT_RECEIVING_STRING_FILTER_ALIGNMENT.md`, `SPECS.md`,
+  `docs/specs/plans.md`, `TASKS.md`, and `uc-provide-editor-feedback.md` now
+  record the delivered event-receiving string-filter slice.
+- 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  event-receiving string-filter diagnostics implementation.
+- 2026-05-09: `rtk pnpm test` completed with exit code 0 after grouped
+  event-receiving string-filter diagnostics implementation; the VS Code
+  harness emitted the existing macOS `task_name_for_pid` codesign noise line.
+- 2026-05-09: `rtk pnpm run test:web` completed with exit code 0 after
+  grouped event-receiving string-filter diagnostics implementation and
+  emitted the existing localhost dev-extension `package.nls.json` 404 noise.
+- 2026-05-09: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped event-receiving string-filter diagnostics
+  implementation.
+- 2026-05-09: `rtk pnpm run lint:md` completed with exit code 0 after grouped
+  event-receiving string-filter diagnostics implementation.
 - 2026-05-07: `rtk pnpm run qlty` completed with exit code 0 after grouped
   transfer-file explicit value-shape diagnostics implementation.
 - 2026-05-07: `rtk pnpm test` completed with exit code 0 after grouped
@@ -670,23 +732,50 @@
 
 - Status: Approved
 - Approved at: 2026-05-09
-- Approved scope: grouped execution-interval control context diagnostics for
-  explicit `etn=y` combinations on `tmwj` / `rtmwj`, limited to documented
-  start-condition and compatible-ISAM restrictions through the existing
-  editor-feedback boundary, plus the smallest helper/rule-array refactor
-  needed to keep the checks on the current
-  `buildSyntaxDiagnostics.ts` execution-interval path, while preserving raw
-  parser output, domain wrapper values, normalized parameters, unit-list
-  projection, flow projection, command generation, generated artifacts,
-  dependency versions, configuration, and `engines.vscode`.
+- Approved scope: grouped JP1 event reception monitoring string-filter
+  diagnostics for explicit `evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and
+  `evtmc` combinations on `evwj` / `revwj`, limited to documented byte-length
+  and allowed-format rules through the existing editor-feedback boundary,
+  plus the smallest helper/rule-array refactor needed to keep the checks on
+  the current `buildSyntaxDiagnostics.ts` event-receiving path, while
+  preserving raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, command generation,
+  generated artifacts, dependency versions, configuration, and
+  `engines.vscode`.
 
-Current implementation gate: the approved grouped execution-interval control
-context slice is implemented and validated for the file-local detectable
-start-condition restriction. Compatible-ISAM detection remains deferred
-because the current editor-feedback boundary has no database-mode input.
+Current implementation gate: approved implementation may proceed only within
+the grouped event-receiving string-filter scope recorded above.
 
 ## Prior Approval Evidence
 
+- 2026-05-09: User replied "Approved. Proceed with implementation." after the
+  grouped JP1 event reception monitoring string-filter diagnostics approval
+  request. Approved changes are limited to adding grouped application-level
+  semantic diagnostics for explicit `evusr`, `evgrp`, `evwms`, `evdet`,
+  `evwfr`, and `evtmc` values on `evwj` / `revwj` through the existing
+  editor-feedback boundary, plus the smallest helper/rule-array refactor
+  needed to keep the checks on the current
+  `buildSyntaxDiagnostics.ts` event-receiving path; preserving raw parser
+  output, domain wrapper values, normalized parameters, unit-list projection,
+  flow projection, and command generation; adding focused regression
+  evidence; updating SDD tracking; and running validation. Parser grammar,
+  domain normalization, generated artifacts, configuration, dependency
+  versions, compatible-ISAM/environment inputs, and `engines.vscode` are out
+  of scope.
+- 2026-05-09: User replied "Approved. Proceed with implementation." after the
+  grouped execution-interval control context diagnostics approval request.
+  Approved changes were limited to adding grouped application-level semantic
+  diagnostics for explicit `etn=y` combinations on `tmwj` / `rtmwj` through
+  the existing editor-feedback boundary, limited to the documented
+  start-condition restriction that is detectable from file-local context,
+  plus the smallest helper/rule-array refactor needed to keep the check on
+  the current `buildSyntaxDiagnostics.ts` execution-interval path;
+  preserving raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation;
+  adding focused regression evidence; updating SDD tracking; and running
+  validation. Compatible-ISAM detection, parser grammar, domain defaults,
+  projection changes, generated artifacts, configuration, dependency
+  versions, and `engines.vscode` were out of scope.
 - 2026-05-08: User replied "Approved. Proceed with implementation." after the
   grouped transfer-file filename/path semantics approval request. Approved
   changes were limited to adding grouped application-level semantic

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -73,6 +73,11 @@ rules in `docs/specs/README.md`, not in this file.
   be re-selected from the remaining partial or deferred gaps using the same
   user-meaningful grouping rule, rather than broadening immediately into a
   new environment-configuration seam for compatible-ISAM.
+- After re-checking the remaining actionable gaps again, the next recommended
+  JP1/AJS v13 candidate should move to the remaining event-reception
+  monitoring filter family and group the still-raw string-filter parameters
+  (`evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and `evtmc`) instead of
+  jumping to smaller default-only cleanup or environment-sensitive work.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -91,9 +96,8 @@ rules in `docs/specs/README.md`, not in this file.
 ## Next Priority Tasks
 
 1. Re-check the remaining partial or deferred JP1/AJS3 v13 parameter-alignment
-   gaps after the delivered transfer-file filename/path slice and record the
-   next approval-gated candidate using the same user-meaningful grouping
-   rule.
+   gaps after the delivered JP1 event reception monitoring string-filter
+   slice and record the next approval-gated candidate.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -108,31 +112,32 @@ rules in `docs/specs/README.md`, not in this file.
 
 - Branch: `main`; a dedicated implementation branch was attempted but could
   not be created from the sandboxed session after approval
-- Objective: deliver the approved JP1/AJS v13 execution-interval control
-  context slice after the grouped transfer-file filename/path slice.
+- Objective: deliver the approved JP1/AJS v13 event-reception monitoring
+  string-filter slice after the execution-interval control context
+  diagnostics.
 - Status: implementation and validation are complete in the recorded scope.
-- Scope: grouped execution-interval control context diagnostics were added in
-  `buildSyntaxDiagnostics.ts` for explicit `etn=y` on `tmwj` / `rtmwj` when
-  the unit is not defined in a start-condition context, including only the
-  smallest helper needed to keep the check on the existing
-  execution-interval diagnostics path.
+- Scope: grouped semantic diagnostics were added in
+  `buildSyntaxDiagnostics.ts` for explicit `evusr`, `evgrp`, `evwms`,
+  `evdet`, `evwfr`, and `evtmc` values on `evwj` / `revwj`, plus only the
+  smallest helper/rule-array refactor needed to keep the checks on the
+  existing event-receiving diagnostics path.
 - Out of scope: parser grammar changes, domain wrapper normalization changes,
-  unit-list projection changes, compatible-ISAM environment detection,
-  broader wait-job default reconciliation, transfer-file platform-specific
-  path interpretation, generated artifacts, dependency changes,
+  unit-list projection changes, flow projection changes, command generation,
+  compatible-ISAM detection, generated artifacts, dependency changes,
   configuration, and `engines.vscode`.
 - Impact summary: the implemented scope affected
-  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`, focused
-  diagnostics regression tests, the parameter-alignment feature docs, and the
-  editor-feedback behavior contract. The stale HTTP Connection coverage row
-  was also synchronized to the already delivered `eu=def` behavior.
-- Risks and assumptions: the delivered slice assumes that the file-local
-  detectable part of the JP1/AJS3 v13 rule is the start-condition context.
-  Compatible-ISAM restrictions remain visible as deferred work because the
-  current editor-feedback inputs do not identify database mode.
-- Alternatives considered: expanding immediately into compatible-ISAM support
-  would require a new environment/configuration seam; broad wait-job
-  reconciliation would exceed the current reviewable boundary.
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`, the parameter-alignment
+  feature docs, and the editor-feedback behavior contract for syntactically
+  valid `evwj` / `revwj` documents.
+- Risks and assumptions: the delivered slice keeps behavior diagnostic-only.
+  Regex and macro-variable allowance still differs by parameter, so the new
+  shared helpers intentionally stop at explicit quoted-string and format
+  validation instead of inferring broader parser semantics.
+- Alternatives considered: returning to HTTP Connection `eu` would be smaller
+  but less user-meaningful; broadening immediately into compatible-ISAM or
+  platform-specific transfer-file interpretation would introduce new seams
+  that exceed the smallest reviewable boundary.
 
 ## Build/Test Performance SDD
 
@@ -161,9 +166,11 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped execution-interval control start-condition diagnostics are
-  implemented and validated; remaining candidates should be re-selected from
-  the updated coverage matrix.
+  slice: grouped JP1 event reception monitoring string-filter diagnostics are
+  implemented and validated; the next candidate should be re-selected from
+  the remaining partial or deferred gaps, while the previously delivered
+  execution-interval start-condition diagnostics remain complete with
+  compatible-ISAM still deferred.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -259,6 +259,38 @@ const isValidExplicitFileMonitoringInterval = (
 const isExplicitMacroVariable = (value: string): boolean =>
   /^\?[^?\r\n]+\?$/.test(value);
 
+const parseHashEscapedQuotedStringLiteralContent = (
+  value: string,
+): string | undefined => {
+  if (!value.startsWith('"') || !value.endsWith('"')) {
+    return undefined;
+  }
+
+  let content = "";
+  for (let index = 1; index < value.length - 1; index += 1) {
+    const character = value[index];
+
+    if (character === "#") {
+      const escapedCharacter = value[index + 1];
+      if (escapedCharacter !== '"' && escapedCharacter !== "#") {
+        return undefined;
+      }
+
+      content += escapedCharacter;
+      index += 1;
+      continue;
+    }
+
+    if (character === '"') {
+      return undefined;
+    }
+
+    content += character;
+  }
+
+  return content;
+};
+
 const parseQuotedStringLiteralContent = (value: string): string | undefined => {
   const matched = /^"((?:\\.|[^"\\])*)"$/.exec(value);
   return matched?.[1];
@@ -312,15 +344,89 @@ const hasInvalidWildcardWithShortMonitoringInterval = (
   return monitoringInterval >= 1 && monitoringInterval <= 9;
 };
 
+const hasValidByteLength = (
+  value: string,
+  minimum: number,
+  maximum: number,
+): boolean => {
+  const byteLength = getByteLength(value);
+  return byteLength >= minimum && byteLength <= maximum;
+};
+
+const isValidExplicitEventReceivingQuotedString = (
+  parameter: UnitParameter | undefined,
+  minimum: number,
+  maximum: number,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (!rawValue) {
+    return false;
+  }
+
+  const content = parseHashEscapedQuotedStringLiteralContent(rawValue);
+  return content !== undefined && hasValidByteLength(content, minimum, maximum);
+};
+
+const isValidExplicitEventReceivingFilterReference = (
+  parameter: UnitParameter | undefined,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (!rawValue || !hasValidByteLength(rawValue, 1, 2048)) {
+    return false;
+  }
+
+  const separatorIndex = rawValue.indexOf(":");
+  if (separatorIndex <= 0) {
+    return false;
+  }
+
+  const attributeName = rawValue.slice(0, separatorIndex);
+  const attributeValue = rawValue.slice(separatorIndex + 1);
+  return (
+    attributeName.length > 0 &&
+    parseHashEscapedQuotedStringLiteralContent(attributeValue) !== undefined
+  );
+};
+
+const isValidExplicitEventReceivingTimeoutCondition = (
+  parameter: UnitParameter | undefined,
+): boolean => {
+  const rawValue = parameter?.value;
+  if (!rawValue) {
+    return false;
+  }
+
+  if (rawValue === "n" || rawValue === "a") {
+    return true;
+  }
+
+  const separatorIndex = rawValue.indexOf(":");
+  if (separatorIndex <= 0) {
+    return false;
+  }
+
+  const mode = rawValue.slice(0, separatorIndex);
+  if (!["n", "a", "d", "b"].includes(mode)) {
+    return false;
+  }
+
+  const fileName = parseHashEscapedQuotedStringLiteralContent(
+    rawValue.slice(separatorIndex + 1),
+  );
+  return fileName !== undefined && hasValidByteLength(fileName, 1, 256);
+};
+
 const collectRuleDiagnostics = (
   unit: Unit,
   rules: readonly UnitParameterDiagnosticRule[],
 ): SyntaxDiagnosticDto[] =>
   rules.flatMap((rule) => {
-    const parameter = findParameter(unit, rule.key);
-    return parameter && rule.isInvalid(parameter, unit)
-      ? [buildDiagnostic(parameter, rule.message)]
-      : [];
+    const parameters = findParameters(unit, rule.key);
+    return parameters.flatMap((parameter) =>
+      rule.isInvalid(parameter, unit)
+        ? [buildDiagnostic(parameter, rule.message)]
+        : [],
+    );
   });
 
 type ParsedExplicitScheduleRuleValue = {
@@ -954,6 +1060,20 @@ const eventSendingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
 
 const eventReceivingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
   {
+    key: "evusr",
+    message:
+      "Event issue source user name (evusr) must be a quoted string between 1 and 20 bytes.",
+    isInvalid: (parameter) =>
+      !isValidExplicitEventReceivingQuotedString(parameter, 1, 20),
+  },
+  {
+    key: "evgrp",
+    message:
+      "Event issue source group name (evgrp) must be a quoted string between 1 and 20 bytes.",
+    isInvalid: (parameter) =>
+      !isValidExplicitEventReceivingQuotedString(parameter, 1, 20),
+  },
+  {
     key: "evhst",
     message: "Event host (evhst) must be between 1 and 255 bytes.",
     isInvalid: (parameter) => !isValidExplicitEventHostValue(parameter),
@@ -970,6 +1090,34 @@ const eventReceivingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
     message:
       "Event source IP address (evipa) must be a dotted-decimal IPv4 address between 0.0.0.0 and 255.255.255.255.",
     isInvalid: (parameter) => !isValidExplicitIpv4Address(parameter),
+  },
+  {
+    key: "evwms",
+    message:
+      "Event message filter (evwms) must be a quoted string between 1 and 1024 bytes.",
+    isInvalid: (parameter) =>
+      !isValidExplicitEventReceivingQuotedString(parameter, 1, 1024),
+  },
+  {
+    key: "evdet",
+    message:
+      "Detailed event information filter (evdet) must be a quoted string between 1 and 1024 bytes.",
+    isInvalid: (parameter) =>
+      !isValidExplicitEventReceivingQuotedString(parameter, 1, 1024),
+  },
+  {
+    key: "evwfr",
+    message:
+      'Optional extended attribute filter (evwfr) must use optional-extended-attribute-name:"value" format within 2048 bytes.',
+    isInvalid: (parameter) =>
+      !isValidExplicitEventReceivingFilterReference(parameter),
+  },
+  {
+    key: "evtmc",
+    message:
+      'End judgment condition (evtmc) must be n, a, n:"file-name", a:"file-name", d:"file-name", or b:"file-name" with a file name between 1 and 256 bytes.',
+    isInvalid: (parameter) =>
+      !isValidExplicitEventReceivingTimeoutCondition(parameter),
   },
   {
     key: "evesc",

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -1917,6 +1917,142 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("does not report event receiving string-filter diagnostics for omitted and valid explicit values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=wait1,evwj,+0+0;",
+        "  el=wait2,revwj,+160+0;",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        '    evusr="ops.*";',
+        '    evgrp="admins";',
+        '    evwms="match message";',
+        '    evdet="detail text";',
+        '    evwfr=?AJS2.EVENT?:"value";',
+        '    evtmc=n:"/tmp/result.txt";',
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports event receiving string-filter diagnostics for explicit invalid values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=wait1,evwj,+0+0;",
+        "  el=wait2,revwj,+160+0;",
+        "  el=wait3,evwj,+320+0;",
+        "  el=wait4,revwj,+480+0;",
+        "  el=wait5,evwj,+640+0;",
+        "  el=wait6,revwj,+800+0;",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evusr=plain-user;",
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        `    evgrp="${"a".repeat(21)}";`,
+        "  }",
+        "  unit=wait3,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        `    evwms="${"m".repeat(1025)}";`,
+        "  }",
+        "  unit=wait4,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    evdet=detail-text;",
+        "  }",
+        "  unit=wait5,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evwfr=attribute:value;",
+        "  }",
+        "  unit=wait6,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        '    evtmc=d:"";',
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 6);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 12,
+          column: 4,
+          length: 5,
+          message:
+            "Event issue source user name (evusr) must be a quoted string between 1 and 20 bytes.",
+        },
+        {
+          line: 17,
+          column: 4,
+          length: 5,
+          message:
+            "Event issue source group name (evgrp) must be a quoted string between 1 and 20 bytes.",
+        },
+        {
+          line: 22,
+          column: 4,
+          length: 5,
+          message:
+            "Event message filter (evwms) must be a quoted string between 1 and 1024 bytes.",
+        },
+        {
+          line: 27,
+          column: 4,
+          length: 5,
+          message:
+            "Detailed event information filter (evdet) must be a quoted string between 1 and 1024 bytes.",
+        },
+        {
+          line: 32,
+          column: 4,
+          length: 5,
+          message:
+            'Optional extended attribute filter (evwfr) must use optional-extended-attribute-name:"value" format within 2048 bytes.',
+        },
+        {
+          line: 37,
+          column: 4,
+          length: 5,
+          message:
+            'End judgment condition (evtmc) must be n, a, n:"file-name", a:"file-name", d:"file-name", or b:"file-name" with a file name between 1 and 256 bytes.',
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error", "error", "error", "error"],
+    );
+  });
+
   test("reports event-host diagnostics for explicit out-of-range evhst values", () => {
     const oversizedHost = "a".repeat(256);
     const diagnostics = buildSyntaxDiagnostics(


### PR DESCRIPTION
## Summary
- add JP1 event reception monitoring string-filter diagnostics for `evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and `evtmc`
- keep the checks on the existing editor-feedback rule-array path and expand regression coverage in `buildSyntaxDiagnostics.test.ts`
- sync SDD records, coverage matrix, plans, and editor-feedback use-case docs for the delivered slice

## Why
The JP1/AJS v13 parameter-alignment backlog still had a user-visible gap in event reception monitoring filter validation. This slice closes that gap in one job-family-sized change without changing parser output, wrapper values, or projections.

## Impact
- invalid explicit event-receiving filter values now produce semantic diagnostics in editor feedback
- raw parser output, domain wrapper values, normalized parameters, unit-list projection, flow projection, and command generation remain unchanged
- SDD tracking now marks the string-filter slice as delivered and leaves numeric/timeout-oriented follow-ups deferred

## Validation
- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`