### PR TITLE
[codex] align event receiving numeric identifier diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -177,6 +177,16 @@ Scenario: Event reception monitoring identifiers must stay within documented
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Event reception monitoring numeric identifiers must stay within
+  documented ranges
+  Given a syntactically valid JP1/AJS document with a JP1 event reception
+    monitoring job
+  And explicit `evuid`, `evgid`, or `evpid` is outside the JP1/AJS3 v13
+    signed-decimal range `-1..9999999999`
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Event reception monitoring string filters must stay within documented
   explicit forms
   Given a syntactically valid JP1/AJS document with a JP1 event reception

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
@@ -125,5 +125,6 @@ slices plus the remaining grouped follow-up for `Evwj` / `Revwj`.
   preserving regular-expression and macro-variable allowance.
 - Grouped event-receiving string-filter validation is now aligned in
   `EVENT_RECEIVING_STRING_FILTER_ALIGNMENT.md`.
-- Revisit numeric identifier and timeout-oriented event reception monitoring
-  validation as separate later slices.
+- Revisit timeout-oriented event reception monitoring validation later.
+- Grouped numeric identifier validation for `evuid`, `evgid`, and `evpid` is
+  now tracked in `EVENT_RECEIVING_NUMERIC_IDENTIFIER_ALIGNMENT.md`.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_NUMERIC_IDENTIFIER_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_NUMERIC_IDENTIFIER_ALIGNMENT.md
@@ -1,0 +1,100 @@
+# Event Receiving Numeric-Identifier Alignment
+
+## Purpose
+
+Record the JP1/AJS3 version 13 alignment status for the numeric identifier
+parameters of JP1 event reception monitoring jobs.
+
+This keeps the backlog grouped at a user-meaningful size: users configure one
+JP1 event reception monitoring job definition, and the remaining numeric
+identifier gaps all sit on the same `evwj` / `revwj` diagnostic seam.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual section:
+  Command Reference, `5.2.9 Job definition for monitoring JP1 event reception`
+- Source URL:
+  <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0224.HTM>
+
+## Slice Boundary
+
+- Application seam:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`
+- Existing consumers:
+  `src/extension/diagnostics/registerDiagnostics.ts` plus
+  `src/domain/models/units/Evwj.ts` and `Revwj` via inheritance
+- Regression evidence:
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`
+- Out of scope:
+  parser grammar changes, domain wrapper normalization changes, unit-list
+  projection changes, flow projection changes, command generation,
+  generated artifacts, dependency changes, configuration changes,
+  compatible-ISAM or host-environment inputs, timeout-oriented event-
+  reception rules such as `etm`, `fd`, `ha`, and `ets`, and `engines.vscode`
+
+## Investigation Notes
+
+- The current event-receiving diagnostic path already validates explicit
+  string-filter, event-host, event-ID, IP-address, and search-scope values,
+  but it does not yet validate `evuid`, `evgid`, or `evpid`.
+- `Evwj` already exposes `evuid`, `evgid`, and `evpid` through the same
+  `ParamFactory` facade and the same shared application editor-feedback
+  boundary as the previously delivered event-receiving slices.
+- The official JP1/AJS3 v13 command reference states that `evuid`, `evgid`,
+  and `evpid` each accept signed-decimal values in the range
+  `-1..9999999999`.
+- This candidate is preferable to HTTP Connection `eu` cleanup because it
+  closes three still-visible validation gaps in one job family at once.
+- This candidate is preferable to timeout-oriented event-receiving work
+  because `etm`, `fd`, `ha`, and `ets` introduce a different validation shape
+  and broader execution-context decisions than the remaining numeric
+  identifier family.
+- `buildSyntaxDiagnostics.ts` already has generic unsigned decimal-range
+  helpers, so the likely refactor need is only the smallest signed-range
+  helper or rule builder that keeps the new checks on the existing
+  `eventReceivingDiagnosticRules` path.
+
+## Delivered Alignment
+
+- Keep ownership in the shared application editor-feedback boundary.
+- Add grouped semantic diagnostics for explicit invalid `evuid`, `evgid`, and
+  `evpid` values on `evwj` / `revwj`.
+- Extract only the smallest helper and rule-array refactor needed to keep the
+  signed-decimal range checks on the current event-receiving diagnostics
+  path.
+- Preserve raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
+
+## Affected Backlog
+
+- Event reception monitoring job:
+  remaining numeric identifier validation outside the already aligned
+  string-filter, event-host, event-ID, IP-address, and search-scope keys
+
+## Alternatives
+
+- Pick HTTP Connection `eu` next:
+  rejected because it is smaller and less user-visible than the grouped
+  numeric-identifier slice.
+- Broaden immediately to `etm`, `fd`, `ha`, or `ets`:
+  rejected for now because those timeout-oriented rules are a different
+  validation shape from the remaining numeric identifier family.
+- Move the validation into domain wrappers:
+  rejected because the current alignment policy preserves raw explicit
+  manual-invalid values and surfaces them through editor feedback.
+
+## Delivered Behavior
+
+- Editor feedback now reports semantic diagnostics when explicit `evuid`,
+  `evgid`, or `evpid` values are not signed decimal integers within the
+  documented JP1/AJS3 v13 range `-1..9999999999`.
+- Omitted `evuid`, `evgid`, and `evpid` values remain non-diagnostic.
+- Existing event-receiving diagnostics should remain on the same shared rule
+  path.
+
+## Remaining Gap
+
+- Timeout or start-condition rules such as `etm`, `fd`, `ha`, and `ets`
+  remain separate future slices because they require a different validation
+  shape from the numeric identifier family.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -190,9 +190,22 @@ coverage.
   `buildSyntaxDiagnostics.ts` and `Evwj.ts`
 - Evidence: `buildSyntaxDiagnostics.test.ts`
 - Remaining gap:
-  numeric identifier validation for `evuid`, `evgid`, and `evpid`, plus
   timeout- or start-condition-oriented validation outside this string-filter
-  family, remain deferred
+  family remains deferred
+
+### Event Reception Monitoring Numeric Identifiers
+
+- Keys: `evuid`, `evgid`, and `evpid`
+- Unit scope:
+  JP1 event reception monitoring jobs and recovery JP1 event reception
+  monitoring jobs
+- Status: aligned
+- Owning seam:
+  `buildSyntaxDiagnostics.ts` and `Evwj.ts`
+- Evidence: `buildSyntaxDiagnostics.test.ts`
+- Remaining gap:
+  timeout- or start-condition-oriented validation outside this numeric
+  identifier family remains deferred
 
 ## Boundary Decisions
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -281,6 +281,23 @@ JP1/AJS3 version 13 reference documents.
   byte-length or allowed-format rules, while raw parser output, domain
   wrapper values, normalized parameters, unit-list projection, flow
   projection, and command generation remain unchanged.
+- JP1 event reception monitoring job numeric identifier validation is
+  approval-sensitive because existing behavior preserves explicit `evuid`,
+  `evgid`, and `evpid` values as raw parsed data without editor feedback. A
+  grouped diagnostic slice should stay inside application editor-feedback for
+  `evwj` / `revwj`, report explicit signed-decimal values outside the
+  documented JP1/AJS3 v13 range `-1..9999999999`, reuse or extract only the
+  smallest signed-range helper needed to keep the checks on the current
+  event-receiving rule-array path, and preserve raw parser output, domain
+  wrapper values, normalized parameters, unit-list projection, flow
+  projection, and command generation.
+- JP1 event reception monitoring job numeric identifier validation is aligned
+  through application editor-feedback. Explicit `evuid`, `evgid`, and
+  `evpid` values on `evwj` / `revwj` now report a semantic diagnostic when
+  they are not signed decimal integers within the JP1/AJS3 v13 range
+  `-1..9999999999`, while raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation remain unchanged.
 - JP1 event reception monitoring job `evwid` and `evipa` validation are
   aligned through application editor-feedback. Explicit `evwid` values on
   `evwj` / `revwj` now report a semantic diagnostic when they are not

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -216,6 +216,27 @@
 - [x] Add focused regression evidence for valid and invalid explicit
       `evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and `evtmc` values
 - [x] Run required code-change validation after implementation
+- [x] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
+      delivered JP1 event reception monitoring string-filter slice and select
+      the next candidate using the same user-meaningful grouping rule
+- [x] Record the next grouped JP1 event reception monitoring numeric
+      identifier slice in feature-local investigation docs with manual-backed
+      scope, affected seams, alternatives, and regression evidence
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      JP1 event reception monitoring numeric identifier diagnostics
+- [x] Implement grouped JP1 event reception monitoring numeric identifier
+      diagnostics only after approval
+- [x] Refactor `buildSyntaxDiagnostics.ts` within the approved scope so the
+      new event-receiving numeric identifier checks stay on the existing
+      rule-array path
+- [x] Add focused regression evidence for valid and invalid explicit
+      `evuid`, `evgid`, and `evpid` values, including boundary values
+      `-1` and `9999999999`
+- [x] Run required code-change validation after implementation
+- [ ] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
+      delivered JP1 event reception monitoring numeric identifier slice and
+      select the next candidate using the same user-meaningful grouping rule
 
 ## Notes
 
@@ -689,6 +710,38 @@
   `EVENT_RECEIVING_STRING_FILTER_ALIGNMENT.md`, `SPECS.md`,
   `docs/specs/plans.md`, `TASKS.md`, and `uc-provide-editor-feedback.md` now
   record the delivered event-receiving string-filter slice.
+- 2026-05-09: Remaining actionable JP1/AJS v13 gaps were re-checked after the
+  delivered event-receiving string-filter slice. The next recommended
+  approval-gated candidate is grouped JP1 event reception monitoring numeric
+  identifier diagnostics for `evwj` / `revwj`, because the remaining
+  user-visible gap still clusters around one job definition, one
+  event-receiving editor-feedback seam, and one regression-test file.
+- 2026-05-09: Investigation confirmed from the JP1/AJS3 v13 event reception
+  monitoring definition that explicit `evuid`, `evgid`, and `evpid` values
+  share the same signed-decimal range `-1..9999999999`, making them a better
+  grouped follow-up than broadening immediately into timeout-oriented `etm`,
+  `fd`, `ha`, or `ets` work.
+- 2026-05-09: The likely code refactor seam for the next slice is limited to
+  the smallest signed-decimal range helper or rule builder needed to keep the
+  new checks on the current `buildSyntaxDiagnostics.ts`
+  `eventReceivingDiagnosticRules` path, instead of adding a separate
+  validation branch.
+- 2026-05-09: `EVENT_RECEIVING_NUMERIC_IDENTIFIER_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
+  `TASKS.md`, and `uc-provide-editor-feedback.md` now record the pending
+  event-receiving numeric identifier slice and its approval boundary.
+- 2026-05-09: Grouped JP1 event reception monitoring numeric identifier
+  diagnostics now report explicit invalid `evuid`, `evgid`, and `evpid`
+  values on `evwj` / `revwj` through the existing editor-feedback boundary.
+  Raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.
+- 2026-05-09: `buildSyntaxDiagnostics.ts` now keeps the new numeric
+  identifier checks on the existing event-receiving rule-array path by adding
+  the smallest signed-decimal range helper needed for the approved scope.
+- 2026-05-09: `EVENT_RECEIVING_NUMERIC_IDENTIFIER_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
+  `TASKS.md`, and `uc-provide-editor-feedback.md` now record the delivered
+  event-receiving numeric identifier slice.
 - 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after grouped
   event-receiving string-filter diagnostics implementation.
 - 2026-05-09: `rtk pnpm test` completed with exit code 0 after grouped
@@ -727,27 +780,52 @@
   warnings after grouped `ets` timeout-action diagnostics implementation.
 - 2026-05-08: `rtk pnpm run lint:md` completed with exit code 0 after grouped
   `ets` timeout-action diagnostics implementation.
+- 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  event-receiving numeric identifier diagnostics implementation.
+- 2026-05-09: `rtk pnpm test` completed with exit code 0 after grouped
+  event-receiving numeric identifier diagnostics implementation; the VS Code
+  harness emitted the existing macOS `task_name_for_pid` codesign noise line.
+- 2026-05-09: `rtk pnpm run test:web` completed with exit code 0 after
+  grouped event-receiving numeric identifier diagnostics implementation and
+  emitted the existing localhost dev-extension `package.nls.json` 404 noise.
+- 2026-05-09: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped event-receiving numeric identifier diagnostics
+  implementation.
+- 2026-05-09: `rtk pnpm run lint:md` completed with exit code 0 after grouped
+  event-receiving numeric identifier diagnostics implementation.
 
 ## Human Approval
 
 - Status: Approved
 - Approved at: 2026-05-09
-- Approved scope: grouped JP1 event reception monitoring string-filter
-  diagnostics for explicit `evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and
-  `evtmc` combinations on `evwj` / `revwj`, limited to documented byte-length
-  and allowed-format rules through the existing editor-feedback boundary,
-  plus the smallest helper/rule-array refactor needed to keep the checks on
-  the current `buildSyntaxDiagnostics.ts` event-receiving path, while
-  preserving raw parser output, domain wrapper values, normalized
-  parameters, unit-list projection, flow projection, command generation,
-  generated artifacts, dependency versions, configuration, and
-  `engines.vscode`.
+- Approved scope: grouped JP1 event reception monitoring numeric identifier
+  diagnostics for explicit `evuid`, `evgid`, and `evpid` combinations on
+  `evwj` / `revwj`, limited to the documented signed-decimal range
+  `-1..9999999999` through the existing editor-feedback boundary, plus the
+  smallest helper/rule-array refactor needed to keep the checks on the
+  current `buildSyntaxDiagnostics.ts` event-receiving path, while preserving
+  raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, command generation, generated artifacts,
+  dependency versions, configuration, and `engines.vscode`.
 
 Current implementation gate: approved implementation may proceed only within
-the grouped event-receiving string-filter scope recorded above.
+the grouped event-receiving numeric identifier scope recorded above.
 
 ## Prior Approval Evidence
 
+- 2026-05-09: User replied "Approved. Proceed with implementation." after the
+  grouped JP1 event reception monitoring numeric identifier diagnostics
+  approval request. Approved changes are limited to adding grouped
+  application-level semantic diagnostics for explicit `evuid`, `evgid`, and
+  `evpid` values on `evwj` / `revwj` through the existing editor-feedback
+  boundary, plus the smallest helper/rule-array refactor needed to keep the
+  checks on the current `buildSyntaxDiagnostics.ts` event-receiving path;
+  preserving raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation;
+  adding focused regression evidence; updating SDD tracking; and running
+  validation. Parser grammar, domain normalization, generated artifacts,
+  configuration, dependency versions, compatible-ISAM/environment inputs,
+  and `engines.vscode` are out of scope.
 - 2026-05-09: User replied "Approved. Proceed with implementation." after the
   grouped JP1 event reception monitoring string-filter diagnostics approval
   request. Approved changes are limited to adding grouped application-level

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -78,6 +78,12 @@ rules in `docs/specs/README.md`, not in this file.
   monitoring filter family and group the still-raw string-filter parameters
   (`evusr`, `evgrp`, `evwms`, `evdet`, `evwfr`, and `evtmc`) instead of
   jumping to smaller default-only cleanup or environment-sensitive work.
+- After the delivered grouped JP1 event reception monitoring string-filter
+  diagnostics slice, the next recommended JP1/AJS v13 candidate should stay
+  within the same `evwj` / `revwj` job definition and align the remaining
+  numeric identifier parameters (`evuid`, `evgid`, and `evpid`) together,
+  because they share one manual section, one editor-feedback seam, one
+  signed-decimal validation shape, and one regression-test file.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -96,7 +102,7 @@ rules in `docs/specs/README.md`, not in this file.
 ## Next Priority Tasks
 
 1. Re-check the remaining partial or deferred JP1/AJS3 v13 parameter-alignment
-   gaps after the delivered JP1 event reception monitoring string-filter
+   gaps after the delivered JP1 event reception monitoring numeric identifier
    slice and record the next approval-gated candidate.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
@@ -113,31 +119,31 @@ rules in `docs/specs/README.md`, not in this file.
 - Branch: `main`; a dedicated implementation branch was attempted but could
   not be created from the sandboxed session after approval
 - Objective: deliver the approved JP1/AJS v13 event-reception monitoring
-  string-filter slice after the execution-interval control context
-  diagnostics.
+  numeric-identifier slice after the delivered string-filter diagnostics.
 - Status: implementation and validation are complete in the recorded scope.
 - Scope: grouped semantic diagnostics were added in
-  `buildSyntaxDiagnostics.ts` for explicit `evusr`, `evgrp`, `evwms`,
-  `evdet`, `evwfr`, and `evtmc` values on `evwj` / `revwj`, plus only the
-  smallest helper/rule-array refactor needed to keep the checks on the
-  existing event-receiving diagnostics path.
+  `buildSyntaxDiagnostics.ts` for explicit `evuid`, `evgid`, and `evpid`
+  values on `evwj` / `revwj`, plus only the smallest helper/rule-array
+  refactor needed to keep the checks on the current event-receiving
+  diagnostics path.
 - Out of scope: parser grammar changes, domain wrapper normalization changes,
   unit-list projection changes, flow projection changes, command generation,
-  compatible-ISAM detection, generated artifacts, dependency changes,
+  timeout-oriented event-receiving rules such as `etm`, `fd`, `ha`, and
+  `ets`, compatible-ISAM detection, generated artifacts, dependency changes,
   configuration, and `engines.vscode`.
 - Impact summary: the implemented scope affected
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
   `src/test/suite/buildSyntaxDiagnostics.test.ts`, the parameter-alignment
   feature docs, and the editor-feedback behavior contract for syntactically
   valid `evwj` / `revwj` documents.
-- Risks and assumptions: the delivered slice keeps behavior diagnostic-only.
-  Regex and macro-variable allowance still differs by parameter, so the new
-  shared helpers intentionally stop at explicit quoted-string and format
-  validation instead of inferring broader parser semantics.
-- Alternatives considered: returning to HTTP Connection `eu` would be smaller
-  but less user-meaningful; broadening immediately into compatible-ISAM or
-  platform-specific transfer-file interpretation would introduce new seams
-  that exceed the smallest reviewable boundary.
+- Risks and assumptions: the delivered slice stays diagnostic-only and does
+  not change raw parser output, domain wrapper values, or projection
+  behavior. The helper refactor stayed limited to one signed-range parsing
+  seam inside the existing editor-feedback path.
+- Alternatives considered: returning to HTTP Connection `eu` remains smaller
+  but less user-meaningful; broadening immediately into timeout-oriented
+  `evwj` rules or compatible-ISAM work would mix different validation shapes
+  and introduce new context seams.
 
 ## Build/Test Performance SDD
 
@@ -166,10 +172,10 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped JP1 event reception monitoring string-filter diagnostics are
-  implemented and validated; the next candidate should be re-selected from
-  the remaining partial or deferred gaps, while the previously delivered
-  execution-interval start-condition diagnostics remain complete with
+  slice: grouped JP1 event reception monitoring numeric identifier
+  diagnostics are implemented and validated for explicit `evuid`, `evgid`,
+  and `evpid`, while the previously delivered event-receiving string-filter
+  and execution-interval start-condition diagnostics remain complete with
   compatible-ISAM still deferred.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -88,11 +88,13 @@ const buildExplicitDecimalRangeRule = (
   minimum: number,
   maximum: number,
   message: string,
+  options: { allowNegative?: boolean } = {},
 ): UnitParameterDiagnosticRule => ({
   key,
   message,
   isInvalid: (parameter) =>
-    parseExplicitDecimalInRange(parameter, minimum, maximum) === undefined,
+    parseExplicitDecimalInRange(parameter, minimum, maximum, options) ===
+    undefined,
 });
 
 const buildExplicitByteLengthRule = (
@@ -131,9 +133,11 @@ const parseExplicitDecimalInRange = (
   parameter: UnitParameter | undefined,
   minimum: number,
   maximum: number,
+  options: { allowNegative?: boolean } = {},
 ): number | undefined => {
   const rawValue = parameter?.value;
-  if (!rawValue || !/^\d+$/.test(rawValue)) {
+  const decimalPattern = options.allowNegative ? /^-?\d+$/ : /^\d+$/;
+  if (!rawValue || !decimalPattern.test(rawValue)) {
     return undefined;
   }
 
@@ -1059,6 +1063,27 @@ const eventSendingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
 ];
 
 const eventReceivingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
+  buildExplicitDecimalRangeRule(
+    "evuid",
+    -1,
+    9999999999,
+    "Event issue source user ID (evuid) must be a signed decimal value between -1 and 9999999999.",
+    { allowNegative: true },
+  ),
+  buildExplicitDecimalRangeRule(
+    "evgid",
+    -1,
+    9999999999,
+    "Event issue source group ID (evgid) must be a signed decimal value between -1 and 9999999999.",
+    { allowNegative: true },
+  ),
+  buildExplicitDecimalRangeRule(
+    "evpid",
+    -1,
+    9999999999,
+    "Event issue source process ID (evpid) must be a signed decimal value between -1 and 9999999999.",
+    { allowNegative: true },
+  ),
   {
     key: "evusr",
     message:

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -2053,6 +2053,100 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("does not report event receiving numeric-identifier diagnostics for omitted and boundary values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=wait1,evwj,+0+0;",
+        "  el=wait2,revwj,+160+0;",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evuid=-1;",
+        "    evgid=0;",
+        "    evpid=9999999999;",
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports event receiving numeric-identifier diagnostics for explicit out-of-range values", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=wait1,evwj,+0+0;",
+        "  el=wait2,revwj,+160+0;",
+        "  el=wait3,evwj,+320+0;",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evuid=-2;",
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    evgid=10000000000;",
+        "  }",
+        "  unit=wait3,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evpid=abc;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 3);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 9,
+          column: 4,
+          length: 5,
+          message:
+            "Event issue source user ID (evuid) must be a signed decimal value between -1 and 9999999999.",
+        },
+        {
+          line: 14,
+          column: 4,
+          length: 5,
+          message:
+            "Event issue source group ID (evgid) must be a signed decimal value between -1 and 9999999999.",
+        },
+        {
+          line: 19,
+          column: 4,
+          length: 5,
+          message:
+            "Event issue source process ID (evpid) must be a signed decimal value between -1 and 9999999999.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error"],
+    );
+  });
+
   test("reports event-host diagnostics for explicit out-of-range evhst values", () => {
     const oversizedHost = "a".repeat(256);
     const diagnostics = buildSyntaxDiagnostics(


### PR DESCRIPTION
## Summary
- add grouped editor-feedback diagnostics for explicit `evuid`, `evgid`, and `evpid` values on `evwj` / `revwj`
- unify signed and unsigned decimal range validation behind the shared explicit decimal range helper
- sync the JP1/AJS v13 alignment SDD artifacts and editor-feedback use case for the delivered numeric-identifier slice

## Why
This closes the remaining event-reception numeric identifier validation gap in a user-meaningful slice without changing parser output, domain wrapper values, projection behavior, or command generation.

## Validation
- rtk pnpm run qlty
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
- rtk pnpm run lint:md

## Notes
- desktop tests still emit the existing macOS `task_name_for_pid` codesign noise line
- web tests still emit the existing dev-extension `package.nls.json` 404 noise
- build still emits the existing webpack asset-size warnings
