### PR TITLE
Add event-receiving timeout-control diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -202,6 +202,20 @@ Scenario: Event reception monitoring string filters must stay within documented
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Event reception monitoring timeout controls must preserve documented
+  values and start-condition rules
+  Given a syntactically valid JP1/AJS document with a JP1 event reception
+    monitoring job
+  And explicit `etm` is outside the JP1/AJS3 v13 range `1..1440`
+  Or explicit `ha` is outside the JP1/AJS3 v13 value set `{y|n}`
+  Or explicit `ets` is outside the JP1/AJS3 v13 value set
+    `{kl|nr|wr|an}`
+  Or explicit `etm`, `ha`, or `ets` is specified on a job defined in a
+    start-condition context
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Event host values must stay within documented byte-length rules
   Given a syntactically valid JP1/AJS document with a JP1 event sending job
     or JP1 event reception monitoring job

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_JOB_ALIGNMENT.md
@@ -3,11 +3,12 @@
 ## Purpose
 
 Record the JP1/AJS3 version 13 alignment status and remaining grouped
-validation candidate for JP1 event reception monitoring job semantic
+validation candidates for JP1 event reception monitoring job semantic
 diagnostics.
 
-This document covers the delivered `evesc`, `evwid`, and `evipa` diagnostic
-slices plus the remaining grouped follow-up for `Evwj` / `Revwj`.
+This document covers the delivered `evesc`, `evwid`, `evipa`, and
+timeout-control diagnostic slices plus the remaining grouped follow-up for
+`Evwj` / `Revwj`.
 
 ## Normative Reference
 
@@ -125,6 +126,9 @@ slices plus the remaining grouped follow-up for `Evwj` / `Revwj`.
   preserving regular-expression and macro-variable allowance.
 - Grouped event-receiving string-filter validation is now aligned in
   `EVENT_RECEIVING_STRING_FILTER_ALIGNMENT.md`.
-- Revisit timeout-oriented event reception monitoring validation later.
+- Grouped event-receiving timeout-control validation is now aligned in
+  `EVENT_RECEIVING_TIMEOUT_CONTROL_ALIGNMENT.md`.
+- Revisit `fd` and broader wait-condition event reception monitoring
+  validation later.
 - Grouped numeric identifier validation for `evuid`, `evgid`, and `evpid` is
   now tracked in `EVENT_RECEIVING_NUMERIC_IDENTIFIER_ALIGNMENT.md`.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_TIMEOUT_CONTROL_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_TIMEOUT_CONTROL_ALIGNMENT.md
@@ -1,0 +1,125 @@
+# Event Receiving Timeout-Control Alignment
+
+## Purpose
+
+Record the next JP1/AJS3 version 13 parameter-alignment candidate for the
+timeout-control and start-condition-restricted parameters of JP1 event
+reception monitoring jobs.
+
+This keeps the backlog grouped at a user-meaningful size: users configure one
+JP1 event reception monitoring job definition, and the remaining timeout
+control gaps all sit on the same `evwj` / `revwj` diagnostic seam.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual section:
+  Command Reference, `5.2.9 Job definition for monitoring JP1 event reception`
+- Source URL:
+  <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0224.HTM>
+
+## Slice Boundary
+
+- Application seam:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`
+- Existing consumers:
+  `src/extension/diagnostics/registerDiagnostics.ts` plus
+  `src/domain/models/units/Evwj.ts` and `Revwj` via inheritance
+- Regression evidence:
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`
+- Preservation evidence:
+  existing raw projection coverage in `src/test/suite/buildUnitListView.test.ts`
+- Out of scope:
+  parser grammar changes, domain wrapper normalization changes, unit-list
+  projection changes, flow projection changes, command generation,
+  generated artifacts, dependency changes, configuration changes,
+  compatible-ISAM or host-environment inputs, `fd` disabled-on-execution
+  semantics, `evwsv`, `jpoif`, wait-condition parameters such as `mm`,
+  `nmg`, `eun`, `ega`, and `uem`, and `engines.vscode`
+
+## Investigation Notes
+
+- The current event-receiving diagnostic path already validates search-scope,
+  event-host, string-filter, and numeric-identifier values, but it still
+  preserves explicit `etm`, `ha`, and `ets` values without semantic
+  diagnostics.
+- `Evwj` already exposes `etm`, `ha`, and `ets` through the same
+  `ParamFactory` facade and the same shared application editor-feedback
+  boundary as the previously delivered event-receiving slices.
+- The official JP1/AJS3 v13 command reference states:
+  - `etm` accepts decimal values in the range `1..1440`.
+  - `ha` accepts only `y` or `n`.
+  - `ets` accepts only `kl`, `nr`, `wr`, or `an`.
+  - explicit `etm`, `ha`, and `ets` are invalid for a job within the start
+    condition.
+- `buildSyntaxDiagnostics.ts` already has the main seams needed for this
+  grouped slice:
+  - `buildExplicitDecimalRangeRule(...)` already covers the `1..1440`
+    numeric-range shape;
+  - `eventTimeoutActionDiagnosticRules` already centralizes explicit `ets`
+    allowed-value checks for other wait-like job families;
+  - `hasStartConditionContext(...)` already detects the sibling start-
+    condition context used by the recent execution-interval slice.
+- This candidate is preferable to returning to HTTP Connection `eu`, because
+  it closes multiple still-visible validation gaps in one job family at once.
+- This candidate is preferable to broadening immediately into compatible-ISAM
+  or `fd` behavior, because the timeout-control family stays inside one
+  existing diagnostic seam and avoids introducing a new environment or
+  disabled-behavior interpretation seam during the same slice.
+
+## Delivered Alignment
+
+- Keep ownership in the shared application editor-feedback boundary.
+- Add grouped semantic diagnostics for explicit invalid `etm`, `ha`, and
+  `ets` values on `evwj` / `revwj`.
+- Add grouped semantic diagnostics for explicit `etm`, `ha`, and `ets`
+  values when the unit is defined in a start-condition context.
+- Reuse existing shared explicit-value and sibling-context helpers where
+  practical, extracting only the smallest helper or rule-array refactor
+  needed to keep the checks on the current event-receiving diagnostics path.
+- Preserve raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
+
+## Delivered Behavior
+
+- Editor feedback now reports semantic diagnostics when explicit `etm` values
+  on `evwj` / `revwj` fall outside the documented JP1/AJS3 v13 range
+  `1..1440`.
+- Editor feedback now reports semantic diagnostics when explicit `ha` values
+  on `evwj` / `revwj` fall outside the documented JP1/AJS3 v13 value set
+  `{y|n}`.
+- Editor feedback now reports semantic diagnostics when explicit `ets` values
+  on `evwj` / `revwj` fall outside the documented JP1/AJS3 v13 value set
+  `{kl|nr|wr|an}`.
+- Editor feedback now reports semantic diagnostics when explicit `etm`, `ha`,
+  or `ets` is specified on a JP1 event reception monitoring job defined in a
+  start-condition context.
+- Existing event-receiving search-scope, event-host, string-filter, and
+  numeric-identifier diagnostics remain on the same shared rule path.
+
+## Affected Backlog
+
+- Event reception monitoring job:
+  remaining timeout-control and start-condition-restricted validation outside
+  the already aligned search-scope, string-filter, event-host, and numeric-
+  identifier families
+
+## Alternatives
+
+- Pick HTTP Connection `eu` next:
+  rejected because it is smaller and less user-visible than the grouped
+  event-receiving timeout-control slice.
+- Broaden this slice immediately to `fd`:
+  rejected for now because the manual says `fd` is disabled when a start-
+  condition job is executed, which is a different semantic shape from
+  outright invalid explicit timeout-control parameters.
+- Move the validation into domain wrappers:
+  rejected because the current alignment policy preserves raw explicit
+  manual-invalid values and surfaces them through editor feedback.
+
+## Remaining Gap
+
+- `fd` range or disabled-on-execution behavior, compatible-ISAM-sensitive
+  interpretation, and the broader wait-condition parameter family remain
+  separate future slices because they introduce different validation shapes
+  or new runtime-context seams.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -207,6 +207,24 @@ coverage.
   timeout- or start-condition-oriented validation outside this numeric
   identifier family remains deferred
 
+### Event Reception Monitoring Timeout Controls
+
+- Keys: `etm`, `ha`, and `ets`
+- Unit scope:
+  JP1 event reception monitoring jobs and recovery JP1 event reception
+  monitoring jobs
+- Status: aligned
+- Owning seam:
+  `buildSyntaxDiagnostics.ts`, `Evwj.ts`, and shared
+  `eventTimeoutActionDiagnosticRules`
+- Evidence:
+  `buildSyntaxDiagnostics.test.ts` and existing raw projection coverage in
+  `buildUnitListView.test.ts`
+- Remaining gap:
+  `fd` disabled-on-execution semantics, compatible-ISAM-sensitive
+  interpretation, and the broader wait-condition parameter family remain
+  separate future slices
+
 ## Boundary Decisions
 
 - This matrix covers only categories with feature-local investigation records.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -298,6 +298,31 @@ JP1/AJS3 version 13 reference documents.
   `-1..9999999999`, while raw parser output, domain wrapper values,
   normalized parameters, unit-list projection, flow projection, and command
   generation remain unchanged.
+- JP1 event reception monitoring timeout-control diagnostics are approval-
+  sensitive because existing behavior preserves explicit `etm`, `ha`, and
+  `ets` values as raw parsed data without editor feedback, including when the
+  job is defined in a start-condition context where those parameters are
+  documented as invalid. A focused follow-up should stay inside application
+  editor-feedback for `evwj` / `revwj`, report explicit `etm` values outside
+  `1..1440`, explicit `ha` values outside `{y|n}`, explicit `ets` values
+  outside `{kl|nr|wr|an}`, and explicit `etm` / `ha` / `ets` when the unit is
+  defined in a start-condition context, reuse the existing decimal-range,
+  shared `ets`, and sibling-context helper seams where practical, and
+  preserve raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation. `fd`
+  disabled-on-execution behavior, compatible-ISAM-sensitive interpretation,
+  and broader wait-condition semantics remain separate approval-sensitive
+  work.
+- JP1 event reception monitoring timeout-control diagnostics are aligned
+  through application editor-feedback. Explicit `etm` values on `evwj` /
+  `revwj` now report a semantic diagnostic when they fall outside `1..1440`,
+  explicit `ha` values now report a semantic diagnostic when they fall
+  outside `{y|n}`, explicit `ets` values now report a semantic diagnostic
+  when they fall outside `{kl|nr|wr|an}`, and explicit `etm` / `ha` / `ets`
+  now report a semantic diagnostic when they are specified on jobs defined in
+  a start-condition context, while raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation remain unchanged.
 - JP1 event reception monitoring job `evwid` and `evipa` validation are
   aligned through application editor-feedback. Explicit `evwid` values on
   `evwj` / `revwj` now report a semantic diagnostic when they are not

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -234,8 +234,25 @@
       `evuid`, `evgid`, and `evpid` values, including boundary values
       `-1` and `9999999999`
 - [x] Run required code-change validation after implementation
-- [ ] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
+- [x] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
       delivered JP1 event reception monitoring numeric identifier slice and
+      select the next candidate using the same user-meaningful grouping rule
+- [x] Record the next grouped JP1 event reception monitoring timeout-control
+      slice in feature-local investigation docs with manual-backed scope,
+      affected seams, alternatives, and regression evidence
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      JP1 event reception monitoring timeout-control diagnostics
+- [x] Implement grouped JP1 event reception monitoring timeout-control
+      diagnostics only after approval
+- [x] Refactor `buildSyntaxDiagnostics.ts` within the approved scope so the
+      new timeout-control checks stay on the existing event-receiving rule-
+      array path and reuse the smallest shared start-condition helper seam
+- [x] Add focused regression evidence for valid and invalid explicit `etm`,
+      `ha`, and `ets` values, including start-condition-context violations
+- [x] Run required code-change validation after implementation
+- [ ] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
+      delivered JP1 event reception monitoring timeout-control slice and
       select the next candidate using the same user-meaningful grouping rule
 
 ## Notes
@@ -742,6 +759,58 @@
   `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
   `TASKS.md`, and `uc-provide-editor-feedback.md` now record the delivered
   event-receiving numeric identifier slice.
+- 2026-05-09: Remaining actionable JP1/AJS v13 gaps were re-checked after the
+  delivered event-receiving numeric-identifier slice. The next recommended
+  approval-gated candidate is grouped JP1 event reception monitoring
+  timeout-control diagnostics for `evwj` / `revwj`, because the remaining
+  user-visible gap still clusters around one job definition, one
+  event-receiving editor-feedback seam, and one existing start-condition
+  context helper.
+- 2026-05-09: Investigation confirmed from the JP1/AJS3 v13 event reception
+  monitoring definition that explicit `etm`, `ha`, and `ets` values share the
+  same timeout-control family and the same documented invalidation when the
+  job is defined in a start-condition context, while `fd` remains a separate
+  follow-up because the manual describes it as disabled-on-execution rather
+  than as an invalid explicit parameter.
+- 2026-05-09: The likely code refactor seam for the next slice is limited to
+  reusing the current decimal-range rule builder, the shared
+  `eventTimeoutActionDiagnosticRules`, and the existing
+  `hasStartConditionContext(...)` helper so the new checks stay on the current
+  `buildSyntaxDiagnostics.ts` `eventReceivingDiagnosticRules` path instead of
+  adding a separate validation branch.
+- 2026-05-09: `EVENT_RECEIVING_TIMEOUT_CONTROL_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
+  `TASKS.md`, and `uc-provide-editor-feedback.md` now record the pending
+  event-receiving timeout-control slice and its approval boundary.
+- 2026-05-09: Grouped JP1 event reception monitoring timeout-control
+  diagnostics now report explicit invalid `etm`, `ha`, and `ets` values on
+  `evwj` / `revwj`, and also report explicit `etm`, `ha`, or `ets` when the
+  job is defined in a start-condition context, through the existing
+  editor-feedback boundary. Raw parser output, domain wrapper values,
+  normalized parameters, unit-list projection, flow projection, and command
+  generation remain unchanged.
+- 2026-05-09: `buildSyntaxDiagnostics.ts` now keeps the new timeout-control
+  checks on the existing event-receiving rule-array path by reusing the
+  current decimal-range rule builder, shared `eventTimeoutActionDiagnosticRules`,
+  and `hasStartConditionContext(...)` helper instead of adding a separate
+  validation branch.
+- 2026-05-09: `EVENT_RECEIVING_TIMEOUT_CONTROL_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
+  `TASKS.md`, and `uc-provide-editor-feedback.md` now record the delivered
+  event-receiving timeout-control slice.
+- 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  event-receiving timeout-control diagnostics implementation.
+- 2026-05-09: `rtk pnpm test` completed with exit code 0 after grouped
+  event-receiving timeout-control diagnostics implementation; the VS Code
+  harness emitted the existing macOS `task_name_for_pid` codesign noise line.
+- 2026-05-09: `rtk pnpm run test:web` completed with exit code 0 after
+  grouped event-receiving timeout-control diagnostics implementation and
+  emitted the existing localhost dev-extension `package.nls.json` 404 noise.
+- 2026-05-09: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped event-receiving timeout-control diagnostics
+  implementation.
+- 2026-05-09: `rtk pnpm run lint:md` completed with exit code 0 after
+  grouped event-receiving timeout-control diagnostics implementation.
 - 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after grouped
   event-receiving string-filter diagnostics implementation.
 - 2026-05-09: `rtk pnpm test` completed with exit code 0 after grouped
@@ -798,21 +867,37 @@
 
 - Status: Approved
 - Approved at: 2026-05-09
-- Approved scope: grouped JP1 event reception monitoring numeric identifier
-  diagnostics for explicit `evuid`, `evgid`, and `evpid` combinations on
-  `evwj` / `revwj`, limited to the documented signed-decimal range
-  `-1..9999999999` through the existing editor-feedback boundary, plus the
-  smallest helper/rule-array refactor needed to keep the checks on the
-  current `buildSyntaxDiagnostics.ts` event-receiving path, while preserving
-  raw parser output, domain wrapper values, normalized parameters, unit-list
-  projection, flow projection, command generation, generated artifacts,
-  dependency versions, configuration, and `engines.vscode`.
+- Approved scope: grouped JP1 event reception monitoring timeout-control
+  diagnostics for explicit `etm`, `ha`, and `ets` values on `evwj` /
+  `revwj`, limited to the documented `etm` range `1..1440`, `ha` value set
+  `{y|n}`, `ets` value set `{kl|nr|wr|an}`, and explicit use of `etm`, `ha`,
+  or `ets` on jobs defined in a start-condition context through the existing
+  editor-feedback boundary, plus the smallest helper/rule-array refactor
+  needed to keep the checks on the current `buildSyntaxDiagnostics.ts`
+  event-receiving path, while preserving raw parser output, domain wrapper
+  values, normalized parameters, unit-list projection, flow projection,
+  command generation, generated artifacts, dependency versions,
+  configuration, and `engines.vscode`.
 
 Current implementation gate: approved implementation may proceed only within
-the grouped event-receiving numeric identifier scope recorded above.
+the grouped event-receiving timeout-control scope recorded above.
 
 ## Prior Approval Evidence
 
+- 2026-05-09: User replied "Approved. Proceed with implementation." after the
+  grouped JP1 event reception monitoring timeout-control diagnostics approval
+  request. Approved changes are limited to adding grouped application-level
+  semantic diagnostics for explicit `etm`, `ha`, and `ets` values on
+  `evwj` / `revwj`, including their documented invalidation in
+  start-condition context, through the existing editor-feedback boundary,
+  plus the smallest helper/rule-array refactor needed to keep the checks on
+  the current `buildSyntaxDiagnostics.ts` event-receiving path; preserving
+  raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation; adding focused
+  regression evidence; updating SDD tracking; and running validation. Parser
+  grammar, domain normalization, `fd` disabled-on-execution behavior,
+  generated artifacts, configuration, dependency versions,
+  compatible-ISAM/environment inputs, and `engines.vscode` are out of scope.
 - 2026-05-09: User replied "Approved. Proceed with implementation." after the
   grouped JP1 event reception monitoring numeric identifier diagnostics
   approval request. Approved changes are limited to adding grouped

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -84,6 +84,17 @@ rules in `docs/specs/README.md`, not in this file.
   numeric identifier parameters (`evuid`, `evgid`, and `evpid`) together,
   because they share one manual section, one editor-feedback seam, one
   signed-decimal validation shape, and one regression-test file.
+- After the delivered grouped JP1 event reception monitoring numeric-
+  identifier slice, the next recommended JP1/AJS v13 candidate should stay
+  within the same `evwj` / `revwj` job definition and group the remaining
+  timeout-control parameters (`etm`, `ha`, and `ets`), because they share one
+  manual section, one editor-feedback seam, one existing start-condition
+  context helper, and one existing `ets` helper seam.
+- After the delivered grouped JP1 event reception monitoring timeout-control
+  slice, the next recommended JP1/AJS v13 candidate should be re-selected
+  from the remaining partial or deferred gaps using the same user-meaningful
+  grouping rule, instead of broadening immediately into `fd` disabled-
+  behavior or compatible-ISAM-sensitive work.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -102,7 +113,7 @@ rules in `docs/specs/README.md`, not in this file.
 ## Next Priority Tasks
 
 1. Re-check the remaining partial or deferred JP1/AJS3 v13 parameter-alignment
-   gaps after the delivered JP1 event reception monitoring numeric identifier
+   gaps after the delivered JP1 event reception monitoring timeout-control
    slice and record the next approval-gated candidate.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
@@ -119,18 +130,17 @@ rules in `docs/specs/README.md`, not in this file.
 - Branch: `main`; a dedicated implementation branch was attempted but could
   not be created from the sandboxed session after approval
 - Objective: deliver the approved JP1/AJS v13 event-reception monitoring
-  numeric-identifier slice after the delivered string-filter diagnostics.
+  timeout-control slice after the delivered numeric-identifier diagnostics.
 - Status: implementation and validation are complete in the recorded scope.
-- Scope: grouped semantic diagnostics were added in
-  `buildSyntaxDiagnostics.ts` for explicit `evuid`, `evgid`, and `evpid`
-  values on `evwj` / `revwj`, plus only the smallest helper/rule-array
-  refactor needed to keep the checks on the current event-receiving
-  diagnostics path.
+- Scope: grouped semantic diagnostics were added for explicit `etm`, `ha`,
+  and `ets` values on `evwj` / `revwj`, including the documented
+  start-condition invalidation for those parameters, plus only the smallest
+  helper/rule-array refactor needed to keep the checks on the current
+  event-receiving diagnostics path.
 - Out of scope: parser grammar changes, domain wrapper normalization changes,
   unit-list projection changes, flow projection changes, command generation,
-  timeout-oriented event-receiving rules such as `etm`, `fd`, `ha`, and
-  `ets`, compatible-ISAM detection, generated artifacts, dependency changes,
-  configuration, and `engines.vscode`.
+  `fd` disabled-on-execution behavior, compatible-ISAM detection, generated
+  artifacts, dependency changes, configuration, and `engines.vscode`.
 - Impact summary: the implemented scope affected
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
   `src/test/suite/buildSyntaxDiagnostics.test.ts`, the parameter-alignment
@@ -138,12 +148,14 @@ rules in `docs/specs/README.md`, not in this file.
   valid `evwj` / `revwj` documents.
 - Risks and assumptions: the delivered slice stays diagnostic-only and does
   not change raw parser output, domain wrapper values, or projection
-  behavior. The helper refactor stayed limited to one signed-range parsing
-  seam inside the existing editor-feedback path.
+  behavior. The current manual wording is clear for `etm`, `ha`, and `ets`
+  invalidation in start-condition context. `fd` remains deferred because its
+  disabled-on-execution semantics are not the same as outright invalid
+  explicit parameter usage.
 - Alternatives considered: returning to HTTP Connection `eu` remains smaller
-  but less user-meaningful; broadening immediately into timeout-oriented
-  `evwj` rules or compatible-ISAM work would mix different validation shapes
-  and introduce new context seams.
+  but less user-meaningful; broadening immediately into `fd` or
+  compatible-ISAM work would mix a different semantic shape or a new runtime
+  context seam into the same slice.
 
 ## Build/Test Performance SDD
 
@@ -172,11 +184,11 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped JP1 event reception monitoring numeric identifier
-  diagnostics are implemented and validated for explicit `evuid`, `evgid`,
-  and `evpid`, while the previously delivered event-receiving string-filter
-  and execution-interval start-condition diagnostics remain complete with
-  compatible-ISAM still deferred.
+  slice: grouped JP1 event reception monitoring timeout-control diagnostics
+  are implemented and validated for explicit `etm`, `ha`, and `ets` values on
+  `evwj` / `revwj`, while the previously delivered event-receiving numeric-
+  identifier and string-filter diagnostics remain complete and compatible-
+  ISAM-sensitive work still deferred.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -1064,6 +1064,18 @@ const eventSendingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
 
 const eventReceivingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
   buildExplicitDecimalRangeRule(
+    "etm",
+    1,
+    1440,
+    "Event timeout period (etm) must be between 1 and 1440.",
+  ),
+  buildExplicitAllowedValuesRule(
+    "ha",
+    new Set(["y", "n"]),
+    "Hold attribute (ha) must be y or n.",
+  ),
+  ...eventTimeoutActionDiagnosticRules,
+  buildExplicitDecimalRangeRule(
     "evuid",
     -1,
     9999999999,
@@ -1409,7 +1421,42 @@ const buildEventReceivingDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
   findUnitsByTypes(rootUnits, eventReceivingDiagnosticTargetTypes).flatMap(
-    (unit) => collectRuleDiagnostics(unit, eventReceivingDiagnosticRules),
+    (unit) => {
+      const diagnostics = collectRuleDiagnostics(
+        unit,
+        eventReceivingDiagnosticRules,
+      );
+
+      if (!hasStartConditionContext(unit)) {
+        return diagnostics;
+      }
+
+      const invalidStartConditionParameters = [
+        {
+          parameter: findParameter(unit, "etm"),
+          message:
+            "Event timeout period (etm) cannot be specified for jobs defined as start conditions.",
+        },
+        {
+          parameter: findParameter(unit, "ha"),
+          message:
+            "Hold attribute (ha) cannot be specified for jobs defined as start conditions.",
+        },
+        {
+          parameter: findParameter(unit, "ets"),
+          message:
+            "Event timeout action (ets) cannot be specified for jobs defined as start conditions.",
+        },
+      ];
+
+      invalidStartConditionParameters.forEach(({ parameter, message }) => {
+        if (parameter) {
+          diagnostics.push(buildDiagnostic(parameter, message));
+        }
+      });
+
+      return diagnostics;
+    },
   );
 
 export const buildSyntaxDiagnostics = (

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -2147,6 +2147,135 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("does not report event receiving timeout-control diagnostics for valid explicit values outside start-condition context", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=wait1,evwj,+0+0;",
+        "  el=wait2,revwj,+160+0;",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    etm=1;",
+        "    ha=y;",
+        "    ets=kl;",
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    etm=1440;",
+        "    ha=n;",
+        "    ets=an;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(diagnostics, []);
+  });
+
+  test("reports event receiving timeout-control diagnostics for explicit invalid values and start-condition usage", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=start-condition,rc,+0+0;",
+        "  el=wait1,evwj,+160+0;",
+        "  el=wait2,revwj,+320+0;",
+        "  el=wait3,evwj,+480+0;",
+        "  el=wait4,revwj,+640+0;",
+        "  unit=start-condition,,jp1admin,;",
+        "  {",
+        "    ty=rc;",
+        "  }",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    etm=0;",
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    ha=maybe;",
+        "  }",
+        "  unit=wait3,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    ets=xx;",
+        "  }",
+        "  unit=wait4,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    etm=10;",
+        "    ha=y;",
+        "    ets=wr;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.strictEqual(diagnostics.length, 6);
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 14,
+          column: 4,
+          length: 5,
+          message: "Event timeout period (etm) must be between 1 and 1440.",
+        },
+        {
+          line: 19,
+          column: 4,
+          length: 5,
+          message: "Hold attribute (ha) must be y or n.",
+        },
+        {
+          line: 24,
+          column: 4,
+          length: 5,
+          message:
+            "Event timeout action (ets) must be one of kl, nr, wr, or an.",
+        },
+        {
+          line: 29,
+          column: 4,
+          length: 5,
+          message:
+            "Event timeout period (etm) cannot be specified for jobs defined as start conditions.",
+        },
+        {
+          line: 30,
+          column: 4,
+          length: 5,
+          message:
+            "Hold attribute (ha) cannot be specified for jobs defined as start conditions.",
+        },
+        {
+          line: 31,
+          column: 4,
+          length: 5,
+          message:
+            "Event timeout action (ets) cannot be specified for jobs defined as start conditions.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error", "error", "error", "error"],
+    );
+  });
+
   test("reports event-host diagnostics for explicit out-of-range evhst values", () => {
     const oversizedHost = "a".repeat(256);
     const diagnostics = buildSyntaxDiagnostics(


### PR DESCRIPTION
## Summary
- add JP1 event reception monitoring diagnostics for explicit invalid \, \, and \ values
- report explicit \, \, and \ on start-condition event-receiving jobs without changing parser or projection behavior
- sync the SDD specs, tasks, coverage matrix, and editor-feedback use case for the delivered slice

## Validation
- rtk pnpm run qlty
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
- rtk pnpm run lint:md