### PR TITLE
Align shared wait-job fd diagnostics

### DIFF
--- a/docs/requirements/use-cases/uc-provide-editor-feedback.md
+++ b/docs/requirements/use-cases/uc-provide-editor-feedback.md
@@ -255,6 +255,18 @@ Scenario: Execution-interval control end timing must preserve documented
   Then application-level diagnostic DTOs include the semantic parameter violation
   And raw parser output remains available to downstream consumers
 
+Scenario: Shared wait-job execution time must preserve documented range and
+  start-condition behavior
+  Given a syntactically valid JP1/AJS document with a file monitoring job,
+    execution-interval control job, or JP1 event reception monitoring job
+  And explicit `fd` is outside the JP1/AJS3 v13 range `1..1440`
+  Or explicit `fd` is specified on a job defined in a start-condition context
+    where the JP1/AJS3 v13 manual says the parameter is disabled when the job
+    executes
+  When editor feedback is requested
+  Then application-level diagnostic DTOs include the semantic parameter violation
+  And raw parser output remains available to downstream consumers
+
 Scenario: Shared filename-like rules stay explicit across parameter families
   Given a syntactically valid JP1/AJS document with a parameter family that
     uses documented filename-like or host-like values
@@ -297,9 +309,9 @@ Scenario: Shared string diagnostics preserve documented macro-variable allowance
 
 - desktop and web extension entry points continue to share the same
   application logic for diagnostics and hover decisions
-- compatible-ISAM-specific semantic diagnostics require an explicit host or
-  workspace configuration input because the JP1/AJS definition file alone does
-  not identify the database mode
+- compatible-ISAM-specific semantic diagnostics are out of scope for this
+  repository because compatible-ISAM is limited to legacy migration-mode
+  environments that this extension will not model or support explicitly
 
 ## Risks Or Edge Cases
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_TIMEOUT_CONTROL_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EVENT_RECEIVING_TIMEOUT_CONTROL_ALIGNMENT.md
@@ -119,7 +119,9 @@ control gaps all sit on the same `evwj` / `revwj` diagnostic seam.
 
 ## Remaining Gap
 
-- `fd` range or disabled-on-execution behavior, compatible-ISAM-sensitive
-  interpretation, and the broader wait-condition parameter family remain
-  separate future slices because they introduce different validation shapes
-  or new runtime-context seams.
+- `fd` range or disabled-on-execution behavior and the broader wait-condition
+  parameter family remain separate future slices because they introduce
+  different validation shapes than this delivered timeout-control slice.
+  Compatible-ISAM-sensitive interpretation is not planned for this repository
+  because that mode is limited to legacy migration environments outside the
+  supported scope.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md
@@ -61,9 +61,9 @@ restrictions that are not yet modeled in editor feedback.
   editor-feedback boundary for `tmwj` / `rtmwj`.
 - Explicit `etn=y` now reports a semantic diagnostic when a `tmwj` / `rtmwj`
   unit is not defined in a start-condition context.
-- Compatible-ISAM-specific `etn` restrictions remain deferred because the
-  current editor-feedback boundary has no host-configuration input that can
-  identify database mode from the JP1/AJS definition alone.
+- Compatible-ISAM-specific `etn` restrictions are not planned for this
+  repository because compatible-ISAM applies only to legacy migration-mode
+  environments that this extension will not model explicitly.
 - Broader wait-job default reconciliation also remains outside the smallest
   meaningful validation slice.
 
@@ -107,6 +107,6 @@ restrictions that are not yet modeled in editor feedback.
   backlog grouped by one job definition instead of by environment-specific
   file-path behavior.
 - Model compatible-ISAM as a hard-coded global assumption:
-  rejected because the current repository has no explicit source of truth for
-  database mode, and inferring one inside editor feedback would hide a new
-  environment dependency.
+  rejected because compatible-ISAM is a legacy migration-only mode that this
+  repository will not support explicitly, and inferring it inside editor
+  feedback would add an unsupported environment dependency.

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -140,8 +140,9 @@ coverage.
   `parameterFactory.test.ts` for existing domain default seams and
   `buildUnitListRemainingGroups.test.ts` for group 13 projection
 - Remaining gap:
-  none for the currently modeled file-monitoring parameters in this feature
-  scope
+  none for the currently modeled `flwf`, `flwc`, `flwi`, `flco`, and `ets`
+  family in this feature scope. Shared wait-job `fd` execution-time
+  semantics are tracked separately in `WAIT_JOB_EXECUTION_TIME_ALIGNMENT.md`
 
 ### Execution-Interval Control Job Defaults
 
@@ -161,8 +162,10 @@ coverage.
   aligned through editor-feedback, explicit `tmitv` range diagnostics and
   explicit `etn` allowed-value diagnostics are aligned through
   editor-feedback, and explicit `etn=y` start-condition diagnostics are now
-  aligned through editor-feedback. Compatible-ISAM-specific restrictions and
-  broader wait-job default reconciliation remain deferred
+  aligned through editor-feedback. Shared wait-job `fd` execution-time
+  semantics are tracked separately in `WAIT_JOB_EXECUTION_TIME_ALIGNMENT.md`.
+  Compatible-ISAM-specific restrictions are not planned for this repository.
+  Broader wait-job default reconciliation remains deferred
 
 ### Event Reception Monitoring Job Search Scope
 
@@ -221,9 +224,10 @@ coverage.
   `buildSyntaxDiagnostics.test.ts` and existing raw projection coverage in
   `buildUnitListView.test.ts`
 - Remaining gap:
-  `fd` disabled-on-execution semantics, compatible-ISAM-sensitive
-  interpretation, and the broader wait-condition parameter family remain
-  separate future slices
+  shared wait-job `fd` execution-time semantics are now tracked separately in
+  `WAIT_JOB_EXECUTION_TIME_ALIGNMENT.md`. Compatible-ISAM-sensitive
+  interpretation is not planned for this repository, and the broader
+  wait-condition parameter family remains a separate future slice
 
 ## Boundary Decisions
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -190,11 +190,24 @@ JP1/AJS3 version 13 reference documents.
   start-condition context, while raw parser output, domain wrapper values,
   normalized parameters, unit-list projection, flow projection, and command
   generation remain unchanged.
-- Execution-interval control compatible-ISAM restrictions remain approval-
-  sensitive because the current repository has no explicit runtime input that
-  identifies database mode for editor-feedback decisions. Any future slice
-  should introduce that environment/configuration seam deliberately instead of
-  inferring compatible-ISAM mode from JP1/AJS definition text alone.
+- Execution-interval control compatible-ISAM restrictions are not planned for
+  this repository because compatible-ISAM is limited to legacy migration-mode
+  environments that the extension will not model or support explicitly.
+- Shared wait-job execution-time diagnostics for `fd` are approval-sensitive
+  because file monitoring, execution-interval control, and JP1 event
+  reception monitoring jobs all expose the same parameter while current
+  behavior preserves explicit raw values without editor feedback. A focused
+  follow-up should stay inside application editor-feedback, report explicit
+  `fd` values outside the documented JP1/AJS3 v13 range `1..1440`, report
+  explicit `fd` on jobs defined in a start-condition context where the manual
+  says the parameter is disabled when the job executes, reuse the existing
+  start-condition helper and only the smallest shared helper/rule-array
+  refactor needed to keep the checks on the current wait-like diagnostic
+  paths, and preserve raw parser output, domain wrapper values, normalized
+  parameters, unit-list projection, flow projection, and command generation.
+  Broader wait-condition family alignment remains separate approval-sensitive
+  work. Compatible-ISAM-sensitive restrictions are not planned because that
+  mode is outside this repository's supported environment scope.
 - Job end-judgment `jd` / `abr` diagnostics are approval-sensitive because
   existing behavior preserves explicit invalid combinations as raw parsed
   values without editor feedback. A diagnostic slice must preserve raw parser

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -251,9 +251,25 @@
 - [x] Add focused regression evidence for valid and invalid explicit `etm`,
       `ha`, and `ets` values, including start-condition-context violations
 - [x] Run required code-change validation after implementation
-- [ ] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
+- [x] Re-check the remaining partial or deferred JP1/AJS v13 gaps after the
       delivered JP1 event reception monitoring timeout-control slice and
       select the next candidate using the same user-meaningful grouping rule
+- [x] Record the next grouped shared wait-job execution-time (`fd`) slice in
+      feature-local investigation docs with manual-backed scope, affected
+      seams, alternatives, and regression evidence
+- [x] Record human approval before changing editor-feedback diagnostics,
+      runtime code, tests, generated artifacts, or configuration for grouped
+      shared wait-job `fd` diagnostics
+- [x] Implement grouped shared wait-job `fd` diagnostics only after approval
+- [x] Refactor `buildSyntaxDiagnostics.ts` within the approved scope so
+      shared `fd` checks stay on the existing file-monitoring,
+      execution-interval, and event-receiving diagnostic paths through the
+      smallest shared helper seam
+- [x] Add focused regression evidence for valid explicit `fd`, explicit
+      out-of-range `fd`, and explicit `fd` usage in start-condition context
+      across file monitoring, execution-interval control, and JP1 event
+      reception monitoring jobs
+- [x] Run required code-change validation after implementation
 
 ## Notes
 
@@ -690,13 +706,13 @@
   Raw parser output, domain wrapper values, normalized parameters, unit-list
   projection, flow projection, and command generation remain unchanged.
 - 2026-05-09: Implementation confirmed that the current editor-feedback
-  boundary has no host or workspace input that identifies compatible-ISAM
-  mode, so that environment-specific restriction remains deferred instead of
-  being guessed from JP1/AJS definition text.
+  boundary does not model compatible-ISAM mode, and the repository now treats
+  compatible-ISAM-specific restrictions as unsupported because that mode is
+  limited to legacy migration environments outside the target scope.
 - 2026-05-09: `EXECUTION_INTERVAL_CONTROL_JOB_ALIGNMENT.md`,
   `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
   `TASKS.md`, and `uc-provide-editor-feedback.md` now record the delivered
-  start-condition slice and the deferred compatible-ISAM note.
+  start-condition slice and the unsupported compatible-ISAM note.
 - 2026-05-09: Remaining actionable JP1/AJS v13 gaps were re-checked after the
   delivered execution-interval control start-condition slice. The next
   recommended approval-gated candidate is grouped JP1 event reception
@@ -798,6 +814,45 @@
   `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
   `TASKS.md`, and `uc-provide-editor-feedback.md` now record the delivered
   event-receiving timeout-control slice.
+- 2026-05-09: Remaining actionable JP1/AJS v13 gaps were re-checked after the
+  delivered JP1 event reception monitoring timeout-control slice. The next
+  recommended approval-gated candidate is grouped shared wait-job
+  execution-time (`fd`) diagnostics across `flwj` / `rflwj`,
+  `tmwj` / `rtmwj`, and `evwj` / `revwj`, because the remaining user-visible
+  gap now shares one parameter name, one numeric-range rule, one documented
+  start-condition-disabled rule, and existing wait-like diagnostic seams
+  inside `buildSyntaxDiagnostics.ts`.
+- 2026-05-09: Investigation confirmed from the JP1/AJS3 v13 file monitoring,
+  execution-interval control, and JP1 event reception monitoring definitions
+  that explicit `fd` accepts decimal values in the range `1..1440`, and when
+  the job is defined as a start condition the parameter is disabled when the
+  job executes.
+- 2026-05-09: The likely code refactor seam for the next slice is limited to
+  reusing the current decimal-range rule builder and
+  `hasStartConditionContext(...)` helper, plus only the smallest shared
+  helper or rule-array extraction needed to keep `fd` checks on the current
+  file-monitoring, execution-interval, and event-receiving diagnostics
+  paths instead of adding a separate validation branch.
+- 2026-05-09: `WAIT_JOB_EXECUTION_TIME_ALIGNMENT.md`, `SPECS.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `docs/specs/plans.md`,
+  `docs/specs/roadmap.md`, `TASKS.md`, and
+  `uc-provide-editor-feedback.md` now record the pending shared wait-job
+  `fd` slice and its approval boundary.
+- 2026-05-09: Grouped shared wait-job execution-time (`fd`) diagnostics now
+  report explicit out-of-range `fd` values and explicit `fd` usage in
+  start-condition context on `flwj` / `rflwj`, `tmwj` / `rtmwj`, and
+  `evwj` / `revwj` through the existing editor-feedback boundary. Raw parser
+  output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, and command generation remain unchanged.
+- 2026-05-09: `buildSyntaxDiagnostics.ts` now keeps the shared `fd` checks on
+  the existing file-monitoring, execution-interval, and event-receiving
+  diagnostic paths by reusing the current decimal-range rule builder and
+  sibling start-condition helper, plus only the smallest shared helper
+  extraction needed for start-condition-disabled parameters.
+- 2026-05-09: `WAIT_JOB_EXECUTION_TIME_ALIGNMENT.md`, `SPECS.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `docs/specs/plans.md`, `TASKS.md`, and
+  `uc-provide-editor-feedback.md` now record the delivered shared wait-job
+  `fd` slice and the unsupported compatible-ISAM policy.
 - 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after grouped
   event-receiving timeout-control diagnostics implementation.
 - 2026-05-09: `rtk pnpm test` completed with exit code 0 after grouped
@@ -867,23 +922,34 @@
 
 - Status: Approved
 - Approved at: 2026-05-09
-- Approved scope: grouped JP1 event reception monitoring timeout-control
-  diagnostics for explicit `etm`, `ha`, and `ets` values on `evwj` /
-  `revwj`, limited to the documented `etm` range `1..1440`, `ha` value set
-  `{y|n}`, `ets` value set `{kl|nr|wr|an}`, and explicit use of `etm`, `ha`,
-  or `ets` on jobs defined in a start-condition context through the existing
-  editor-feedback boundary, plus the smallest helper/rule-array refactor
-  needed to keep the checks on the current `buildSyntaxDiagnostics.ts`
-  event-receiving path, while preserving raw parser output, domain wrapper
-  values, normalized parameters, unit-list projection, flow projection,
-  command generation, generated artifacts, dependency versions,
-  configuration, and `engines.vscode`.
+- Approved scope: grouped shared wait-job execution-time (`fd`) diagnostics
+  for explicit `fd` values on `flwj` / `rflwj`, `tmwj` / `rtmwj`, and
+  `evwj` / `revwj`, limited to the documented `fd` range `1..1440` and the
+  documented start-condition-disabled behavior for explicit `fd` through the
+  existing editor-feedback boundary, plus the smallest helper/rule-array
+  refactor needed to keep the checks on the current file-monitoring,
+  execution-interval, and event-receiving diagnostic paths, while preserving
+  raw parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, command generation, generated artifacts,
+  dependency versions, configuration, and `engines.vscode`.
 
-Current implementation gate: approved implementation may proceed only within
-the grouped event-receiving timeout-control scope recorded above.
+Current implementation gate: the grouped shared wait-job `fd` scope recorded
+above has been approved and implemented.
 
 ## Prior Approval Evidence
 
+- 2026-05-09: User replied "Approved. Proceed with implementation." after the
+  grouped shared wait-job execution-time (`fd`) diagnostics approval request.
+  Approved changes were limited to adding grouped application-level semantic
+  diagnostics for explicit `fd` values on `flwj` / `rflwj`, `tmwj` /
+  `rtmwj`, and `evwj` / `revwj`, limited to the documented range `1..1440`
+  and documented start-condition-disabled behavior through the existing
+  editor-feedback boundary, plus the smallest helper/rule-array refactor
+  needed to keep the checks on the current file-monitoring,
+  execution-interval, and event-receiving diagnostic paths; preserving raw
+  parser output, domain wrapper values, normalized parameters, unit-list
+  projection, flow projection, command generation, generated artifacts,
+  dependency versions, configuration, and `engines.vscode`.
 - 2026-05-09: User replied "Approved. Proceed with implementation." after the
   grouped JP1 event reception monitoring timeout-control diagnostics approval
   request. Approved changes are limited to adding grouped application-level
@@ -1259,6 +1325,16 @@ the grouped event-receiving timeout-control scope recorded above.
 
 ## Validation
 
+- 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after grouped
+  shared wait-job `fd` diagnostics implementation
+- 2026-05-09: `rtk pnpm test` completed with exit code 0 after grouped
+  shared wait-job `fd` diagnostics implementation; the VS Code harness
+  emitted the existing macOS `task_name_for_pid` codesign noise line
+- 2026-05-09: `rtk pnpm run test:web` completed with exit code 0 after
+  grouped shared wait-job `fd` diagnostics implementation and emitted the
+  existing localhost dev-extension `package.nls.json` 404 noise
+- 2026-05-09: `rtk pnpm run build` completed with existing webpack asset-size
+  warnings after grouped shared wait-job `fd` diagnostics implementation
 - 2026-05-09: `rtk pnpm run qlty` completed with exit code 0 after grouped
   execution-interval control start-condition diagnostics implementation
 - 2026-05-09: `rtk pnpm test` completed with exit code 0 after grouped

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/WAIT_JOB_EXECUTION_TIME_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/WAIT_JOB_EXECUTION_TIME_ALIGNMENT.md
@@ -1,0 +1,134 @@
+# Wait-Job Execution-Time Alignment
+
+## Purpose
+
+Record the next JP1/AJS3 version 13 parameter-alignment candidate for the
+shared execution-time parameter `fd=time-required-for-execution` across the
+currently modeled wait-like job families.
+
+This keeps the backlog grouped at a user-meaningful size: users configuring
+file monitoring jobs, execution-interval control jobs, and JP1 event
+reception monitoring jobs all see the same `fd` parameter name and the same
+documented range and start-condition-disabled behavior.
+
+## Normative References
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual sections:
+  - Command Reference, `5.2.10 File monitoring job definition`
+  - Command Reference, `5.2.16 Execution-interval control job definition`
+  - Command Reference, `5.2.9 Job definition for monitoring JP1 event reception`
+- Source URLs:
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213b1920e/AJSO0220.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213b1920e/AJSO0226.HTM>
+  - <https://itpfdoc.hitachi.co.jp/manuals/3021/30213L4920e/AJSO0224.HTM>
+
+## Slice Boundary
+
+- Application seam:
+  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`
+- Existing consumers:
+  `src/extension/diagnostics/registerDiagnostics.ts` plus the currently
+  modeled wait-like unit wrappers `Flwj` / `Rflwj`, `Tmwj` / `Rtmwj`, and
+  `Evwj` / `Revwj`
+- Regression evidence:
+  `src/test/suite/buildSyntaxDiagnostics.test.ts`
+- Preservation evidence:
+  existing raw projection coverage in
+  `src/test/suite/buildUnitListRemainingGroups.test.ts` and
+  `src/test/suite/buildUnitListView.test.ts`
+- Out of scope:
+  parser grammar changes, domain wrapper normalization changes, unit-list
+  projection changes, flow projection changes, command generation,
+  generated artifacts, dependency changes, configuration changes,
+  compatible-ISAM or host-environment inputs, broader wait-condition
+  parameters such as `mm`, `nmg`, `eun`, `ega`, `uem`, and `jpoif`, and
+  `engines.vscode`
+
+## Investigation Notes
+
+- The current repository models `fd` on multiple job families, but the three
+  wait-like diagnostic paths already active in `buildSyntaxDiagnostics.ts`
+  are `flwj` / `rflwj`, `tmwj` / `rtmwj`, and `evwj` / `revwj`.
+- The JP1/AJS3 v13 manual text is materially the same across those three job
+  definitions:
+  - explicit `fd` accepts decimal values in the range `1..1440`;
+  - when the job is defined as a start condition, `fd` is disabled when the
+    job executes.
+- `buildSyntaxDiagnostics.ts` already has the smallest shared seams needed
+  for this slice:
+  - `buildExplicitDecimalRangeRule(...)` already covers the `1..1440`
+    numeric-range shape;
+  - `hasStartConditionContext(...)` already detects the sibling
+    start-condition context used by the recent execution-interval and
+    event-receiving slices;
+  - the file-monitoring, execution-interval, and event-receiving rule arrays
+    already keep these families isolated without needing parser or domain
+    changes.
+- This candidate is preferable to jumping straight to compatible-ISAM rules,
+  because compatible-ISAM is a legacy migration-only mode that this
+  repository will not model explicitly.
+- This candidate is preferable to broadening immediately into `mm`, `nmg`,
+  `eun`, `ega`, `uem`, or `jpoif`, because `fd` shares one validation shape
+  and one start-condition rule across the currently modeled wait-like job
+  families.
+
+## Delivered Alignment
+
+- Keep ownership in the shared application editor-feedback boundary.
+- Add grouped semantic diagnostics for explicit invalid `fd` values on
+  `flwj` / `rflwj`, `tmwj` / `rtmwj`, and `evwj` / `revwj`.
+- Add grouped semantic diagnostics for explicit `fd` values when those units
+  are defined in a start-condition context, because the manual says the
+  parameter is disabled when the job executes.
+- Reuse existing shared explicit-value and sibling-context helpers where
+  practical, extracting only the smallest helper or rule-array refactor
+  needed to keep the checks on the current file-monitoring,
+  execution-interval, and event-receiving diagnostics paths.
+- Preserve raw parser output, domain wrapper values, normalized parameters,
+  unit-list projection, flow projection, and command generation.
+
+## Delivered Behavior
+
+- Editor feedback now reports semantic diagnostics when explicit `fd` values
+  on `flwj` / `rflwj`, `tmwj` / `rtmwj`, and `evwj` / `revwj` fall outside
+  the documented JP1/AJS3 v13 range `1..1440`.
+- Editor feedback now reports semantic diagnostics when explicit `fd` is
+  specified on those wait-like job families in a start-condition context.
+- The implementation reuses the existing decimal-range rule builder and
+  sibling start-condition helper, with only the smallest shared helper
+  extraction needed to keep the checks on the current file-monitoring,
+  execution-interval, and event-receiving diagnostic paths.
+
+## Affected Backlog
+
+- File monitoring jobs:
+  shared `fd` execution-time diagnostics outside the already aligned
+  `flwf`, `flwc`, `flwi`, `flco`, and `ets` family
+- Execution-interval control jobs:
+  shared `fd` execution-time diagnostics outside the already aligned
+  `tmitv`, `etn`, and `ets` family
+- JP1 event reception monitoring jobs:
+  shared `fd` execution-time diagnostics outside the already aligned
+  search-scope, string-filter, numeric-identifier, and timeout-control
+  families
+
+## Alternatives
+
+- Re-open compatible-ISAM restrictions first:
+  rejected because compatible-ISAM is a legacy migration-only mode that this
+  repository will not support explicitly.
+- Broaden immediately to the full wait-condition family:
+  rejected for now because `mm`, `nmg`, `eun`, `ega`, `uem`, and `jpoif`
+  add additional value-shape, multiplicity, or environment-sensitive rules.
+- Keep `fd` raw because the parameter is disabled rather than rejected:
+  rejected for now because the same editor-feedback boundary already surfaces
+  documented context-sensitive parameter misuse for nearby wait-like job
+  families, and the manual-backed disabled behavior is still user-visible.
+
+## Remaining Gap
+
+- The broader shared wait-condition parameter family remains a separate future
+  slice. Compatible-ISAM-sensitive restrictions are not planned because that
+  mode is limited to legacy migration environments outside this repository's
+  support policy.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -71,8 +71,8 @@ rules in `docs/specs/README.md`, not in this file.
 - After the delivered grouped execution-interval control start-condition
   diagnostics slice, the next recommended JP1/AJS v13 candidate should again
   be re-selected from the remaining partial or deferred gaps using the same
-  user-meaningful grouping rule, rather than broadening immediately into a
-  new environment-configuration seam for compatible-ISAM.
+  user-meaningful grouping rule, rather than broadening immediately into
+  unsupported compatible-ISAM-specific behavior.
 - After re-checking the remaining actionable gaps again, the next recommended
   JP1/AJS v13 candidate should move to the remaining event-reception
   monitoring filter family and group the still-raw string-filter parameters
@@ -91,10 +91,13 @@ rules in `docs/specs/README.md`, not in this file.
   manual section, one editor-feedback seam, one existing start-condition
   context helper, and one existing `ets` helper seam.
 - After the delivered grouped JP1 event reception monitoring timeout-control
-  slice, the next recommended JP1/AJS v13 candidate should be re-selected
-  from the remaining partial or deferred gaps using the same user-meaningful
-  grouping rule, instead of broadening immediately into `fd` disabled-
-  behavior or compatible-ISAM-sensitive work.
+  slice, the next recommended JP1/AJS v13 candidate should move to the
+  shared wait-job execution-time (`fd`) family across file monitoring,
+  execution-interval control, and JP1 event reception monitoring jobs,
+  because those families now share one parameter name, one numeric-range
+  rule, one start-condition-disabled rule, and existing diagnostic seams in
+  `buildSyntaxDiagnostics.ts`, while still avoiding unsupported
+  compatible-ISAM-specific behavior.
 - JP1/AJS v13 parameter alignment remains the active implementation priority
   until the documented diagnostics, validation, and category-level coverage
   gaps are either completed or explicitly re-scoped.
@@ -113,7 +116,7 @@ rules in `docs/specs/README.md`, not in this file.
 ## Next Priority Tasks
 
 1. Re-check the remaining partial or deferred JP1/AJS3 v13 parameter-alignment
-   gaps after the delivered JP1 event reception monitoring timeout-control
+   gaps after the delivered grouped shared wait-job execution-time (`fd`)
    slice and record the next approval-gated candidate.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
@@ -129,33 +132,35 @@ rules in `docs/specs/README.md`, not in this file.
 
 - Branch: `main`; a dedicated implementation branch was attempted but could
   not be created from the sandboxed session after approval
-- Objective: deliver the approved JP1/AJS v13 event-reception monitoring
-  timeout-control slice after the delivered numeric-identifier diagnostics.
+- Objective: deliver the approved grouped shared wait-job execution-time
+  (`fd`) slice after the delivered JP1 event reception monitoring
+  timeout-control diagnostics.
 - Status: implementation and validation are complete in the recorded scope.
-- Scope: grouped semantic diagnostics were added for explicit `etm`, `ha`,
-  and `ets` values on `evwj` / `revwj`, including the documented
-  start-condition invalidation for those parameters, plus only the smallest
-  helper/rule-array refactor needed to keep the checks on the current
-  event-receiving diagnostics path.
+- Scope: grouped semantic diagnostics were added for explicit `fd` values on
+  `flwj` / `rflwj`, `tmwj` / `rtmwj`, and `evwj` / `revwj`, limited to the
+  documented range `1..1440` and the documented start-condition-disabled
+  behavior, plus only the smallest helper/rule-array refactor needed to keep
+  the checks on the current file-monitoring, execution-interval, and
+  event-receiving diagnostics paths.
 - Out of scope: parser grammar changes, domain wrapper normalization changes,
   unit-list projection changes, flow projection changes, command generation,
-  `fd` disabled-on-execution behavior, compatible-ISAM detection, generated
+  broader wait-condition parameters, compatible-ISAM detection, generated
   artifacts, dependency changes, configuration, and `engines.vscode`.
 - Impact summary: the implemented scope affected
   `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
   `src/test/suite/buildSyntaxDiagnostics.test.ts`, the parameter-alignment
   feature docs, and the editor-feedback behavior contract for syntactically
-  valid `evwj` / `revwj` documents.
-- Risks and assumptions: the delivered slice stays diagnostic-only and does
-  not change raw parser output, domain wrapper values, or projection
-  behavior. The current manual wording is clear for `etm`, `ha`, and `ets`
-  invalidation in start-condition context. `fd` remains deferred because its
-  disabled-on-execution semantics are not the same as outright invalid
-  explicit parameter usage.
-- Alternatives considered: returning to HTTP Connection `eu` remains smaller
-  but less user-meaningful; broadening immediately into `fd` or
-  compatible-ISAM work would mix a different semantic shape or a new runtime
-  context seam into the same slice.
+  valid wait-like job documents that specify `fd`.
+- Risks and assumptions: this slice is intended to stay diagnostic-only and
+  must not change raw parser output, domain wrapper values, or projection
+  behavior. The current manual wording is consistent for `fd` across the
+  three targeted job definitions. Compatible-ISAM-sensitive restrictions are
+  intentionally unsupported because compatible-ISAM is limited to legacy
+  migration-mode environments outside this repository's target scope.
+- Alternatives considered: returning to smaller default-only cleanup remains
+  less user-meaningful; broadening immediately into the full wait-condition
+  family would enlarge the seam before the shared `fd` rule is closed, and
+  compatible-ISAM-sensitive work is intentionally unsupported.
 
 ## Build/Test Performance SDD
 
@@ -184,11 +189,12 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped JP1 event reception monitoring timeout-control diagnostics
-  are implemented and validated for explicit `etm`, `ha`, and `ets` values on
-  `evwj` / `revwj`, while the previously delivered event-receiving numeric-
-  identifier and string-filter diagnostics remain complete and compatible-
-  ISAM-sensitive work still deferred.
+  slice: grouped shared wait-job execution-time (`fd`) diagnostics are
+  implemented and validated for explicit `fd` values on
+  `flwj` / `rflwj`, `tmwj` / `rtmwj`, and `evwj` / `revwj`, while the
+  previously delivered event-receiving timeout-control, numeric-identifier,
+  and string-filter diagnostics remain complete and compatible-ISAM-sensitive
+  work is intentionally unsupported.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -14,7 +14,6 @@
 
 1. Re-base parameter interpretation on JP1/Automatic Job Management System 3
    version 13 Definition File Reference.
-
    - Start from the documented audit of current shared parameter-semantics
      seams.
    - Add traceability from JP1/AJS v13 manual sections to supported parameter
@@ -62,7 +61,6 @@
      alignment slices.
 
 2. Keep read-only JP1/AJS WebAPI import in beta while feedback is limited.
-
    - Keep transport, authentication, and endpoint details in infrastructure.
    - Keep generated OpenAPI mocks and stubs reproducible from repository-local
      contracts.
@@ -72,7 +70,6 @@
      environment and enough user feedback are recorded.
 
 3. Maintain normalized-model convergence.
-
    - Prefer stable `AjsDocument` / `AjsUnit` contracts for application-facing
      behavior.
    - Keep unit-local JP1/AJS behavior on wrappers when it is not reused across
@@ -80,7 +77,6 @@
    - Promote only cross-consumer semantics into normalized helpers.
 
 4. Introduce stricter parser/infrastructure boundaries.
-
    - Define an application-facing parser or document-loading port.
    - Move concrete parser orchestration behind an adapter boundary when
      practical.
@@ -89,7 +85,6 @@
    - Preserve current desktop and web extension behavior while migrating.
 
 5. Use Qlty findings as architectural feedback.
-
    - Track active implementation under
      `docs/specs/features/qlty-driven-architecture-refactoring/`.
    - Phase 0 removes repository noise before structural changes.

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -51,6 +51,13 @@
      through editor-feedback while preserving raw parameter data.
    - Continue with documented deferred diagnostics and range-validation gaps
      only as focused, approval-gated slices.
+   - After the delivered grouped JP1 event reception monitoring timeout-control
+     slice, the next recommended JP1/AJS v13 candidate should group the shared
+     wait-job execution-time parameter `fd` across file monitoring,
+     execution-interval control, and JP1 event reception monitoring jobs,
+     because those families now share one parameter name, one `1..1440`
+     numeric-range rule, one documented start-condition-disabled rule, and
+     existing wait-like diagnostic seams.
    - Keep behavior-preserving slices separate from behavior-changing manual
      alignment slices.
 

--- a/src/application/editor-feedback/buildSyntaxDiagnostics.ts
+++ b/src/application/editor-feedback/buildSyntaxDiagnostics.ts
@@ -894,6 +894,15 @@ const eventTimeoutActionDiagnosticRules = [
   ),
 ] as const;
 
+const waitJobExecutionTimeDiagnosticRules = [
+  buildExplicitDecimalRangeRule(
+    "fd",
+    1,
+    1440,
+    "Execution time (fd) must be between 1 and 1440.",
+  ),
+] as const;
+
 const transferFileByteLengthRules: readonly UnitParameterDiagnosticRule[] =
   transferFileIndexes.flatMap((index) => [
     buildExplicitByteLengthRule(
@@ -999,6 +1008,7 @@ const fileMonitoringDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
       return !splitFileMonitoringConditions(effectiveFlwc).has("c");
     },
   },
+  ...waitJobExecutionTimeDiagnosticRules,
   ...eventTimeoutActionDiagnosticRules,
 ];
 
@@ -1015,6 +1025,7 @@ const executionIntervalControlDiagnosticRules: readonly UnitParameterDiagnosticR
       new Set(["y", "n"]),
       "End timing (etn) must be y or n.",
     ),
+    ...waitJobExecutionTimeDiagnosticRules,
     ...eventTimeoutActionDiagnosticRules,
   ];
 
@@ -1063,6 +1074,7 @@ const eventSendingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
 ];
 
 const eventReceivingDiagnosticRules: readonly UnitParameterDiagnosticRule[] = [
+  ...waitJobExecutionTimeDiagnosticRules,
   buildExplicitDecimalRangeRule(
     "etm",
     1,
@@ -1353,7 +1365,16 @@ const buildFileMonitoringDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
   findUnitsByTypes(rootUnits, fileMonitoringDiagnosticTargetTypes).flatMap(
-    (unit) => collectRuleDiagnostics(unit, fileMonitoringDiagnosticRules),
+    (unit) => [
+      ...collectRuleDiagnostics(unit, fileMonitoringDiagnosticRules),
+      ...collectStartConditionDisabledParameterDiagnostics(unit, [
+        {
+          key: "fd",
+          message:
+            "Execution time (fd) cannot be specified for jobs defined as start conditions.",
+        },
+      ]),
+    ],
   );
 
 const buildExecutionIntervalControlDiagnostics = (
@@ -1363,10 +1384,16 @@ const buildExecutionIntervalControlDiagnostics = (
     rootUnits,
     executionIntervalControlDiagnosticTargetTypes,
   ).flatMap((unit) => {
-    const diagnostics = collectRuleDiagnostics(
-      unit,
-      executionIntervalControlDiagnosticRules,
-    );
+    const diagnostics = [
+      ...collectRuleDiagnostics(unit, executionIntervalControlDiagnosticRules),
+      ...collectStartConditionDisabledParameterDiagnostics(unit, [
+        {
+          key: "fd",
+          message:
+            "Execution time (fd) cannot be specified for jobs defined as start conditions.",
+        },
+      ]),
+    ];
     const endTimingParameter = findParameter(unit, "etn");
 
     if (endTimingParameter?.value === "y" && !hasStartConditionContext(unit)) {
@@ -1417,43 +1444,56 @@ const isValidExplicitEventSearchCondition = (
   return parseExplicitDecimalInRange(parameter, 1, 720) !== undefined;
 };
 
+const collectStartConditionDisabledParameterDiagnostics = (
+  unit: Unit,
+  parameterMessages: readonly { key: string; message: string }[],
+): SyntaxDiagnosticDto[] => {
+  if (!hasStartConditionContext(unit)) {
+    return [];
+  }
+
+  return parameterMessages.flatMap(({ key, message }) => {
+    const parameter = findParameter(unit, key);
+    return parameter ? [buildDiagnostic(parameter, message)] : [];
+  });
+};
+
 const buildEventReceivingDiagnostics = (
   rootUnits: Unit[],
 ): SyntaxDiagnosticDto[] =>
   findUnitsByTypes(rootUnits, eventReceivingDiagnosticTargetTypes).flatMap(
     (unit) => {
-      const diagnostics = collectRuleDiagnostics(
-        unit,
-        eventReceivingDiagnosticRules,
-      );
-
-      if (!hasStartConditionContext(unit)) {
-        return diagnostics;
-      }
-
-      const invalidStartConditionParameters = [
-        {
-          parameter: findParameter(unit, "etm"),
-          message:
-            "Event timeout period (etm) cannot be specified for jobs defined as start conditions.",
-        },
-        {
-          parameter: findParameter(unit, "ha"),
-          message:
-            "Hold attribute (ha) cannot be specified for jobs defined as start conditions.",
-        },
-        {
-          parameter: findParameter(unit, "ets"),
-          message:
-            "Event timeout action (ets) cannot be specified for jobs defined as start conditions.",
-        },
+      const diagnostics = [
+        ...collectRuleDiagnostics(unit, eventReceivingDiagnosticRules),
+        ...collectStartConditionDisabledParameterDiagnostics(unit, [
+          {
+            key: "fd",
+            message:
+              "Execution time (fd) cannot be specified for jobs defined as start conditions.",
+          },
+        ]),
       ];
 
-      invalidStartConditionParameters.forEach(({ parameter, message }) => {
-        if (parameter) {
-          diagnostics.push(buildDiagnostic(parameter, message));
-        }
-      });
+      const invalidStartConditionParameters =
+        collectStartConditionDisabledParameterDiagnostics(unit, [
+          {
+            key: "etm",
+            message:
+              "Event timeout period (etm) cannot be specified for jobs defined as start conditions.",
+          },
+          {
+            key: "ha",
+            message:
+              "Hold attribute (ha) cannot be specified for jobs defined as start conditions.",
+          },
+          {
+            key: "ets",
+            message:
+              "Event timeout action (ets) cannot be specified for jobs defined as start conditions.",
+          },
+        ]);
+
+      diagnostics.push(...invalidStartConditionParameters);
 
       return diagnostics;
     },

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -991,6 +991,70 @@ suite("Build Syntax Diagnostics", () => {
     );
   });
 
+  test("reports file monitoring fd diagnostics for explicit out-of-range values and start-condition usage", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=start-condition,rc,+0+0;",
+        "  el=file1,flwj,+160+0;",
+        "  el=file2,rflwj,+320+0;",
+        "  unit=start-condition,,jp1admin,;",
+        "  {",
+        "    ty=rc;",
+        "  }",
+        "  unit=file1,,jp1admin,;",
+        "  {",
+        "    ty=flwj;",
+        "    fd=0;",
+        "  }",
+        "  unit=file2,,jp1admin,;",
+        "  {",
+        "    ty=rflwj;",
+        "    fd=10;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 14,
+          column: 4,
+          length: 4,
+          message: "Execution time (fd) must be between 1 and 1440.",
+        },
+        {
+          line: 14,
+          column: 4,
+          length: 4,
+          message:
+            "Execution time (fd) cannot be specified for jobs defined as start conditions.",
+        },
+        {
+          line: 19,
+          column: 4,
+          length: 5,
+          message:
+            "Execution time (fd) cannot be specified for jobs defined as start conditions.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error"],
+    );
+  });
+
   test("does not report event timeout action diagnostics for omitted defaults and valid explicit values", () => {
     const diagnostics = buildSyntaxDiagnostics(
       [
@@ -1216,6 +1280,70 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(
       diagnostics.map((diagnostic) => diagnostic.severity),
       ["error", "error", "error", "error"],
+    );
+  });
+
+  test("reports execution-interval control fd diagnostics for explicit out-of-range values and start-condition usage", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=start-condition,rc,+0+0;",
+        "  el=interval1,tmwj,+160+0;",
+        "  el=interval2,rtmwj,+320+0;",
+        "  unit=start-condition,,jp1admin,;",
+        "  {",
+        "    ty=rc;",
+        "  }",
+        "  unit=interval1,,jp1admin,;",
+        "  {",
+        "    ty=tmwj;",
+        "    fd=1441;",
+        "  }",
+        "  unit=interval2,,jp1admin,;",
+        "  {",
+        "    ty=rtmwj;",
+        "    fd=10;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 14,
+          column: 4,
+          length: 7,
+          message: "Execution time (fd) must be between 1 and 1440.",
+        },
+        {
+          line: 14,
+          column: 4,
+          length: 7,
+          message:
+            "Execution time (fd) cannot be specified for jobs defined as start conditions.",
+        },
+        {
+          line: 19,
+          column: 4,
+          length: 5,
+          message:
+            "Execution time (fd) cannot be specified for jobs defined as start conditions.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error"],
     );
   });
 
@@ -2273,6 +2401,70 @@ suite("Build Syntax Diagnostics", () => {
     assert.deepStrictEqual(
       diagnostics.map((diagnostic) => diagnostic.severity),
       ["error", "error", "error", "error", "error", "error"],
+    );
+  });
+
+  test("reports event receiving fd diagnostics for explicit out-of-range values and start-condition usage", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  el=start-condition,rc,+0+0;",
+        "  el=wait1,evwj,+160+0;",
+        "  el=wait2,revwj,+320+0;",
+        "  unit=start-condition,,jp1admin,;",
+        "  {",
+        "    ty=rc;",
+        "  }",
+        "  unit=wait1,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    fd=0;",
+        "  }",
+        "  unit=wait2,,jp1admin,;",
+        "  {",
+        "    ty=revwj;",
+        "    fd=10;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 14,
+          column: 4,
+          length: 4,
+          message: "Execution time (fd) must be between 1 and 1440.",
+        },
+        {
+          line: 14,
+          column: 4,
+          length: 4,
+          message:
+            "Execution time (fd) cannot be specified for jobs defined as start conditions.",
+        },
+        {
+          line: 19,
+          column: 4,
+          length: 5,
+          message:
+            "Execution time (fd) cannot be specified for jobs defined as start conditions.",
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => diagnostic.severity),
+      ["error", "error", "error"],
     );
   });
 


### PR DESCRIPTION
## Summary
- add shared editor-feedback diagnostics for explicit `fd` values across file monitoring, execution-interval control, and event reception monitoring jobs
- report start-condition-context `fd` usage through the existing wait-like diagnostic paths with a small shared helper refactor
- sync SDD artifacts for the delivered `fd` slice and mark compatible-ISAM behavior as intentionally unsupported

## Testing
- rtk pnpm run qlty
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
- rtk pnpm run lint:md