### PR TITLE
[codex] align wait-job timeout-action defaults

### DIFF
--- a/docs/requirements/use-cases/uc-build-unit-list.md
+++ b/docs/requirements/use-cases/uc-build-unit-list.md
@@ -52,6 +52,14 @@ Scenario: Start-condition monitoring projection uses effective schedule pairs
   When either the `wc` count or `wt` time disables monitoring for that pair
   Then the unit-list schedule definition output shows empty effective values
   for both start-condition monitoring columns
+
+Scenario: Wait-job timeout-action projection uses shared default semantics
+  Given a currently modeled wait-job family exposes `ets` through the shared
+    parameter accessor
+  And the job omits `ets`
+  When the unit-list document DTO is built
+  Then group 13 `eventTimeoutAction` shows the same JP1/AJS3 v13 default
+    semantics already exposed by the shared wait-job parameter path
 ```
 
 ## Acceptance Notes

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/PARAMETER_COVERAGE_MATRIX.md
@@ -149,7 +149,7 @@ coverage.
 - Keys: `tmitv`, `etn`, and `ets`
 - Unit scope:
   execution-interval control jobs and recovery execution-interval control jobs
-- Status: partial
+- Status: aligned
 - Owning seam:
   `Tmwj.ts`, `optionalScalarParameterBuilders.ts`, `Defaults.ts`, and
   `buildUnitListRemainingGroups.ts`
@@ -157,15 +157,28 @@ coverage.
   `parameterFactory.test.ts` for domain defaults and
   `buildUnitListRemainingGroups.test.ts` for group 13 projection
 - Remaining gap:
-  execution-interval control job defaults and unit-list group 13 projection
-  are aligned for these values, explicit `ets` timeout-action diagnostics are
-  aligned through editor-feedback, explicit `tmitv` range diagnostics and
-  explicit `etn` allowed-value diagnostics are aligned through
-  editor-feedback, and explicit `etn=y` start-condition diagnostics are now
-  aligned through editor-feedback. Shared wait-job `fd` execution-time
-  semantics are tracked separately in `WAIT_JOB_EXECUTION_TIME_ALIGNMENT.md`.
-  Compatible-ISAM-specific restrictions are not planned for this repository.
-  Broader wait-job default reconciliation remains deferred
+  none for the currently modeled execution-interval control defaults in this
+  feature scope. Shared wait-job `fd` execution-time semantics are tracked
+  separately in `WAIT_JOB_EXECUTION_TIME_ALIGNMENT.md`. Compatible-ISAM-
+  specific restrictions are not planned for this repository.
+
+### Wait-Job Timeout-Action Projection
+
+- Keys: `ets`
+- Unit scope:
+  log-file monitoring jobs, mail receiving monitoring jobs, MQ message
+  receiving monitoring jobs, message queue receiving jobs, and Windows event
+  log monitoring jobs, plus their recovery variants
+- Status: aligned
+- Owning seam:
+  `buildUnitListRemainingGroups.ts`,
+  `optionalScalarParameterBuilders.ts`, and `Defaults.ts`
+- Evidence:
+  `buildUnitListRemainingGroups.test.ts` and `buildUnitListView.test.ts`
+- Remaining gap:
+  none for the currently modeled wait-job `eventTimeoutAction` projection in
+  this feature scope. Event-receiving timeout-control projection remains
+  tracked separately from this slice.
 
 ### Event Reception Monitoring Job Search Scope
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/SPECS.md
@@ -152,6 +152,25 @@ JP1/AJS3 version 13 reference documents.
   values, normalized parameters, unit-list projection, flow projection, and
   command generation remain unchanged. Broader `ets`-bearing unit families and
   `tmitv` / `etn` validation remain deferred.
+- Wait-job group 13 `eventTimeoutAction` projection is a separate approval-
+  sensitive boundary from the shared domain `ParamFactory.ets` default because
+  it is user-visible table output. Current projection is default-aware for
+  `flwj` / `rflwj` and `tmwj` / `rtmwj`, but other currently modeled
+  `ets`-bearing wait-job families still project omitted values raw/empty. If
+  approved, the next focused follow-up should stay inside
+  `buildUnitListRemainingGroups.ts`, reconcile omitted `ets` display for the
+  currently modeled wait-job families that already share `ParamFactory.ets`,
+  and include only the smallest helper refactor needed to replace the current
+  family-specific projection seam while preserving explicit normalized values,
+  parser output, domain wrapper values, editor-feedback diagnostics, flow
+  projection, and command generation.
+- Wait-job group 13 `eventTimeoutAction` projection is now aligned for the
+  currently modeled wait-job families `lfwj` / `rlfwj`, `mlwj` / `rmlwj`,
+  `mqwj` / `rmqwj`, `mswj` / `rmswj`, and `ntwj` / `rntwj`. Omitted `ets`
+  now uses the same shared default-aware semantics already exposed by
+  `ParamFactory.ets`, while explicit normalized values, parser output, domain
+  wrapper values, editor-feedback diagnostics, flow projection, and command
+  generation remain unchanged.
 - Execution-interval control job defaults are approval-sensitive because
   JP1/AJS3 version 13 defines omitted `tmitv`, `etn`, and `ets` behavior for
   `tmwj` / `rtmwj`, while current code only has generic defaults for `etn` and

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/TASKS.md
@@ -71,6 +71,20 @@
       explicit in-range values, and explicit out-of-range `wth`, `tho`, `rjs`,
       `rje`, `rec`, and `rei` values
 - [x] Run required code-change validation after implementation
+- [x] Record the next grouped shared wait-job `ets` default-projection slice
+      in feature-local investigation docs with manual-backed scope, affected
+      seams, alternatives, and regression evidence
+- [x] Record human approval before changing unit-list projection runtime code,
+      tests, generated artifacts, or configuration for grouped shared wait-job
+      `eventTimeoutAction` default reconciliation
+- [x] Implement grouped shared wait-job `eventTimeoutAction` default
+      reconciliation only after approval
+- [x] Refactor `buildUnitListRemainingGroups.ts` within the approved scope so
+      omitted `ets` projection stays on one shared default-aware helper path
+      for the currently modeled wait-job families
+- [x] Add focused regression evidence for omitted and explicit `ets`
+      projection across the approved wait-job family scope
+- [x] Run required code-change validation after implementation
 - [x] Record human approval before changing editor-feedback diagnostics,
       shared schedule-rule helpers, runtime code, or tests for grouped
       schedule-rule range diagnostics
@@ -738,6 +752,50 @@
   filter checks on the existing rule-array path, and `collectRuleDiagnostics`
   now evaluates all explicit occurrences for a key so repeated `evwfr`
   parameters can be diagnosed without a separate implementation branch.
+- 2026-05-09: Remaining actionable JP1/AJS v13 gaps were re-checked after the
+  delivered shared wait-job `fd` and execution-interval `etn=y`
+  start-condition slices. The next recommended approval-gated candidate is
+  grouped shared wait-job `eventTimeoutAction` default reconciliation across
+  the currently modeled `ets`-bearing wait-job families, because the
+  remaining mismatch now sits in one user-visible group 13 concept and one
+  small projection seam rather than in parser or editor-feedback behavior.
+- 2026-05-09: Investigation confirmed that `ParamFactory.ets` already resolves
+  omitted values through `DEFAULTS.Ets`, while
+  `buildUnitListRemainingGroups.ts` still limits default-aware
+  `eventTimeoutAction` projection to `flwj` / `rflwj` and
+  `tmwj` / `rtmwj`. The remaining candidate is therefore projection
+  reconciliation for the currently modeled wait-job families
+  `lfwj` / `rlfwj`, `mlwj` / `rmlwj`, `mqwj` / `rmqwj`,
+  `mswj` / `rmswj`, and `ntwj` / `rntwj`.
+- 2026-05-09: `WAIT_JOB_TIMEOUT_ACTION_DEFAULT_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
+  `TASKS.md`, and `uc-build-unit-list.md` now record the pending shared
+  wait-job `eventTimeoutAction` default-projection slice and its approval
+  boundary.
+- 2026-05-17: User replied "Approved. Proceed with implementation." after the
+  grouped shared wait-job `eventTimeoutAction` default-projection approval
+  request. Approved changes were limited to unit-list projection in
+  `buildUnitListRemainingGroups.ts` for omitted `ets` on
+  `lfwj` / `rlfwj`, `mlwj` / `rmlwj`, `mqwj` / `rmqwj`,
+  `mswj` / `rmswj`, and `ntwj` / `rntwj`, plus the smallest helper refactor
+  needed to keep the projection on one shared default-aware path, focused
+  regression updates in `buildUnitListRemainingGroups.test.ts` and
+  `buildUnitListView.test.ts`, SDD sync, and validation. Parser grammar,
+  editor-feedback behavior, domain wrapper defaults, flow projection,
+  command generation, generated artifacts, configuration, dependency
+  versions, and `engines.vscode` stayed out of scope.
+- 2026-05-17: Grouped shared wait-job `eventTimeoutAction` default
+  reconciliation now projects omitted `ets` through the shared
+  `DEFAULTS.Ets` path for the approved currently modeled wait-job families,
+  while explicit normalized values remain unchanged.
+- 2026-05-17: `buildUnitListRemainingGroups.ts` now keeps the approved wait-
+  job timeout-action projection on one shared default-aware helper path
+  instead of the earlier file-monitoring/execution-interval-only
+  special-casing.
+- 2026-05-17: `WAIT_JOB_TIMEOUT_ACTION_DEFAULT_ALIGNMENT.md`,
+  `PARAMETER_COVERAGE_MATRIX.md`, `SPECS.md`, `docs/specs/plans.md`,
+  `TASKS.md`, and `uc-build-unit-list.md` now record the delivered shared
+  wait-job `eventTimeoutAction` default-projection slice.
 - 2026-05-09:
   `PARAMETER_COVERAGE_MATRIX.md`, `EVENT_RECEIVING_JOB_ALIGNMENT.md`,
   `EVENT_RECEIVING_STRING_FILTER_ALIGNMENT.md`, `SPECS.md`,
@@ -921,20 +979,21 @@
 ## Human Approval
 
 - Status: Approved
-- Approved at: 2026-05-09
-- Approved scope: grouped shared wait-job execution-time (`fd`) diagnostics
-  for explicit `fd` values on `flwj` / `rflwj`, `tmwj` / `rtmwj`, and
-  `evwj` / `revwj`, limited to the documented `fd` range `1..1440` and the
-  documented start-condition-disabled behavior for explicit `fd` through the
-  existing editor-feedback boundary, plus the smallest helper/rule-array
-  refactor needed to keep the checks on the current file-monitoring,
-  execution-interval, and event-receiving diagnostic paths, while preserving
-  raw parser output, domain wrapper values, normalized parameters, unit-list
-  projection, flow projection, command generation, generated artifacts,
-  dependency versions, configuration, and `engines.vscode`.
+- Approved at: 2026-05-17
+- Approved scope: grouped shared wait-job `eventTimeoutAction` default
+  reconciliation in `buildUnitListRemainingGroups.ts` for omitted `ets` on
+  `lfwj` / `rlfwj`, `mlwj` / `rmlwj`, `mqwj` / `rmqwj`,
+  `mswj` / `rmswj`, and `ntwj` / `rntwj`, plus the smallest helper refactor
+  needed to keep the projection on one shared default-aware path, focused
+  regression updates in `buildUnitListRemainingGroups.test.ts` and
+  `buildUnitListView.test.ts`, SDD sync, and required validation while
+  preserving parser output, domain wrapper values, editor-feedback behavior,
+  flow projection, command generation, generated artifacts, dependency
+  versions, configuration, and `engines.vscode`.
 
-Current implementation gate: the grouped shared wait-job `fd` scope recorded
-above has been approved and implemented.
+Current implementation gate: the grouped shared wait-job
+`eventTimeoutAction` default-projection scope recorded above has been approved
+and implemented.
 
 ## Prior Approval Evidence
 

--- a/docs/specs/features/align-jp1-v13-parameter-and-command-reference/WAIT_JOB_TIMEOUT_ACTION_DEFAULT_ALIGNMENT.md
+++ b/docs/specs/features/align-jp1-v13-parameter-and-command-reference/WAIT_JOB_TIMEOUT_ACTION_DEFAULT_ALIGNMENT.md
@@ -1,0 +1,111 @@
+# Wait-Job Timeout-Action Default Alignment
+
+## Purpose
+
+Record the next JP1/AJS3 version 13 parameter-alignment candidate around the
+remaining inconsistent unit-list projection of omitted `ets` values across the
+currently modeled wait-job families.
+
+This slice is grouped at a user-meaningful size: the same group 13
+`eventTimeoutAction` concept is already shown to users for file monitoring and
+execution-interval control jobs, while several other wait-job families still
+fall back to raw-only projection even though the shared domain accessor already
+exposes the same default.
+
+## Normative Reference
+
+- Product/version: JP1/Automatic Job Management System 3 version 13
+- Manual sections sharing `ets={kl|nr|wr|an}`:
+  - Command Reference, file-monitoring-job family
+  - Command Reference, execution-interval-control-job family
+  - Command Reference, currently modeled wait-job families that expose `ets`
+- Parameter in scope:
+  `ets={kl|nr|wr|an}` with omitted value resolved through the shared default
+  path already modeled by `ParamFactory.ets`
+
+## Slice Boundary
+
+- Application seam:
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`
+- Existing shared view contract:
+  `src/application/unit-list/buildUnitListView.ts`
+- Existing domain reference points kept unchanged:
+  `src/domain/models/parameters/optionalScalarParameterBuilders.ts`,
+  `src/domain/models/parameters/Defaults.ts`, and the wait-job wrappers that
+  already expose `ParamFactory.ets`
+- Candidate unit scope:
+  `lfwj` / `rlfwj`, `mlwj` / `rmlwj`, `mqwj` / `rmqwj`,
+  `mswj` / `rmswj`, and `ntwj` / `rntwj`
+- Regression evidence:
+  `src/test/suite/buildUnitListRemainingGroups.test.ts` and
+  `src/test/suite/buildUnitListView.test.ts`
+- Out of scope:
+  parser grammar changes, editor-feedback diagnostics, domain-wrapper default
+  changes, normalized parameter storage, flow projection, command generation,
+  generated artifacts, dependency changes, configuration, and
+  `engines.vscode`
+
+## Investigation Notes
+
+- `ParamFactory.ets` already resolves omitted values through `DEFAULTS.Ets`,
+  so the remaining mismatch is not in the domain accessor. The visible gap is
+  that `buildUnitListRemainingGroups.ts` still makes group 13
+  `eventTimeoutAction` default-aware only for `flwj` / `rflwj` and
+  `tmwj` / `rtmwj`.
+- The currently modeled wait-job wrappers `Lfwj`, `Mlwj`, `Mqwj`, `Mswj`, and
+  `Ntwj` already expose the same `ets` parameter through the same shared
+  accessor, which makes this a better shared projection/refactor slice than a
+  job-by-job cleanup.
+- Because the current gap is presentation-facing and already has a narrow seam,
+  it is a better next slice than broadening immediately into transfer-file
+  macro-variable tightening or other environment-sensitive work.
+- The current `findGroup13EventTimeoutAction(...)` helper is the smallest
+  refactor seam. If approved, it should be generalized so one default-aware
+  path owns all currently modeled wait-job families that surface the group 13
+  timeout-action concept.
+
+## Planned Alignment If Approved
+
+- Keep ownership in the shared application unit-list projection boundary.
+- Reconcile omitted `ets` display for the currently modeled wait-job families
+  so group 13 `eventTimeoutAction` uses the same JP1/AJS3 v13 default-aware
+  behavior already exposed through `ParamFactory.ets`.
+- Refactor only enough helper structure to replace the current narrow
+  job-family special-casing with one shared, readable default-aware projection
+  path.
+- Preserve explicit normalized values, raw parser output, domain wrapper
+  values, editor-feedback diagnostics, flow projection, and command
+  generation.
+
+## Delivered Alignment
+
+- Unit-list group 13 `eventTimeoutAction` now resolves omitted `ets` through
+  the shared `DEFAULTS.Ets` path for the approved currently modeled wait-job
+  families `lfwj` / `rlfwj`, `mlwj` / `rmlwj`, `mqwj` / `rmqwj`,
+  `mswj` / `rmswj`, and `ntwj` / `rntwj`.
+- Explicit normalized `ets` values remain visible and unchanged.
+- The implementation stays inside `buildUnitListRemainingGroups.ts` and
+  replaces the earlier narrow family-specific check with one shared
+  default-aware helper path for the approved scope.
+- Raw parser output, domain wrapper values, editor-feedback diagnostics, flow
+  projection, and command generation remain unchanged.
+
+## Alternatives
+
+- Leave the current projection unchanged:
+  viable, but rejected because it keeps the user-visible table inconsistent
+  across job families that already share one domain default seam.
+- Broaden the slice to every wait-condition parameter:
+  rejected because that would mix one clear omitted-default display gap with
+  larger wait-context semantics.
+- Switch to transfer-file macro-variable tightening first:
+  viable, but deferred because this wait-job slice is smaller, more obviously
+  refactor-oriented, and closes a visible inconsistency without changing
+  diagnostics.
+
+## Follow-up
+
+- Execution-interval control job defaults no longer need to keep this shared
+  `eventTimeoutAction` projection inconsistency as a remaining gap.
+- Event-receiving `ets` projection and any broader wait-condition-family
+  reconciliation remain separate future work unless explicitly approved.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -73,6 +73,13 @@ rules in `docs/specs/README.md`, not in this file.
   be re-selected from the remaining partial or deferred gaps using the same
   user-meaningful grouping rule, rather than broadening immediately into
   unsupported compatible-ISAM-specific behavior.
+- After re-checking the remaining actionable JP1/AJS v13 gaps again, the next
+  recommended candidate should group the still-inconsistent wait-job
+  `eventTimeoutAction` default projection across the currently modeled
+  `ets`-bearing wait-job families, because the domain wrapper default already
+  exists, the user-visible table concept is shared in group 13, and the
+  remaining work is better framed as one projection-reconciliation/refactor
+  slice than as job-by-job cleanup.
 - After re-checking the remaining actionable gaps again, the next recommended
   JP1/AJS v13 candidate should move to the remaining event-reception
   monitoring filter family and group the still-raw string-filter parameters
@@ -115,9 +122,9 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Next Priority Tasks
 
-1. Re-check the remaining partial or deferred JP1/AJS3 v13 parameter-alignment
-   gaps after the delivered grouped shared wait-job execution-time (`fd`)
-   slice and record the next approval-gated candidate.
+1. Record and approval-gate the grouped shared wait-job
+   `eventTimeoutAction` default-projection reconciliation slice across the
+   currently modeled `ets`-bearing wait-job families.
 2. Continue JP1/AJS v13 parameter-alignment slices until the feature-local
    coverage matrix no longer has actionable `Partial` or `Deferred` gaps, or
    until a gap is explicitly re-scoped as outside the alignment feature.
@@ -132,35 +139,34 @@ rules in `docs/specs/README.md`, not in this file.
 
 - Branch: `main`; a dedicated implementation branch was attempted but could
   not be created from the sandboxed session after approval
-- Objective: deliver the approved grouped shared wait-job execution-time
-  (`fd`) slice after the delivered JP1 event reception monitoring
-  timeout-control diagnostics.
+- Objective: deliver the approved grouped shared wait-job
+  `eventTimeoutAction` default-projection reconciliation slice after the
+  delivered shared wait-job execution-time (`fd`) and execution-interval
+  `etn=y` start-condition diagnostics.
 - Status: implementation and validation are complete in the recorded scope.
-- Scope: grouped semantic diagnostics were added for explicit `fd` values on
-  `flwj` / `rflwj`, `tmwj` / `rtmwj`, and `evwj` / `revwj`, limited to the
-  documented range `1..1440` and the documented start-condition-disabled
-  behavior, plus only the smallest helper/rule-array refactor needed to keep
-  the checks on the current file-monitoring, execution-interval, and
-  event-receiving diagnostics paths.
-- Out of scope: parser grammar changes, domain wrapper normalization changes,
-  unit-list projection changes, flow projection changes, command generation,
-  broader wait-condition parameters, compatible-ISAM detection, generated
-  artifacts, dependency changes, configuration, and `engines.vscode`.
+- Scope: grouped unit-list projection reconciliation for omitted `ets` on the
+  currently modeled wait-job families `lfwj` / `rlfwj`,
+  `mlwj` / `rmlwj`, `mqwj` / `rmqwj`, `mswj` / `rmswj`, and
+  `ntwj` / `rntwj`, limited to group 13 `eventTimeoutAction` plus only the
+  smallest helper refactor needed to replace the current family-specific
+  projection seam with one shared default-aware path.
+- Out of scope: parser grammar changes, editor-feedback diagnostics, domain
+  wrapper default behavior, normalized parameter storage, flow projection,
+  command generation, generated artifacts, dependency changes, configuration,
+  and `engines.vscode`.
 - Impact summary: the implemented scope affected
-  `src/application/editor-feedback/buildSyntaxDiagnostics.ts`,
-  `src/test/suite/buildSyntaxDiagnostics.test.ts`, the parameter-alignment
-  feature docs, and the editor-feedback behavior contract for syntactically
-  valid wait-like job documents that specify `fd`.
-- Risks and assumptions: this slice is intended to stay diagnostic-only and
-  must not change raw parser output, domain wrapper values, or projection
-  behavior. The current manual wording is consistent for `fd` across the
-  three targeted job definitions. Compatible-ISAM-sensitive restrictions are
-  intentionally unsupported because compatible-ISAM is limited to legacy
-  migration-mode environments outside this repository's target scope.
-- Alternatives considered: returning to smaller default-only cleanup remains
-  less user-meaningful; broadening immediately into the full wait-condition
-  family would enlarge the seam before the shared `fd` rule is closed, and
-  compatible-ISAM-sensitive work is intentionally unsupported.
+  `src/application/unit-list/buildUnitListRemainingGroups.ts`,
+  `src/test/suite/buildUnitListRemainingGroups.test.ts`,
+  `src/test/suite/buildUnitListView.test.ts`, the parameter-alignment feature
+  docs, and the build-unit-list behavior contract for omitted `ets` display.
+- Risks and assumptions: this slice stays presentation-facing and assumes the
+  existing shared `ParamFactory.ets` default already expresses the intended
+  JP1/AJS3 v13 semantics for the approved wait-job families. It must not
+  broaden into other wait-condition parameters, event-receiving projection, or
+  unsupported compatible-ISAM behavior.
+- Alternatives considered: transfer-file macro-variable tightening remains a
+  viable later candidate, but the delivered wait-job projection slice closed a
+  clearer user-visible inconsistency with a smaller refactor seam.
 
 ## Build/Test Performance SDD
 
@@ -189,12 +195,12 @@ rules in `docs/specs/README.md`, not in this file.
   active SDD for staged validation performance work.
 - `docs/specs/features/align-jp1-v13-parameter-and-command-reference/`:
   active JP1/AJS3 version 13 alignment records and coverage matrix. Current
-  slice: grouped shared wait-job execution-time (`fd`) diagnostics are
-  implemented and validated for explicit `fd` values on
-  `flwj` / `rflwj`, `tmwj` / `rtmwj`, and `evwj` / `revwj`, while the
-  previously delivered event-receiving timeout-control, numeric-identifier,
-  and string-filter diagnostics remain complete and compatible-ISAM-sensitive
-  work is intentionally unsupported.
+  slice: grouped shared wait-job `eventTimeoutAction` default projection
+  reconciliation is implemented and validated across the approved currently
+  modeled `ets`-bearing wait-job families, after the delivered shared
+  wait-job execution-time (`fd`) and execution-interval `etn=y`
+  start-condition diagnostics. Compatible-ISAM-sensitive work remains
+  intentionally unsupported.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 - `docs/specs/features/modernize-runtime-boundaries/`:

--- a/src/application/unit-list/buildUnitListRemainingGroups.ts
+++ b/src/application/unit-list/buildUnitListRemainingGroups.ts
@@ -32,6 +32,22 @@ const isFileMonitoringJob = (unit: AjsUnit): boolean =>
 const isExecutionIntervalControlJob = (unit: AjsUnit): boolean =>
   unit.unitType === "tmwj" || unit.unitType === "rtmwj";
 
+const isWaitJobWithGroup13TimeoutAction = (unit: AjsUnit): boolean =>
+  unit.unitType === "flwj" ||
+  unit.unitType === "rflwj" ||
+  unit.unitType === "tmwj" ||
+  unit.unitType === "rtmwj" ||
+  unit.unitType === "lfwj" ||
+  unit.unitType === "rlfwj" ||
+  unit.unitType === "mlwj" ||
+  unit.unitType === "rmlwj" ||
+  unit.unitType === "mqwj" ||
+  unit.unitType === "rmqwj" ||
+  unit.unitType === "mswj" ||
+  unit.unitType === "rmswj" ||
+  unit.unitType === "ntwj" ||
+  unit.unitType === "rntwj";
+
 const isQueueJob = (unit: AjsUnit): boolean =>
   unit.unitType === "qj" || unit.unitType === "rq";
 
@@ -86,7 +102,7 @@ const findGroup13EventTimeoutAction = (unit: AjsUnit): string | undefined =>
     unit,
     "ets",
     DEFAULTS.Ets,
-    isFileMonitoringJob(unit) || isExecutionIntervalControlJob(unit),
+    isWaitJobWithGroup13TimeoutAction(unit),
   );
 
 const findGroup15TransferOperation = (

--- a/src/test/suite/buildUnitListRemainingGroups.test.ts
+++ b/src/test/suite/buildUnitListRemainingGroups.test.ts
@@ -114,6 +114,42 @@ unit=root,,jp1admin,;
 }
 `;
 
+const waitJobTimeoutActionDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  unit=log-file-defaults,,jp1admin,;
+  {
+    ty=lfwj;
+  }
+  unit=mail-defaults,,jp1admin,;
+  {
+    ty=mlwj;
+  }
+  unit=mq-defaults,,jp1admin,;
+  {
+    ty=mqwj;
+  }
+  unit=message-queue-defaults,,jp1admin,;
+  {
+    ty=mswj;
+  }
+  unit=windows-event-defaults,,jp1admin,;
+  {
+    ty=ntwj;
+  }
+  unit=mail-explicit,,jp1admin,;
+  {
+    ty=rmlwj;
+    ets=wr;
+  }
+  unit=regular-job,,jp1admin,;
+  {
+    ty=j;
+  }
+}
+`;
+
 const queueGroup15Definition = `
 unit=root,,jp1admin,;
 {
@@ -311,6 +347,63 @@ suite("Build Unit List Remaining Groups", () => {
     assert.strictEqual(regularView.group13.timeoutInterval, undefined);
     assert.strictEqual(regularView.group13.eventTimeout, undefined);
     assert.strictEqual(regularView.group13.eventTimeoutAction, undefined);
+  });
+
+  test("projects shared wait-job timeout-action defaults for group 13", () => {
+    const result = parseAjs(waitJobTimeoutActionDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const logFileDefaults = document.rootUnits[0]?.children[0];
+    const mailDefaults = document.rootUnits[0]?.children[1];
+    const mqDefaults = document.rootUnits[0]?.children[2];
+    const messageQueueDefaults = document.rootUnits[0]?.children[3];
+    const windowsEventDefaults = document.rootUnits[0]?.children[4];
+    const mailExplicit = document.rootUnits[0]?.children[5];
+    const regularJob = document.rootUnits[0]?.children[6];
+
+    assert.ok(logFileDefaults);
+    assert.ok(mailDefaults);
+    assert.ok(mqDefaults);
+    assert.ok(messageQueueDefaults);
+    assert.ok(windowsEventDefaults);
+    assert.ok(mailExplicit);
+    assert.ok(regularJob);
+
+    assert.strictEqual(
+      buildUnitListRemainingGroups(logFileDefaults, [], []).group13
+        .eventTimeoutAction,
+      DEFAULTS.Ets,
+    );
+    assert.strictEqual(
+      buildUnitListRemainingGroups(mailDefaults, [], []).group13
+        .eventTimeoutAction,
+      DEFAULTS.Ets,
+    );
+    assert.strictEqual(
+      buildUnitListRemainingGroups(mqDefaults, [], []).group13
+        .eventTimeoutAction,
+      DEFAULTS.Ets,
+    );
+    assert.strictEqual(
+      buildUnitListRemainingGroups(messageQueueDefaults, [], []).group13
+        .eventTimeoutAction,
+      DEFAULTS.Ets,
+    );
+    assert.strictEqual(
+      buildUnitListRemainingGroups(windowsEventDefaults, [], []).group13
+        .eventTimeoutAction,
+      DEFAULTS.Ets,
+    );
+    assert.strictEqual(
+      buildUnitListRemainingGroups(mailExplicit, [], []).group13
+        .eventTimeoutAction,
+      "wr",
+    );
+    assert.strictEqual(
+      buildUnitListRemainingGroups(regularJob, [], []).group13
+        .eventTimeoutAction,
+      undefined,
+    );
   });
 
   test("hides QUEUE job transfer operations in group 15", () => {

--- a/src/test/suite/buildUnitListView.test.ts
+++ b/src/test/suite/buildUnitListView.test.ts
@@ -205,6 +205,38 @@ unit=root,,jp1admin,;
 }
 `;
 
+const waitJobTimeoutActionDefinition = `
+unit=root,,jp1admin,;
+{
+  ty=g;
+  unit=log-file-defaults,,jp1admin,;
+  {
+    ty=lfwj;
+  }
+  unit=mail-defaults,,jp1admin,;
+  {
+    ty=mlwj;
+  }
+  unit=mq-defaults,,jp1admin,;
+  {
+    ty=mqwj;
+  }
+  unit=message-queue-defaults,,jp1admin,;
+  {
+    ty=mswj;
+  }
+  unit=windows-event-defaults,,jp1admin,;
+  {
+    ty=ntwj;
+  }
+  unit=mail-explicit,,jp1admin,;
+  {
+    ty=rmlwj;
+    ets=wr;
+  }
+}
+`;
+
 suite("Build Unit List View", () => {
   test("projects group fields from the normalized model", () => {
     const result = parseAjs(validDefinition);
@@ -415,5 +447,38 @@ suite("Build Unit List View", () => {
       startCondition?.group9.startCondition,
       '"AJSROOT" = "ready"',
     );
+  });
+
+  test("projects shared wait-job timeout-action defaults in group 13 rows", () => {
+    const result = parseAjs(waitJobTimeoutActionDefinition);
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+
+    const rows = buildUnitListView(document);
+    const logFileDefaults = rows.find(
+      (row) => row.absolutePath === "/root/log-file-defaults",
+    );
+    const mailDefaults = rows.find(
+      (row) => row.absolutePath === "/root/mail-defaults",
+    );
+    const mqDefaults = rows.find(
+      (row) => row.absolutePath === "/root/mq-defaults",
+    );
+    const messageQueueDefaults = rows.find(
+      (row) => row.absolutePath === "/root/message-queue-defaults",
+    );
+    const windowsEventDefaults = rows.find(
+      (row) => row.absolutePath === "/root/windows-event-defaults",
+    );
+    const mailExplicit = rows.find(
+      (row) => row.absolutePath === "/root/mail-explicit",
+    );
+
+    assert.strictEqual(logFileDefaults?.group13.eventTimeoutAction, "kl");
+    assert.strictEqual(mailDefaults?.group13.eventTimeoutAction, "kl");
+    assert.strictEqual(mqDefaults?.group13.eventTimeoutAction, "kl");
+    assert.strictEqual(messageQueueDefaults?.group13.eventTimeoutAction, "kl");
+    assert.strictEqual(windowsEventDefaults?.group13.eventTimeoutAction, "kl");
+    assert.strictEqual(mailExplicit?.group13.eventTimeoutAction, "wr");
   });
 });


### PR DESCRIPTION
## What changed
- aligned omitted `ets` projection for the currently modeled wait-job families so unit-list group 13 `eventTimeoutAction` now follows the shared default-aware path
- refactored `buildUnitListRemainingGroups.ts` to replace narrow family-specific timeout-action handling with one shared helper
- added regression coverage in the remaining-groups and full unit-list view tests, and synced the JP1/AJS v13 SDD records for the delivered slice

## Why
The shared domain accessor for `ets` was already default-aware, but the table projection still treated several wait-job families as raw-only. That left a user-visible inconsistency across jobs that expose the same timeout-action concept.

## User impact
Users now see consistent default `eventTimeoutAction` values in group 13 for the approved wait-job families when `ets` is omitted, without changing parser behavior, diagnostics, flow projection, or command generation.

## Validation
- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`
