### PR TITLE
[codex] Add flow refactor and deterministic layout SDD

### DIFF
--- a/docs/requirements/use-cases/uc-build-flow-graph.md
+++ b/docs/requirements/use-cases/uc-build-flow-graph.md
@@ -37,6 +37,20 @@ The user opens or refreshes a flow-oriented view for a selected unit scope.
   changing the selected document
 - nested panels should stay anchored to the expanded unit that owns them and
   should not require reconstructing `UnitEntity` in presentation code
+- expanded nested layout must be recomputed from the selected scope and the
+  full expanded-unit set so the same expanded set always yields the same final
+  placement
+- expanded nested units must be processed in stable order by
+  `depth`, `layout.v`, `layout.h`, `absolutePath`
+- each expanded unit must be treated as one occupied rectangle covering the
+  visible node, its expanded panel, and expanded descendant panels that remain
+  inside that subtree
+- sibling subtrees inside the same container must not overlap by occupied
+  rectangle after expanded layout is resolved
+- collision resolution for nested expansion may push layout only to the right
+  or downward and must keep unaffected upper-left areas fixed
+- collision resolution must move whole subtrees rather than isolated nodes so
+  descendant relative positions stay stable
 - when nested expansion changes visible graph bounds, the viewer must be able
   to refit the current view to include newly visible nodes
 - current-scope flow search uses case-insensitive contiguous partial matching
@@ -72,6 +86,26 @@ Scenario: Nested jobnets can expand in the current graph
   Then the nested graph is revealed in the same viewer scope
   And the parent graph can still be fit into view
 
+Scenario: Expanded layout is deterministic for the same expanded set
+  Given a visible flow graph with two expandable nested jobnets
+  When the first layout is built after expanding A then B
+  And the second layout is built for the same expanded set after
+    expanding B then A
+  Then `positionOverrides` are identical
+  And `nodeDecorations` are identical
+
+Scenario: Expanded sibling panels and visible nodes do not overlap
+  Given a visible flow graph with expanded sibling subtrees in one container
+  When the expanded layout is built
+  Then expanded panels do not overlap each other
+  And expanded panels do not overlap visible nodes from sibling subtrees
+
+Scenario: Expanded layout moves only the affected right/down scope
+  Given a visible flow graph with a deep nested expansion
+  When the parent panel grows because of the expanded descendant
+  Then collision resolution propagates to the affected parent-level scope
+  And unrelated upper-left nodes do not move
+
 Scenario: Current-scope search reveals matches
   Given a visible flow graph with collapsed ancestor jobnets
   When current-scope flow search matches a descendant unit
@@ -84,6 +118,10 @@ Scenario: Current-scope search reveals matches
 - desktop and web presentation layers can convert the DTO into their own graph
   structures without requiring `UnitEntity` reconstruction
 - flow rendering behavior remains unchanged after DTO to XyFlow mapping
+- `src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts` owns
+  presentation-local expanded layout orchestration, including stable expansion
+  ordering, occupied-box calculation, subtree movement, and collision
+  resolution, while preserving the use-case output contract
 - representative graph-oriented fixtures in `sample/` should be reusable for
   regression coverage instead of rebuilding large inline definitions
 - layout details that depend on rendered node bounds stay presentation-local,
@@ -95,8 +133,8 @@ Scenario: Current-scope search reveals matches
 - selected scope changes must preserve current-node and ancestor rendering semantics
 - large sample definitions should continue to build graph DTOs without
   presentation-layer shortcuts
-- expansion ordering can affect layout; presentation state should preserve a
-  predictable order rather than deriving it from unordered sets
+- deep expansion can enlarge an ancestor panel, so collision propagation must
+  be checked at each affected container level
 - search behavior can feel inert if the scope root matches before a more
   visible descendant, so descendant matches may need priority when that
   produces clearer focus behavior

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -171,6 +171,10 @@ Migration should be incremental and use-case driven.
   root for activation wiring
 - `src/extension/telemetry/*` owns the telemetry SDK adapter and composition
   of the runtime telemetry implementation
+- `src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts` owns
+  presentation-local coordinate/layout resolution for nested expansion and
+  must preserve deterministic, expanded-set-based layout behavior without
+  depending on the last active expansion ID
 
 ## Telemetry Boundary
 

--- a/docs/specs/current-state.md
+++ b/docs/specs/current-state.md
@@ -17,6 +17,9 @@ The repository currently mixes legacy and target-oriented structure.
 - activation and composition remain concentrated
 - parser-adjacent logic can still leak toward UI-oriented code
 - DTO and use-case boundaries are still being clarified
+- expanded flow layout is still vulnerable to order-sensitive nested-panel
+  collision handling, with layout growth responsibilities concentrated in one
+  presentation file
 - old folder names coexist with the target clean-architecture layout
 - package-management and validation workflow now center on `pnpm`, so local
   docs, CI, and contributor instructions need to stay aligned with the pinned
@@ -82,3 +85,5 @@ specifically about a narrow edge case.
 - flow-graph improvements are currently aimed at visual resemblance to
   JP1/AJS View, progressive nested expansion, and explicit navigation between
   list and flow views when both are available
+- deterministic nested expansion layout is a current product requirement so
+  the same expanded-unit set yields the same non-overlapping viewer layout

--- a/docs/specs/features/flow-layout-determinism/SPECS.md
+++ b/docs/specs/features/flow-layout-determinism/SPECS.md
@@ -1,0 +1,150 @@
+# Feature Specification: flow-layout-determinism
+
+## Purpose
+
+Define a deterministic expanded-flow layout contract so nested expansion order
+does not change the final placement of visible nodes or expanded panels.
+
+## Origin
+
+- Source use case:
+  `docs/requirements/use-cases/uc-build-flow-graph.md`
+- Related plan:
+  `docs/specs/plans.md`
+
+## Requirements
+
+- Expanded layout must be recomputed deterministically from the selected scope
+  and the full expanded-unit set, not from the most recently expanded unit.
+- Expansion processing order must be stable by
+  `depth`, `layout.v`, `layout.h`, `absolutePath`.
+- Each expanded unit must be represented by an occupied rectangle that covers
+  the normal node rectangle, the expanded panel rectangle, and any expanded
+  descendant panels.
+- Sibling subtrees under the same container must not overlap by occupied
+  rectangle.
+- Collision resolution must move only the affected right-side, lower-side, or
+  lower-right area relative to the expansion source.
+- Collision resolution must move rightward or downward only; it must not pull
+  nodes or panels back toward the upper-left.
+- Collision resolution must move entire subtrees so descendant relative
+  positions stay stable.
+- Bounds changes must continue to let the viewer fit the full visible graph.
+
+## Behavioral Scenarios (optional)
+
+```gherkin
+Feature: Deterministic expanded flow layout
+
+Scenario: Expansion order does not change final layout
+  Given the same normalized flow graph input
+  And the same set of expanded nested units
+  When the units are expanded in order A then B
+  And the layout is built again for the same expanded set in order B then A
+  Then `positionOverrides` are identical
+  And `nodeDecorations` are identical
+
+Scenario: Expanded sibling subtrees avoid overlap
+  Given a visible flow graph with expanded sibling subtrees in one container
+  When expanded layout is built
+  Then expanded panels do not overlap each other
+  And expanded panels do not overlap visible nodes from sibling subtrees
+
+Scenario: Collision resolution preserves unaffected upper-left regions
+  Given a visible flow graph with an expanded subtree
+  When collision resolution grows the occupied area of that subtree
+  Then only the affected right-side, lower-side, or lower-right scope moves
+  And unrelated upper-left nodes do not move
+```
+
+## Architecture
+
+- Domain:
+  none
+- Application:
+  the flow-graph use case owns deterministic graph content and expansion-state
+  outputs that presentation can render predictably
+- Presentation:
+  `src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts` remains the
+  expanded-layout orchestration point for UI-local coordinates, but it must
+  rebuild layout from the expanded set, delegate occupied-box and collision
+  calculations to focused helpers, and avoid order-sensitive
+  `activeExpandedUnitId` collision decisions
+- Infrastructure:
+  none
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected callers, components, commands, adapters, tests, and docs:
+  flow-viewer expanded layout calculation, flow-viewer rendering/fit behavior,
+  search/reveal regression coverage, and SDD documents
+- Propagation decision:
+  preserve graph DTO shape and viewer contracts while tightening the expanded
+  layout algorithm around deterministic occupied-box resolution
+
+### Breaking Change Analysis
+
+- User-visible behavior:
+  nested expansion layout becomes deterministic and non-overlapping by
+  contract
+- API/DTO/schema compatibility:
+  no DTO shape change is intended; only the meaning of layout outputs is
+  tightened
+- VS Code/web extension compatibility:
+  must remain unchanged
+- Changed scenarios:
+  add deterministic expanded-layout scenarios to the flow-graph use case
+
+### Alternative Considerations
+
+- Keep order-sensitive layout and patch collisions incrementally:
+  rejected because identical expanded sets can still produce different layouts
+- Recompute by active expansion path only:
+  rejected because it preserves the current order dependence
+- Rewrite the entire flow viewer:
+  rejected because the required change is layout determinism, not a broader UI
+  redesign
+
+### Approval Impact Decisions
+
+- Approval evidence owner:
+  TASKS.md `Human Approval`
+- Scope changes requiring re-approval:
+  DTO shape changes, search/reveal/fitView behavior changes, non-doc changes
+  outside expanded-flow layout and its tests, dependency upgrades, or
+  `engines.vscode` changes
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility:
+  deterministic layout logic must stay browser-safe
+- Desktop extension compatibility:
+  flow-viewer rendering, search, reveal, and fit behavior must remain stable
+- Model, Serena, or agent choice does not change this behavior contract or the
+  SDD approval gate.
+
+## Acceptance Criteria
+
+- The flow-graph use case documents deterministic expansion ordering,
+  occupied-rectangle semantics, subtree-based collision resolution, and
+  fit-view continuity.
+- The implementation plan names `LayoutBox`, `LayoutItem`, occupied-box
+  calculation, container collision resolution, subtree moves, and regression
+  coverage for order independence and non-overlap.
+- Future implementation must prove that A→B and B→A expansion sequences
+  produce identical `positionOverrides` and `nodeDecorations`.
+
+## Non-Goals
+
+- ReactFlow component redesign
+- Search or reveal feature expansion
+- Parser or normalized-model changes
+- Left/up compaction or layout minimization beyond the approved right/down
+  collision policy
+
+## Open Questions
+
+- None

--- a/docs/specs/features/flow-layout-determinism/TASKS.md
+++ b/docs/specs/features/flow-layout-determinism/TASKS.md
@@ -1,0 +1,61 @@
+# TASKS: flow-layout-determinism
+
+## Sync Rule
+
+- Update this file in the same commit whenever a task is completed, re-scoped,
+  or intentionally dropped.
+- Update `docs/specs/plans.md` or `docs/specs/roadmap.md` in the same commit
+  when branch priorities or repository sequencing change.
+- Keep this file focused on current state only; do not retain historical logs,
+  prior approvals, or long validation diaries once they stop being actionable.
+
+## Current Status
+
+- Runtime status:
+  investigation is recorded, but implementation has not started.
+- Active slice:
+  docs-only specification update for deterministic expanded-flow layout.
+- Open follow-up:
+  request implementation approval after the deterministic layout scope and
+  test expectations are accepted.
+
+## Human Approval
+
+- Status: Pending
+- Approved at:
+- Approved scope:
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
+
+Reset this section back to Pending when the approved slice is complete and no
+active implementation approval remains.
+
+## Active Tasks
+
+- [x] Impact investigation completed and recorded in PLANS/SPECS/TASKS by
+      responsibility.
+- [ ] Record human approval for runtime implementation of deterministic
+      expanded-flow layout.
+- [ ] Add `LayoutBox`, `LayoutItem`, and occupied-box calculation in the
+      approved implementation slice.
+- [ ] Remove `activeExpandedUnitId`-dependent collision resolution in the
+      approved implementation slice.
+- [ ] Add container-level collision resolution for sibling subtree occupied
+      boxes in the approved implementation slice.
+- [ ] Move subtrees by one delta so descendant relative positions remain
+      stable in the approved implementation slice.
+- [ ] Add regression tests for order-independent layout, panel/node
+      non-overlap, and minimal right/down collision push in the approved
+      implementation slice.
+
+## Validation
+
+- [ ] Add or update tests where a slice changes behavior or ownership.
+- [ ] Update README or user documentation if user-facing behavior changes.
+- [ ] Run relevant validation for the approved slice.
+
+## Notes
+
+- This feature intentionally changes the documented layout contract while
+  preserving search, reveal, and fitView behavior.

--- a/docs/specs/features/flow-refactor/SPECS.md
+++ b/docs/specs/features/flow-refactor/SPECS.md
@@ -1,0 +1,129 @@
+# Feature Specification: flow-refactor
+
+## Purpose
+
+Reduce concentrated responsibilities in diagnostics and flow-viewer code by
+splitting large files into domain-aligned rule/layout modules and
+composition-root UI wiring while preserving existing behavior.
+
+## Origin
+
+- Source use cases:
+  `docs/requirements/use-cases/uc-provide-editor-feedback.md`,
+  `docs/requirements/use-cases/uc-build-flow-graph.md`,
+  `docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md`
+- Related plan:
+  `docs/specs/plans.md`
+
+## Requirements
+
+- `buildSyntaxDiagnostics.ts` must move from a large mixed rule file to
+  orchestration plus extracted rule/helper modules.
+- `buildExpandedFlowGraph.ts` must separate graph construction from expanded
+  layout adjustment responsibilities.
+- `FlowContents.tsx` must move state management, subscriptions, and DTO to
+  ReactFlow conversion into hooks or presentation components.
+- Existing diagnostics, flow expansion, search, reveal, and fit behavior must
+  remain unchanged unless a later approved slice explicitly changes them.
+- Desktop and web extension compatibility must remain explicit for every slice.
+- Slices must follow the planned order:
+  PR1 tests only, PR2 diagnostics split, PR3 expanded-flow split,
+  PR4 `FlowContents.tsx` hook extraction, PR5 cleanup and naming/export
+  consolidation.
+
+## Behavioral Scenarios (optional)
+
+No new user-visible behavior is introduced. This feature preserves the
+behavior already contracted by the related use cases while improving internal
+boundaries and sliceability.
+
+## Architecture
+
+- Domain:
+  extract rule-specific helpers from syntax-diagnostic logic where the rules
+  are pure and JP1/AJS-domain-facing
+- Application:
+  keep orchestration boundaries explicit for syntax diagnostics and expanded
+  graph building
+- Presentation:
+  split flow-viewer state, event bridge wiring, and ReactFlow element mapping
+  from `FlowContents.tsx`
+- Infrastructure:
+  no direct behavior change intended; VS Code and webview adapters stay at the
+  boundary
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected callers, components, commands, adapters, tests, and docs:
+  editor-feedback diagnostics, flow-graph construction, flow-viewer rendering
+  and interaction hooks/components, regression tests, and SDD documents
+- Propagation decision:
+  keep parser output contracts, application DTOs, VS Code adapters, and
+  visible flow-viewer behavior stable while extracting internal seams in
+  focused slices
+
+### Breaking Change Analysis
+
+- User-visible behavior:
+  none intended
+- API/DTO/schema compatibility:
+  none intended
+- VS Code/web extension compatibility:
+  must remain unchanged across shared diagnostics and flow-viewer paths
+- Changed scenarios:
+  none
+
+### Alternative Considerations
+
+- Refactor each file independently without one feature umbrella:
+  rejected because the three areas share the same maintainability objective,
+  the same validation expectations, and the same phased PR plan
+- Start with `FlowContents.tsx` hook extraction:
+  not chosen for this feature plan because the accepted slice order starts
+  with characterization tests that protect the later refactors
+- Large one-shot split across diagnostics, graph layout, and UI:
+  rejected because approval, review, and regression diagnosis become harder
+
+### Approval Impact Decisions
+
+- Approval evidence owner:
+  TASKS.md `Human Approval`
+- Scope changes requiring re-approval:
+  user-visible diagnostic text or positions, flow layout/reveal behavior
+  changes, DTO contract changes, parser changes, dependency upgrades, or
+  `engines.vscode` changes
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility:
+  shared diagnostics and flow-viewer code must stay browser-safe
+- Desktop extension compatibility:
+  editor diagnostics, flow-viewer events, and reveal behavior must stay stable
+- Model, Serena, or agent choice does not change this behavior contract or the
+  SDD approval gate.
+
+## Acceptance Criteria
+
+- The feature documents one coherent refactoring objective with five ordered
+  slices and explicit non-goals.
+- Before structural refactors, characterization tests cover diagnostic
+  messages, positions, counts, expanded-flow layout cases, and duplicate-edge
+  prevention as planned in PR1.
+- `buildSyntaxDiagnostics.ts`, `buildExpandedFlowGraph.ts`, and
+  `FlowContents.tsx` each become thinner orchestration/composition files after
+  their approved slices land.
+- All approved slices preserve current desktop and web behavior.
+
+## Non-Goals
+
+- New editor-feedback rules or new flow-viewer features
+- Parser grammar or normalized-model redesign
+- Raising the minimum supported VS Code version
+- Replacing mutable expanded-flow context with a full immutable redesign
+
+## Open Questions
+
+- None

--- a/docs/specs/features/flow-refactor/TASKS.md
+++ b/docs/specs/features/flow-refactor/TASKS.md
@@ -1,0 +1,64 @@
+# TASKS: flow-refactor
+
+## Sync Rule
+
+- Update this file in the same commit whenever a task is completed, re-scoped,
+  or intentionally dropped.
+- Update `docs/specs/plans.md` or `docs/specs/roadmap.md` in the same commit
+  when branch priorities or repository sequencing change.
+- Keep this file focused on current state only; do not retain historical logs,
+  prior approvals, or long validation diaries once they stop being actionable.
+
+## Current Status
+
+- Runtime status:
+  investigation is recorded, but implementation has not started.
+- Active slice:
+  PR1 `tests only` characterization coverage for diagnostics and expanded flow
+  behavior, pending approval.
+- Open follow-up:
+  request approval for PR1, then keep the remaining structural refactor slices
+  in the agreed PR order.
+
+## Human Approval
+
+- Status: Pending
+- Approved at:
+- Approved scope:
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
+
+Reset this section back to Pending when the approved slice is complete and no
+active implementation approval remains.
+
+## Active Tasks
+
+- [x] Impact investigation completed and recorded in PLANS/SPECS/TASKS by
+      responsibility.
+- [ ] Record human approval for PR1 `tests only`.
+- [ ] Add characterization coverage for syntax diagnostics using existing
+      sample definitions and snapshot or equivalent fixed expectations for
+      message, line, column, and count.
+- [ ] Add expanded-flow coverage for no expansion, one-level expansion,
+      multi-level expansion, upper/lower panel interference, and duplicate
+      edge prevention.
+- [ ] Complete PR2 diagnostics rule-set extraction after PR1 lands.
+- [ ] Complete PR3 expanded-flow graph/layout extraction after PR2 lands.
+- [ ] Complete PR4 `FlowContents.tsx` hook/presentation extraction after PR3
+      lands.
+- [ ] Complete PR5 cleanup, naming review, and unnecessary export reduction
+      after PR4 lands.
+
+## Validation
+
+- [ ] Add or update tests where a slice changes behavior or ownership.
+- [ ] Update README or user documentation if user-facing behavior changes.
+- [ ] Run relevant validation for the approved slice.
+
+## Notes
+
+- This feature is repository-native refactoring work and does not add a new
+  repository-level behavior contract.
+- Related behavior contracts remain in the existing editor-feedback and
+  flow-graph use cases.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -130,34 +130,36 @@ rules in `docs/specs/README.md`, not in this file.
    tracked, but defer beta exit until feedback is sufficient.
 2. Keep compatibility risk visible for every shared or extension-runtime
    change.
-3. Investigate and approve `flow-refactor` PR1 characterization tests before
+3. Record deterministic expanded-flow layout implementation approval before
+   editing runtime code or tests for `flow-layout-determinism`.
+4. Investigate and approve `flow-refactor` PR1 characterization tests before
    starting the planned diagnostics, expanded-flow, and flow-viewer refactor
    slices.
 
 ## Current Branch Plan
 
 - Branch: `docs/flow-refactor-sdd`
-- Objective: add the first SDD feature records for the planned `flow-refactor`
-  maintainability work as one umbrella feature with ordered refactoring
-  slices.
-- Status: investigation is complete for the feature definition only.
-  Implementation has not started and still requires explicit approval per
-  slice.
-- Scope: docs-only creation of `docs/specs/features/flow-refactor/`,
-  plus plan/roadmap synchronization needed to register the feature and the
-  first approval target.
+- Objective: add the second docs-only SDD record by introducing the
+  `flow-layout-determinism` feature and tightening the flow-graph use-case
+  contract for deterministic, non-overlapping nested expansion layout.
+- Status: investigation is complete for the spec update only. Runtime
+  implementation has not started and still requires explicit approval.
+- Scope: docs-only creation of `docs/specs/features/flow-layout-determinism/`
+  plus use-case, architecture, current-state, plan, and roadmap updates that
+  define the deterministic expanded-flow layout contract.
 - Out of scope: runtime code, tests, generated artifacts, configuration,
   dependency changes, and `engines.vscode`.
-- Impact summary: this branch records one repository-native refactoring
-  feature that groups diagnostics modularization, expanded-flow graph
-  separation, and `FlowContents.tsx` composition cleanup under the agreed
-  five-PR sequence. The first future implementation slice is PR1
-  characterization tests only.
-- Risks and assumptions: the feature assumes the accepted slice order is
-  stable enough to document now and that no new behavior contract is needed as
-  long as runtime behavior remains unchanged.
-- Alternatives considered: documenting three independent features was rejected
-  because the user wants one related feature sliced by PR order.
+- Impact summary: this branch now records two docs-only feature additions.
+  `flow-refactor` remains the maintainability umbrella. The new
+  `flow-layout-determinism` feature separately tightens the expanded-flow
+  behavior contract so future implementation can remove order-sensitive panel
+  overlap and recompute layout deterministically from the expanded set.
+- Risks and assumptions: the deterministic layout contract assumes right/down
+  push-only collision resolution is sufficient to avoid overlap while
+  preserving current search, reveal, and fitView behavior.
+- Alternatives considered: keeping this work inside `flow-refactor` was
+  rejected because the user wants deterministic flow layout tracked as a
+  separate feature.
 
 ## Build/Test Performance SDD
 
@@ -198,6 +200,9 @@ rules in `docs/specs/README.md`, not in this file.
   active repository-native maintainability feature for diagnostics,
   expanded-flow layout, and flow-viewer composition separation using the
   agreed five-PR slice order.
+- `docs/specs/features/flow-layout-determinism/`:
+  active repository-native feature for deterministic, non-overlapping nested
+  expansion layout in the flow viewer.
 - `docs/specs/features/qlty-driven-architecture-refactoring/`:
   active maintainability-driven architectural refactoring based on Qlty
   complexity, duplication, and code-smell findings; now eligible to resume as

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -130,37 +130,34 @@ rules in `docs/specs/README.md`, not in this file.
    tracked, but defer beta exit until feedback is sufficient.
 2. Keep compatibility risk visible for every shared or extension-runtime
    change.
-3. Resume Qlty-driven architecture refactoring Phase 0 unless another
-   repository-level priority is explicitly recorded.
+3. Investigate and approve `flow-refactor` PR1 characterization tests before
+   starting the planned diagnostics, expanded-flow, and flow-viewer refactor
+   slices.
 
 ## Current Branch Plan
 
-- Branch: `main`; a dedicated implementation branch was attempted but could
-  not be created from the sandboxed session after approval
-- Objective: finish the JP1/AJS v13 parameter-alignment feature by explicitly
-  re-scoping the remaining backlog out of the active feature and promoting the
-  next repository priority.
-- Status: investigation confirmed that no additional runtime slice remains in
-  this feature for work that both shares a manual-backed rule family, reuses
-  an existing shared seam, and closes under repository-supported
-  interpretation. The only remaining completion work is docs-only closure and
-  compression.
-- Scope: docs-only closure work across the active parameter-alignment feature,
-  limited to `docs/specs/plans.md`, `docs/specs/roadmap.md`, and the
-  feature-local alignment docs needed to mark the current supported scope
-  complete.
+- Branch: `docs/flow-refactor-sdd`
+- Objective: add the first SDD feature records for the planned `flow-refactor`
+  maintainability work as one umbrella feature with ordered refactoring
+  slices.
+- Status: investigation is complete for the feature definition only.
+  Implementation has not started and still requires explicit approval per
+  slice.
+- Scope: docs-only creation of `docs/specs/features/flow-refactor/`,
+  plus plan/roadmap synchronization needed to register the feature and the
+  first approval target.
 - Out of scope: runtime code, tests, generated artifacts, configuration,
   dependency changes, and `engines.vscode`.
-- Impact summary: the feature is now documented as complete for the current
-  repository-supported JP1/AJS v13 scope, and the remaining backlog is
-  explicitly excluded instead of being treated as open alignment debt.
-  Investigation also found that no additional runtime slice remains in this
-  feature under the user's three conditions.
-- Risks and assumptions: this closure assumes the remaining excluded topics
-  are lower value than reopening the feature around platform-dependent or
-  broader cross-parameter interpretation.
-- Alternatives considered: reopening the feature for transfer-path semantics
-  or broader cross-parameter work was rejected in favor of a clean re-scope.
+- Impact summary: this branch records one repository-native refactoring
+  feature that groups diagnostics modularization, expanded-flow graph
+  separation, and `FlowContents.tsx` composition cleanup under the agreed
+  five-PR sequence. The first future implementation slice is PR1
+  characterization tests only.
+- Risks and assumptions: the feature assumes the accepted slice order is
+  stable enough to document now and that no new behavior contract is needed as
+  long as runtime behavior remains unchanged.
+- Alternatives considered: documenting three independent features was rejected
+  because the user wants one related feature sliced by PR order.
 
 ## Build/Test Performance SDD
 
@@ -197,6 +194,10 @@ rules in `docs/specs/README.md`, not in this file.
 - `docs/specs/features/modernize-runtime-boundaries/`:
   active modernization follow-up for `UnitEntity` hash readiness and bundle
   pressure notes.
+- `docs/specs/features/flow-refactor/`:
+  active repository-native maintainability feature for diagnostics,
+  expanded-flow layout, and flow-viewer composition separation using the
+  agreed five-PR slice order.
 - `docs/specs/features/qlty-driven-architecture-refactoring/`:
   active maintainability-driven architectural refactoring based on Qlty
   complexity, duplication, and code-smell findings; now eligible to resume as

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -95,6 +95,7 @@
    - Preserve current desktop and web extension behavior while migrating.
 
 5. Use Qlty findings as architectural feedback.
+
    - Track active implementation under
      `docs/specs/features/qlty-driven-architecture-refactoring/`.
    - Phase 0 removes repository noise before structural changes.
@@ -106,6 +107,17 @@
      separation, and `FlowContents.tsx` composition cleanup behind ordered
      PR-sized slices.
    - Every slice must preserve desktop and web extension behavior.
+
+6. Make expanded flow layout deterministic.
+
+   - Track active implementation under
+     `docs/specs/features/flow-layout-determinism/`.
+   - The same selected scope and expanded-unit set must yield the same layout
+     regardless of expansion order.
+   - Expanded sibling subtrees must not overlap by node or panel occupancy.
+   - Collision resolution should push only the affected right/down scope and
+     keep unrelated upper-left regions fixed.
+   - Search, reveal, and fitView behavior must remain intact.
 
 ## Deferred / Optional Slices
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -101,6 +101,10 @@
    - Phase 1 targets flow-viewer complexity.
    - Phase 2 targets application orchestration duplication.
    - Phase 3 targets domain conditional complexity.
+   - `flow-refactor` is the current concrete repository-native slice plan for
+     those phases, bundling diagnostics modularization, expanded-flow graph
+     separation, and `FlowContents.tsx` composition cleanup behind ordered
+     PR-sized slices.
    - Every slice must preserve desktop and web extension behavior.
 
 ## Deferred / Optional Slices


### PR DESCRIPTION
## What changed
- added a new `flow-refactor` SDD feature that groups the planned diagnostics, expanded-flow, and `FlowContents.tsx` maintainability slices
- added a separate `flow-layout-determinism` SDD feature for deterministic, non-overlapping nested expansion layout
- updated the flow graph use case plus related architecture/current-state/plan/roadmap docs to capture the new layout contract and implementation responsibilities

## Why it changed
- the repository needed explicit SDD records before implementation starts on these refactors
- deterministic nested expansion layout needs its own behavior contract so future implementation can remove order-sensitive overlap handling safely

## Impact
- docs only; no runtime, test, or configuration changes
- future implementation slices now have named feature scopes, approval gates, and acceptance criteria

## Validation
- `rtk pnpm run qlty`
- `pnpm run lint:md`
