### PR TITLE
[codex] stabilize expanded flow layout fit view

### DIFF
--- a/docs/specs/features/flow-layout-determinism/TASKS.md
+++ b/docs/specs/features/flow-layout-determinism/TASKS.md
@@ -12,12 +12,13 @@
 ## Current Status
 
 - Runtime status:
-  investigation is recorded, but implementation has not started.
+  deterministic expanded-flow layout and fit-to-view follow-up implementation
+  are complete.
 - Active slice:
-  docs-only specification update for deterministic expanded-flow layout.
+  none.
 - Open follow-up:
-  request implementation approval after the deterministic layout scope and
-  test expectations are accepted.
+  watch for real-world nested layout examples that need additional collision or
+  refit coverage.
 
 ## Human Approval
 
@@ -35,25 +36,30 @@ active implementation approval remains.
 
 - [x] Impact investigation completed and recorded in PLANS/SPECS/TASKS by
       responsibility.
-- [ ] Record human approval for runtime implementation of deterministic
+- [x] Record human approval for runtime implementation of deterministic
       expanded-flow layout.
-- [ ] Add `LayoutBox`, `LayoutItem`, and occupied-box calculation in the
+- [x] Add `LayoutBox`, `LayoutItem`, and occupied-box calculation in the
       approved implementation slice.
-- [ ] Remove `activeExpandedUnitId`-dependent collision resolution in the
+- [x] Remove `activeExpandedUnitId`-dependent collision resolution in the
       approved implementation slice.
-- [ ] Add container-level collision resolution for sibling subtree occupied
+- [x] Add container-level collision resolution for sibling subtree occupied
       boxes in the approved implementation slice.
-- [ ] Move subtrees by one delta so descendant relative positions remain
+- [x] Move subtrees by one delta so descendant relative positions remain
       stable in the approved implementation slice.
-- [ ] Add regression tests for order-independent layout, panel/node
+- [x] Add regression tests for order-independent layout, panel/node
       non-overlap, and minimal right/down collision push in the approved
       implementation slice.
+- [x] Record human approval for the fit-to-view follow-up slice.
+- [x] Include expanded nested panel bounds when the flow viewer refits after
+      expansion.
+- [x] Add regression coverage for manual fit-to-view after nested expansion.
 
 ## Validation
 
-- [ ] Add or update tests where a slice changes behavior or ownership.
-- [ ] Update README or user documentation if user-facing behavior changes.
-- [ ] Run relevant validation for the approved slice.
+- [x] Add or update tests where a slice changes behavior or ownership.
+- [x] README update not required; behavior contract is covered by the
+      flow-graph use case and this feature spec.
+- [x] Run relevant validation for the approved slice.
 
 ## Notes
 

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -130,36 +130,35 @@ rules in `docs/specs/README.md`, not in this file.
    tracked, but defer beta exit until feedback is sufficient.
 2. Keep compatibility risk visible for every shared or extension-runtime
    change.
-3. Record deterministic expanded-flow layout implementation approval before
-   editing runtime code or tests for `flow-layout-determinism`.
+3. Keep deterministic expanded-flow layout and fit-to-view regression coverage
+   visible while real nested-layout examples accumulate.
 4. Investigate and approve `flow-refactor` PR1 characterization tests before
    starting the planned diagnostics, expanded-flow, and flow-viewer refactor
    slices.
 
 ## Current Branch Plan
 
-- Branch: `docs/flow-refactor-sdd`
-- Objective: add the second docs-only SDD record by introducing the
-  `flow-layout-determinism` feature and tightening the flow-graph use-case
-  contract for deterministic, non-overlapping nested expansion layout.
-- Status: investigation is complete for the spec update only. Runtime
-  implementation has not started and still requires explicit approval.
-- Scope: docs-only creation of `docs/specs/features/flow-layout-determinism/`
-  plus use-case, architecture, current-state, plan, and roadmap updates that
-  define the deterministic expanded-flow layout contract.
-- Out of scope: runtime code, tests, generated artifacts, configuration,
-  dependency changes, and `engines.vscode`.
-- Impact summary: this branch now records two docs-only feature additions.
-  `flow-refactor` remains the maintainability umbrella. The new
-  `flow-layout-determinism` feature separately tightens the expanded-flow
-  behavior contract so future implementation can remove order-sensitive panel
-  overlap and recompute layout deterministically from the expanded set.
-- Risks and assumptions: the deterministic layout contract assumes right/down
-  push-only collision resolution is sufficient to avoid overlap while
-  preserving current search, reveal, and fitView behavior.
-- Alternatives considered: keeping this work inside `flow-refactor` was
-  rejected because the user wants deterministic flow layout tracked as a
-  separate feature.
+- Branch: `codex/flow-layout-determinism`
+- Objective: implement the approved deterministic expanded-flow layout slice
+  and its React Flow standard `fitView` follow-up.
+- Status: implementation and validation are complete for the approved slices.
+- Scope: expanded-flow layout collision resolution, React Flow standard
+  `fitView` bounds support, regression tests, and SDD task/plan sync for
+  `flow-layout-determinism`.
+- Out of scope: DTO shape changes, dependency changes, `engines.vscode`
+  changes, and search/reveal/fitView behavior changes.
+- Impact summary: expanded-flow layout already removes active expansion order
+  from collision decisions, computes occupied boxes for visible sibling
+  subtrees, and keeps sibling layout stable by pushing affected right/down
+  scopes. The fit-to-view follow-up represents expanded nested panel bounds as
+  transparent React Flow group nodes so the standard `fitView` calculation can
+  include them after expansion.
+- Risks and assumptions: real-world nested layouts may reveal additional
+  collision or refit cases, but the current slices preserve desktop and web
+  extension behavior under the existing test suite and do not change graph DTO
+  shape.
+- Alternatives considered: preserving active-expanded-unit collision behavior
+  was rejected because it keeps layout dependent on expansion order.
 
 ## Build/Test Performance SDD
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -112,6 +112,12 @@
 
    - Track active implementation under
      `docs/specs/features/flow-layout-determinism/`.
+   - The first deterministic expanded-flow layout implementation slice is
+     delivered with occupied-box collision resolution and order-independent
+     regression coverage.
+   - The React Flow standard `fitView` follow-up is delivered by
+     representing expanded panel bounds as transparent React Flow group
+     nodes.
    - The same selected scope and expanded-unit set must yield the same layout
      regardless of expansion order.
    - Expanded sibling subtrees must not overlap by node or panel occupancy.

--- a/src/test/suite/AjsDocument.test.ts
+++ b/src/test/suite/AjsDocument.test.ts
@@ -14,14 +14,14 @@ suite("ajsDocument", () => {
         return "";
       },
       uri: { toString: () => "file:///sample.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
     const panel = {
       webview: {
         postMessage(message: { type: string; data: unknown }) {
           posted.push(message);
         },
       },
-    } as unknown as vscode.WebviewPanel;
+    } as vscode.WebviewPanel;
 
     readyAjsDocument(document, panel);
 
@@ -36,14 +36,14 @@ suite("ajsDocument", () => {
         return "";
       },
       uri: { toString: () => "file:///sample.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
     const panel = {
       webview: {
         postMessage(message: { type: string; data: unknown }) {
           posted.push(message);
         },
       },
-    } as unknown as vscode.WebviewPanel;
+    } as vscode.WebviewPanel;
 
     const onChange = debouncedAjsDocumentChangeFn(5);
     onChange(document, panel);

--- a/src/test/suite/ajsTableGlobalFilter.test.ts
+++ b/src/test/suite/ajsTableGlobalFilter.test.ts
@@ -20,7 +20,7 @@ const createRow = (
   value: unknown,
 ): Row<UnitListRowView> =>
   ({
-    original: { absolutePath } as UnitListRowView,
+    original: { absolutePath } as unknown as UnitListRowView,
     getValue: () => value,
   }) as unknown as Row<UnitListRowView>;
 

--- a/src/test/suite/buildExpandedFlowGraph.test.ts
+++ b/src/test/suite/buildExpandedFlowGraph.test.ts
@@ -1254,7 +1254,7 @@ suite("Build Expanded Flow Graph", () => {
     assert.ok(upperPanelBottom <= lowerPanelTop);
   });
 
-  test("does not push a lower panel origin when that lower unit is the newly expanded unit", () => {
+  test("pushes a lower panel origin consistently when expansion order changes", () => {
     const result = parseAjs(upperPanelIntrudesLowerPanelDefinition);
     assert.deepStrictEqual(result.errors, []);
     const document = normalizeAjsDocument(result.rootUnits);
@@ -1278,10 +1278,41 @@ suite("Build Expanded Flow Graph", () => {
     const lowerBefore = upperOnlyExpanded.positionOverrides.get(lowerNetId);
     const lowerAfter =
       lowerExpandedAfterUpper.positionOverrides.get(lowerNetId);
+    const upperPosition =
+      lowerExpandedAfterUpper.positionOverrides.get(upperNetId);
+    const upperDecoration =
+      lowerExpandedAfterUpper.nodeDecorations.get(upperNetId);
+    const lowerDecoration =
+      lowerExpandedAfterUpper.nodeDecorations.get(lowerNetId);
+    const lowerThenUpper = buildExpandedFlowGraph(
+      document,
+      currentUnitId,
+      [lowerNetId, upperNetId],
+      16,
+    );
 
     assert.ok(lowerBefore);
     assert.ok(lowerAfter);
-    assert.strictEqual(lowerAfter!.y, lowerBefore!.y);
+    assert.ok(upperPosition);
+    assert.ok(upperDecoration);
+    assert.ok(lowerDecoration);
+
+    const upperPanelBottom =
+      upperPosition!.y +
+      upperDecoration!.panelOffsetYPx +
+      upperDecoration!.panelHeightPx;
+    const lowerPanelTop = lowerAfter!.y + lowerDecoration!.panelOffsetYPx;
+
+    assert.ok(lowerAfter!.y > lowerBefore!.y);
+    assert.ok(upperPanelBottom <= lowerPanelTop);
+    assert.deepStrictEqual(
+      lowerExpandedAfterUpper.positionOverrides,
+      lowerThenUpper.positionOverrides,
+    );
+    assert.deepStrictEqual(
+      lowerExpandedAfterUpper.nodeDecorations,
+      lowerThenUpper.nodeDecorations,
+    );
   });
 
   test("does not apply vertical growth again when a target already has enough y offset", () => {

--- a/src/test/suite/exportCsvView.test.ts
+++ b/src/test/suite/exportCsvView.test.ts
@@ -54,7 +54,7 @@ suite("Export CSV View", () => {
           },
         ],
       }),
-    } as unknown as Table<UnitListRowView>;
+    } as Table<UnitListRowView>;
 
     const csv = exportCsvView(table);
 

--- a/src/test/suite/extensionRuntime.test.ts
+++ b/src/test/suite/extensionRuntime.test.ts
@@ -6,7 +6,7 @@ suite("Extension runtime", () => {
   test("creates MyExtension with telemetry and context", () => {
     const context = {
       subscriptions: [],
-    } as unknown as vscode.ExtensionContext;
+    } as vscode.ExtensionContext;
 
     const runtime = createExtensionRuntime(context);
 

--- a/src/test/suite/extensionSubscriptions.test.ts
+++ b/src/test/suite/extensionSubscriptions.test.ts
@@ -5,7 +5,7 @@ import { createExtensionSubscriptions } from "../../extension/bootstrap/extensio
 
 suite("Extension subscriptions", () => {
   test("creates diagnostics, hover, import, and viewer subscriptions", () => {
-    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const context = { subscriptions: [] } as vscode.ExtensionContext;
     const telemetry: TelemetryPort = {
       trackEvent() {},
       dispose() {},

--- a/src/test/suite/flowGraphView.test.ts
+++ b/src/test/suite/flowGraphView.test.ts
@@ -148,7 +148,6 @@ suite("Flow Graph View", () => {
         setCurrentUnitId: () => undefined,
       },
       {
-        nodeDecorations: new Map(),
         searchMatchedUnitIds: new Set([
           "/root/jobnet/child-net",
           "/root/jobnet/child-net/grand-net",
@@ -254,7 +253,20 @@ suite("Flow Graph View", () => {
           expandedUnitIds: new Set<string>(),
           toggleExpandedUnitId: () => undefined,
         },
-        positionOverrides: new Map(),
+        nodeDecorations: new Map([
+          [
+            "/root/jobnet/child-net",
+            {
+              panelOffsetXPx: -24,
+              panelOffsetYPx: -16,
+              panelWidthPx: 512,
+              panelHeightPx: 384,
+            },
+          ],
+        ]),
+        positionOverrides: new Map([
+          ["/root/jobnet/child-net", { x: 400, y: 144 }],
+        ]),
       },
     );
 
@@ -284,6 +296,21 @@ suite("Flow Graph View", () => {
     assert.strictEqual(nodes[1].data.hasWaitedFor, true);
     assert.strictEqual(nodes[2].data.canExpandNested, true);
     assert.strictEqual(nodes[3].data.canExpandNested, true);
+    const childNetBoundsNode = nodes.find(
+      (node) => node.id === "/root/jobnet/child-net::nested-panel-bounds",
+    );
+    assert.ok(childNetBoundsNode);
+    assert.strictEqual(childNetBoundsNode.type, "group");
+    assert.deepStrictEqual(childNetBoundsNode.position, { x: 376, y: 128 });
+    assert.strictEqual(childNetBoundsNode.width, 512);
+    assert.strictEqual(childNetBoundsNode.height, 384);
+    assert.strictEqual(childNetBoundsNode.initialWidth, 512);
+    assert.strictEqual(childNetBoundsNode.initialHeight, 384);
+    assert.strictEqual(childNetBoundsNode.style?.width, 512);
+    assert.strictEqual(childNetBoundsNode.style?.height, 384);
+    assert.strictEqual(childNetBoundsNode.selectable, false);
+    assert.strictEqual(childNetBoundsNode.draggable, false);
+    assert.strictEqual(childNetBoundsNode.connectable, false);
     assert.strictEqual(edges[0].source, "/root/jobnet");
     assert.strictEqual(edges[0].target, "/root/jobnet/job-a");
   });

--- a/src/test/suite/reportWebviewOperation.test.ts
+++ b/src/test/suite/reportWebviewOperation.test.ts
@@ -20,10 +20,10 @@ suite("Report Webview Operation", () => {
 
     const document = {
       uri: { toString: () => "file:///sample.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
     const panel = {
       viewType: "ajsbutler.tableViewer",
-    } as unknown as vscode.WebviewPanel;
+    } as vscode.WebviewPanel;
 
     reportWebviewOperation(document, panel, telemetry, "copy.csv");
 

--- a/src/test/suite/viewerFactory.test.ts
+++ b/src/test/suite/viewerFactory.test.ts
@@ -10,10 +10,6 @@ import {
   SAVE,
 } from "../../shared/webviewEvents";
 
-type ViewerFactoryDeps = {
-  createWebviewPanel: typeof vscode.window.createWebviewPanel;
-};
-
 suite("ViewerFactory", () => {
   test("reuses an existing panel before creating a new one", () => {
     const telemetry: TelemetryPort = {
@@ -24,7 +20,7 @@ suite("ViewerFactory", () => {
     const document = {
       fileName: "/tmp/sample.ajs",
       uri: { toString: () => "file:///sample.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
     let addCalled = false;
     let readyCalled = false;
     let createCalled = false;
@@ -71,7 +67,7 @@ suite("ViewerFactory", () => {
     const document = {
       fileName: "/tmp/sample.ajs",
       uri: { toString: () => "file:///sample.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
     const added: Array<{
       uri: vscode.Uri;
       panel: vscode.WebviewPanel;
@@ -123,7 +119,7 @@ suite("ViewerFactory", () => {
     const document = {
       fileName: "/tmp/sample.ajs",
       uri: { toString: () => "file:///sample.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
 
     const factory = new ViewerFactory(
       "ajsbutler.testViewer",
@@ -162,7 +158,7 @@ suite("ViewerFactory", () => {
     const document = {
       fileName: "/tmp/sample.ajs",
       uri: { toString: () => "file:///sample.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
     const panel = {
       title: "sample.ajs",
       viewType: "ajsbutler.testViewer",
@@ -183,7 +179,7 @@ suite("ViewerFactory", () => {
         onDidDispose = callback;
         return { dispose() {} };
       },
-    } as unknown as vscode.WebviewPanel;
+    } as vscode.WebviewPanel;
     const added: Array<{
       uri: vscode.Uri;
       panel: vscode.WebviewPanel;

--- a/src/test/suite/viewerWiring.test.ts
+++ b/src/test/suite/viewerWiring.test.ts
@@ -5,7 +5,7 @@ import { createViewerSubscriptions } from "../../extension/bootstrap/viewerWirin
 
 suite("Viewer wiring", () => {
   test("creates viewer subscriptions for both table and flow viewers", () => {
-    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const context = { subscriptions: [] } as vscode.ExtensionContext;
     const telemetry: TelemetryPort = {
       trackEvent() {},
       dispose() {},

--- a/src/test/suite/webviewMediator.test.ts
+++ b/src/test/suite/webviewMediator.test.ts
@@ -21,20 +21,20 @@ suite("WebviewMediator", () => {
 
     const context = {
       subscriptions: [],
-    } as unknown as vscode.ExtensionContext;
+    } as vscode.ExtensionContext;
     const document = {
       languageId: "jp1ajs",
       uri: { toString: () => "file:///sample.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
     const renamedUri = {
       toString: () => "file:///renamed.ajs",
-    } as unknown as vscode.Uri;
+    } as vscode.Uri;
     const panel = {
       title: "sample",
       dispose() {
         panelDisposed = true;
       },
-    } as unknown as vscode.WebviewPanel;
+    } as vscode.WebviewPanel;
 
     const mediator = new WebviewMediator(
       context,

--- a/src/test/suite/webviewStore.test.ts
+++ b/src/test/suite/webviewStore.test.ts
@@ -7,10 +7,10 @@ suite("WebviewStore", () => {
     const store = new WebviewStore("ajsbutler.testViewer");
     const document1 = {
       uri: { toString: () => "file:///one.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
     const document2 = {
       uri: { toString: () => "file:///two.ajs" },
-    } as unknown as vscode.TextDocument;
+    } as vscode.TextDocument;
 
     let panel1Disposed = false;
     let panel2Disposed = false;
@@ -19,13 +19,13 @@ suite("WebviewStore", () => {
       dispose() {
         panel1Disposed = true;
       },
-    } as unknown as vscode.WebviewPanel;
+    } as vscode.WebviewPanel;
     const panel2 = {
       title: "two",
       dispose() {
         panel2Disposed = true;
       },
-    } as unknown as vscode.WebviewPanel;
+    } as vscode.WebviewPanel;
 
     store.add(document1.uri, panel1);
     store.add(document2.uri, panel2);
@@ -59,7 +59,7 @@ suite("WebviewStore", () => {
     const panel = {
       title: "same",
       dispose() {},
-    } as unknown as vscode.WebviewPanel;
+    } as vscode.WebviewPanel;
 
     store.add(storedDocument.uri, panel);
     store.removeByUri(uri);

--- a/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
+++ b/src/ui-component/editor/ajsFlow/buildExpandedFlowGraph.ts
@@ -33,12 +33,20 @@ type ExpandedFlowGraphResult = {
   nodeDecorations: ReadonlyMap<string, ExpandedNodeDecoration>;
 };
 
-type FlowGraphBounds = {
+type LayoutBox = {
   minX: number;
   maxX: number;
   minY: number;
   maxY: number;
 };
+
+type LayoutItem = {
+  unit: AjsUnit;
+  position: FlowGraphPosition;
+  occupiedBox: LayoutBox;
+};
+
+type FlowGraphBounds = LayoutBox;
 
 type FlowGraphMetrics = ReturnType<typeof createFlowGraphMetrics>;
 
@@ -532,20 +540,81 @@ const doBoundsOverlapHorizontally = (
   lowerBounds: FlowGraphBounds,
 ) => upperBounds.minX < lowerBounds.maxX && lowerBounds.minX < upperBounds.maxX;
 
+const doBoundsOverlap = (left: LayoutBox, right: LayoutBox) =>
+  left.minX < right.maxX &&
+  right.minX < left.maxX &&
+  left.minY < right.maxY &&
+  right.minY < left.maxY;
+
+const buildOccupiedLayoutItem = (
+  context: ExpandedFlowGraphBuildContext,
+  unit: AjsUnit,
+): LayoutItem | undefined => {
+  const position = getDisplayPosition(context, unit.id);
+  if (!position) {
+    return undefined;
+  }
+  return {
+    unit,
+    position,
+    occupiedBox:
+      buildExpandedUnitPanelBounds(context, unit) ??
+      buildUnitBaseBounds(position, context.metrics),
+  };
+};
+
+const buildVisibleImmediateChildLayoutItems = (
+  context: ExpandedFlowGraphBuildContext,
+  containerUnitId: string,
+): LayoutItem[] =>
+  getVisibleImmediateChildren(context, containerUnitId)
+    .map((unit) => buildOccupiedLayoutItem(context, unit))
+    .filter((item): item is LayoutItem => !!item);
+
+const resolveSiblingSubtreeCollisions = (
+  context: ExpandedFlowGraphBuildContext,
+  containerUnitId: string,
+) => {
+  const layoutItems = buildVisibleImmediateChildLayoutItems(
+    context,
+    containerUnitId,
+  );
+
+  for (let targetIndex = 0; targetIndex < layoutItems.length; targetIndex++) {
+    let target = layoutItems[targetIndex];
+    for (let fixedIndex = 0; fixedIndex < targetIndex; fixedIndex++) {
+      const fixed = layoutItems[fixedIndex];
+      if (!doBoundsOverlap(fixed.occupiedBox, target.occupiedBox)) {
+        continue;
+      }
+
+      const dx =
+        fixed.position.x < target.position.x
+          ? fixed.occupiedBox.maxX - target.occupiedBox.minX
+          : 0;
+      const dy =
+        fixed.position.y < target.position.y
+          ? fixed.occupiedBox.maxY - target.occupiedBox.minY
+          : 0;
+      if (dx <= 0 && dy <= 0) {
+        continue;
+      }
+
+      addOffset(context, target.unit.id, {
+        x: Math.max(0, dx),
+        y: Math.max(0, dy),
+      });
+      target = buildOccupiedLayoutItem(context, target.unit) ?? target;
+      layoutItems[targetIndex] = target;
+    }
+  }
+};
+
 const resolveLowerExpandedPanelIntrusions = (
   context: ExpandedFlowGraphBuildContext,
   expandedChildren: ReadonlyArray<AjsUnit>,
-  activeExpandedUnitId: string | undefined,
 ) => {
-  if (!activeExpandedUnitId) {
-    return;
-  }
-
   for (const upperChild of expandedChildren) {
-    if (upperChild.id !== activeExpandedUnitId) {
-      continue;
-    }
-
     const upperPosition = getDisplayPosition(context, upperChild.id);
     const upperPanelBounds = buildExpandedUnitPanelBounds(context, upperChild);
     if (!upperPosition || !upperPanelBounds) {
@@ -584,7 +653,6 @@ const relayoutExpandedScope = (
   context: ExpandedFlowGraphBuildContext,
   containerUnit: AjsUnit,
   expandedUnitIdSet: ReadonlySet<string>,
-  activeExpandedUnitId: string | undefined,
 ) => {
   const expandedChildren = containerUnit.children
     .filter(
@@ -595,20 +663,11 @@ const relayoutExpandedScope = (
 
   for (const expandedChild of expandedChildren) {
     revealVisibleNestedUnit(context, expandedChild);
-    relayoutExpandedScope(
-      context,
-      expandedChild,
-      expandedUnitIdSet,
-      activeExpandedUnitId,
-    );
+    relayoutExpandedScope(context, expandedChild, expandedUnitIdSet);
     updateExpandedNodeDecoration(context, expandedChild);
   }
 
-  resolveLowerExpandedPanelIntrusions(
-    context,
-    expandedChildren,
-    activeExpandedUnitId,
-  );
+  resolveLowerExpandedPanelIntrusions(context, expandedChildren);
 
   const immediateVisibleChildren = getVisibleImmediateChildren(
     context,
@@ -651,6 +710,8 @@ const relayoutExpandedScope = (
       targetUnitIds,
     );
   }
+
+  resolveSiblingSubtreeCollisions(context, containerUnit.id);
 };
 
 const buildExpandedPanelBounds = (
@@ -757,9 +818,6 @@ export const buildExpandedFlowGraph = (
   };
 
   const expandedUnitIdList = [...expandedUnitIds];
-  const activeExpandedUnitId = Array.isArray(expandedUnitIds)
-    ? expandedUnitIds.at(-1)
-    : undefined;
   const expandedUnitIdSet = new Set(
     expandedUnitIdList.filter((unitId) => {
       const unit = unitById.get(unitId);
@@ -772,12 +830,7 @@ export const buildExpandedFlowGraph = (
     }),
   );
 
-  relayoutExpandedScope(
-    context,
-    currentUnit,
-    expandedUnitIdSet,
-    activeExpandedUnitId,
-  );
+  relayoutExpandedScope(context, currentUnit, expandedUnitIdSet);
 
   return {
     graph: {

--- a/src/ui-component/editor/ajsFlow/flowGraphView.ts
+++ b/src/ui-component/editor/ajsFlow/flowGraphView.ts
@@ -26,6 +26,9 @@ type CreateReactFlowDataOptions = {
   searchedUnitId?: string;
 };
 
+const nestedPanelBoundsNodeId = (unitId: string): string =>
+  `${unitId}::nested-panel-bounds`;
+
 const toNodeData = (
   node: FlowGraphNodeDto,
   unitDefinitionByPath: ReadonlyMap<string, UnitDefinitionDialogDto>,
@@ -91,6 +94,45 @@ const toEdge = (edge: FlowGraphEdgeDto): Edge => ({
   animated: edge.type === "con",
 });
 
+const toNestedPanelBoundsNode = (
+  node: Node<AjsNode>,
+): Node<AjsNode> | undefined => {
+  const nestedPanel = node.data.nestedPanel;
+  if (!nestedPanel) {
+    return undefined;
+  }
+
+  return {
+    id: nestedPanelBoundsNodeId(node.id),
+    type: "group",
+    data: { label: "" } as AjsNode,
+    position: {
+      x: node.position.x + nestedPanel.panelOffsetXPx,
+      y: node.position.y + nestedPanel.panelOffsetYPx,
+    },
+    width: nestedPanel.panelWidthPx,
+    height: nestedPanel.panelHeightPx,
+    initialWidth: nestedPanel.panelWidthPx,
+    initialHeight: nestedPanel.panelHeightPx,
+    style: {
+      width: nestedPanel.panelWidthPx,
+      height: nestedPanel.panelHeightPx,
+      opacity: 0,
+      pointerEvents: "none",
+      background: "transparent",
+      border: "none",
+    },
+    selectable: false,
+    draggable: false,
+    connectable: false,
+    focusable: false,
+    ariaRole: "presentation",
+    domAttributes: {
+      "aria-hidden": true,
+    },
+  };
+};
+
 export const createReactFlowData = (
   graph: FlowGraphDto,
   unitDefinitionByPath: ReadonlyMap<string, UnitDefinitionDialogDto>,
@@ -114,8 +156,11 @@ export const createReactFlowData = (
       options?.positionOverrides?.get(node.id) ??
       calculateFlowGraphNodePosition(node, theme.typography.htmlFontSize),
   }));
+  const nestedPanelBoundsNodes = nodes
+    .map(toNestedPanelBoundsNode)
+    .filter((node): node is Node<AjsNode> => !!node);
 
   const edges: Edge[] = graph.edges.map(toEdge);
 
-  return { nodes, edges };
+  return { nodes: [...nodes, ...nestedPanelBoundsNodes], edges };
 };


### PR DESCRIPTION
## Summary
- make expanded flow layout deterministic and remove active-expansion-order collision behavior
- keep React Flow standard fitView while representing expanded panel bounds as transparent bounds nodes with explicit size fields
- clean up related test type assertions and sync the flow-layout-determinism SDD docs

## Why
Expanded nested panels could overlap or depend on expansion order, and fit-to-view after expansion could keep targeting the pre-expansion bounds when React Flow did not have explicit node sizing information for the expanded panel area.

## Validation
- rtk pnpm run qlty
- rtk pnpm run lint:md
- rtk pnpm test -- --grep "Flow Graph View"
- rtk pnpm run test:compile
- rtk pnpm test
- rtk pnpm run test:web
- rtk pnpm run build
