### PR TITLE
[codex] Add flow refactor characterization tests

### DIFF
--- a/docs/specs/features/flow-refactor/TASKS.md
+++ b/docs/specs/features/flow-refactor/TASKS.md
@@ -12,12 +12,12 @@
 ## Current Status
 
 - Runtime status:
-  investigation is recorded, but implementation has not started.
+  PR1 characterization tests are implemented and validated.
 - Active slice:
-  PR1 `tests only` characterization coverage for diagnostics and expanded flow
-  behavior, pending approval.
+  PR2 diagnostics rule-set extraction is the next planned slice, pending fresh
+  approval.
 - Open follow-up:
-  request approval for PR1, then keep the remaining structural refactor slices
+  request approval for PR2, then keep the remaining structural refactor slices
   in the agreed PR order.
 
 ## Human Approval
@@ -36,11 +36,13 @@ active implementation approval remains.
 
 - [x] Impact investigation completed and recorded in PLANS/SPECS/TASKS by
       responsibility.
-- [ ] Record human approval for PR1 `tests only`.
-- [ ] Add characterization coverage for syntax diagnostics using existing
+- [x] Confirm current entry point is PR1 `tests only`, not a runtime flow
+      refactor.
+- [x] Record human approval for PR1 `tests only`.
+- [x] Add characterization coverage for syntax diagnostics using existing
       sample definitions and snapshot or equivalent fixed expectations for
       message, line, column, and count.
-- [ ] Add expanded-flow coverage for no expansion, one-level expansion,
+- [x] Add expanded-flow coverage for no expansion, one-level expansion,
       multi-level expansion, upper/lower panel interference, and duplicate
       edge prevention.
 - [ ] Complete PR2 diagnostics rule-set extraction after PR1 lands.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -132,33 +132,36 @@ rules in `docs/specs/README.md`, not in this file.
    change.
 3. Keep deterministic expanded-flow layout and fit-to-view regression coverage
    visible while real nested-layout examples accumulate.
-4. Investigate and approve `flow-refactor` PR1 characterization tests before
-   starting the planned diagnostics, expanded-flow, and flow-viewer refactor
-   slices.
+4. Request approval for `flow-refactor` PR2 diagnostics rule-set extraction
+   before starting structural diagnostics changes.
 
 ## Current Branch Plan
 
-- Branch: `codex/flow-layout-determinism`
-- Objective: implement the approved deterministic expanded-flow layout slice
-  and its React Flow standard `fitView` follow-up.
-- Status: implementation and validation are complete for the approved slices.
-- Scope: expanded-flow layout collision resolution, React Flow standard
-  `fitView` bounds support, regression tests, and SDD task/plan sync for
-  `flow-layout-determinism`.
-- Out of scope: DTO shape changes, dependency changes, `engines.vscode`
-  changes, and search/reveal/fitView behavior changes.
-- Impact summary: expanded-flow layout already removes active expansion order
-  from collision decisions, computes occupied boxes for visible sibling
-  subtrees, and keeps sibling layout stable by pushing affected right/down
-  scopes. The fit-to-view follow-up represents expanded nested panel bounds as
-  transparent React Flow group nodes so the standard `fitView` calculation can
-  include them after expansion.
-- Risks and assumptions: real-world nested layouts may reveal additional
-  collision or refit cases, but the current slices preserve desktop and web
-  extension behavior under the existing test suite and do not change graph DTO
-  shape.
-- Alternatives considered: preserving active-expanded-unit collision behavior
-  was rejected because it keeps layout dependent on expansion order.
+- Branch: `codex/flow-refactor-pr1-tests`
+- Objective: complete the PR1 characterization-test slice before structural
+  flow or diagnostics refactors.
+- Status: PR1 tests-only implementation and validation are complete; PR2
+  diagnostics rule-set extraction remains pending fresh human approval in
+  `docs/specs/features/flow-refactor/TASKS.md`.
+- Scope: PR1 `tests only` characterization coverage for syntax diagnostics
+  and expanded-flow behavior, with no runtime, DTO, dependency, generated
+  artifact, or configuration changes.
+- Out of scope: diagnostics rule extraction, expanded-flow graph/layout
+  extraction, `FlowContents.tsx` hook/presentation extraction, parser changes,
+  dependency updates, `engines.vscode` changes, and user-visible behavior
+  changes.
+- Impact summary: PR1 added characterization coverage only so later PR2-PR4
+  refactors can preserve diagnostic messages, positions, counts,
+  expanded-flow layout, search/reveal, fit behavior, and duplicate-edge
+  prevention. Existing code still concentrates diagnostics rules in
+  `buildSyntaxDiagnostics.ts`, expanded flow construction/layout in
+  `buildExpandedFlowGraph.ts`, and viewer state plus React Flow mapping in
+  `FlowContents.tsx`.
+- Risks and assumptions: PR1 intentionally avoids implementation cleanup; the
+  next meaningful risk is preserving all existing diagnostics behavior while
+  extracting rule-set modules in PR2.
+- Alternatives considered: starting directly with PR2/PR3 refactors remains
+  rejected because the approved feature plan calls for tests first.
 
 ## Build/Test Performance SDD
 

--- a/src/test/suite/buildExpandedFlowGraph.test.ts
+++ b/src/test/suite/buildExpandedFlowGraph.test.ts
@@ -1,7 +1,62 @@
 import * as assert from "assert";
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { AjsUnit } from "../../domain/models/ajs/AjsDocument";
 import { parseAjs } from "../../domain/services/parser/AjsParser";
 import { normalizeAjsDocument } from "../../domain/models/ajs/normalizeAjsDocument";
 import { buildExpandedFlowGraph } from "../../ui-component/editor/ajsFlow/buildExpandedFlowGraph";
+
+const readSample = (name: string): string =>
+  readFileSync(join(__dirname, "../../../sample", name), "utf8");
+
+const tryFindUnitByName = (
+  unit: AjsUnit,
+  name: string,
+): AjsUnit | undefined => {
+  if (unit.name === name) {
+    return unit;
+  }
+  for (const child of unit.children) {
+    const found = tryFindUnitByName(child, name);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+};
+
+const findUnitByName = (unit: AjsUnit, name: string): AjsUnit => {
+  const found = tryFindUnitByName(unit, name);
+  if (found) {
+    return found;
+  }
+  throw new Error(`Unit not found: ${name}`);
+};
+
+const toEdgeLabel = (edge: {
+  source: string;
+  target: string;
+  type: string;
+}): string =>
+  `${edge.source.split("/").pop()}->${edge.target.split("/").pop()}:${
+    edge.type
+  }`;
+
+const toRoundedDecoration = (
+  id: string,
+  decoration: {
+    panelOffsetXPx: number;
+    panelOffsetYPx: number;
+    panelWidthPx: number;
+    panelHeightPx: number;
+  },
+) => ({
+  id: id.split("/").pop() ?? id,
+  panelOffsetXPx: Math.round(decoration.panelOffsetXPx),
+  panelOffsetYPx: Math.round(decoration.panelOffsetYPx),
+  panelWidthPx: Math.round(decoration.panelWidthPx),
+  panelHeightPx: Math.round(decoration.panelHeightPx),
+});
 
 const nestedDefinition = `
 unit=root,,jp1admin,;
@@ -496,6 +551,161 @@ unit=root,,jp1admin,;
 `;
 
 suite("Build Expanded Flow Graph", () => {
+  test("characterizes deep sample graph summaries for collapsed and expanded states", () => {
+    const result = parseAjs(readSample("sample_ref_deep_jobnets_utf8"));
+    assert.deepStrictEqual(result.errors, []);
+    const document = normalizeAjsDocument(result.rootUnits);
+    const rootUnit = document.rootUnits[0];
+    const currentUnit = findUnitByName(rootUnit, "top_main");
+    const expandedUnitNames = [
+      "branch_alpha",
+      "alpha_nested_1",
+      "branch_beta",
+      "branch_gamma",
+    ];
+    const expandedUnitIds = new Set(
+      expandedUnitNames.map((name) => findUnitByName(rootUnit, name).id),
+    );
+
+    const collapsed = buildExpandedFlowGraph(
+      document,
+      currentUnit.id,
+      new Set<string>(),
+      16,
+    );
+    const expanded = buildExpandedFlowGraph(
+      document,
+      currentUnit.id,
+      expandedUnitIds,
+      16,
+    );
+
+    assert.ok(collapsed.graph);
+    assert.ok(expanded.graph);
+    assert.deepStrictEqual(
+      {
+        nodeCount: collapsed.graph.nodes.length,
+        edgeCount: collapsed.graph.edges.length,
+        positionCount: collapsed.positionOverrides.size,
+        decorationCount: collapsed.nodeDecorations.size,
+        labels: collapsed.graph.nodes.map((node) => node.label).sort(),
+        edgeLabels: collapsed.graph.edges.map(toEdgeLabel).sort(),
+      },
+      {
+        nodeCount: 12,
+        edgeCount: 10,
+        positionCount: 12,
+        decorationCount: 0,
+        labels: [
+          "branch_alpha",
+          "branch_beta",
+          "branch_delta",
+          "branch_gamma",
+          "top_left_a",
+          "top_left_b",
+          "top_main",
+          "top_mid_a",
+          "top_mid_b",
+          "top_right_a",
+          "top_right_b",
+          "viewer_root",
+        ],
+        edgeLabels: [
+          "branch_alpha->branch_gamma:con",
+          "branch_alpha->top_mid_a:seq",
+          "branch_beta->branch_delta:con",
+          "branch_beta->top_right_a:seq",
+          "branch_delta->top_right_b:seq",
+          "branch_gamma->top_mid_b:seq",
+          "top_left_a->branch_alpha:seq",
+          "top_left_b->branch_gamma:seq",
+          "top_mid_a->branch_beta:seq",
+          "top_mid_b->branch_delta:seq",
+        ],
+      },
+    );
+
+    const expandedEdgeLabels = expanded.graph.edges.map(toEdgeLabel).sort();
+    assert.strictEqual(
+      new Set(expandedEdgeLabels).size,
+      expandedEdgeLabels.length,
+    );
+    assert.deepStrictEqual(
+      {
+        nodeCount: expanded.graph.nodes.length,
+        edgeCount: expanded.graph.edges.length,
+        positionCount: expanded.positionOverrides.size,
+        decorationCount: expanded.nodeDecorations.size,
+        decorations: Array.from(expanded.nodeDecorations)
+          .map(([id, decoration]) => toRoundedDecoration(id, decoration))
+          .sort((left, right) => left.id!.localeCompare(right.id!)),
+        keyPositions: [
+          "branch_alpha",
+          "alpha_nested_1",
+          "alpha1_deep",
+          "top_mid_a",
+          "branch_beta",
+          "top_right_a",
+          "branch_gamma",
+          "top_mid_b",
+          "branch_delta",
+          "top_right_b",
+        ].map((name) => [
+          name,
+          expanded.positionOverrides.get(findUnitByName(rootUnit, name).id),
+        ]),
+      },
+      {
+        nodeCount: 31,
+        edgeCount: 25,
+        positionCount: 31,
+        decorationCount: 4,
+        decorations: [
+          {
+            id: "alpha_nested_1",
+            panelOffsetXPx: -29,
+            panelOffsetYPx: -19,
+            panelWidthPx: 634,
+            panelHeightPx: 389,
+          },
+          {
+            id: "branch_alpha",
+            panelOffsetXPx: -29,
+            panelOffsetYPx: -19,
+            panelWidthPx: 1354,
+            panelHeightPx: 989,
+          },
+          {
+            id: "branch_beta",
+            panelOffsetXPx: -29,
+            panelOffsetYPx: -19,
+            panelWidthPx: 874,
+            panelHeightPx: 749,
+          },
+          {
+            id: "branch_gamma",
+            panelOffsetXPx: -29,
+            panelOffsetYPx: -19,
+            panelWidthPx: 874,
+            panelHeightPx: 389,
+          },
+        ],
+        keyPositions: [
+          ["branch_alpha", { x: 272, y: 312 }],
+          ["alpha_nested_1", { x: 512, y: 552 }],
+          ["alpha1_deep", { x: 752, y: 792 }],
+          ["top_mid_a", { x: 1712, y: 312 }],
+          ["branch_beta", { x: 1952, y: 312 }],
+          ["top_right_a", { x: 2912, y: 312 }],
+          ["branch_gamma", { x: 272, y: 1512 }],
+          ["top_mid_b", { x: 1712, y: 1512 }],
+          ["branch_delta", { x: 1952, y: 1512 }],
+          ["top_right_b", { x: 2912, y: 1512 }],
+        ],
+      },
+    );
+  });
+
   test("reveals nested jobnets only after their parent scope is expanded", () => {
     const result = parseAjs(nestedDefinition);
     assert.deepStrictEqual(result.errors, []);

--- a/src/test/suite/buildSyntaxDiagnostics.test.ts
+++ b/src/test/suite/buildSyntaxDiagnostics.test.ts
@@ -2,6 +2,91 @@ import * as assert from "assert";
 import { buildSyntaxDiagnostics } from "../../application/editor-feedback/buildSyntaxDiagnostics";
 
 suite("Build Syntax Diagnostics", () => {
+  test("characterizes mixed diagnostic summaries across parser and domain rules", () => {
+    const diagnostics = buildSyntaxDiagnostics(
+      [
+        "unit=root,,jp1admin,;",
+        "{",
+        "  ty=g;",
+        "  st=145,+48:00;",
+        "  el=jobnet,n,+0+0;",
+        "  el=event,evsj,+240+0;",
+        "  el=wait,evwj,+480+0;",
+        "  unit=jobnet,,jp1admin,;",
+        "  {",
+        "    ty=n;",
+        "    ln=0,145;",
+        "  }",
+        "  unit=event,,jp1admin,;",
+        "  {",
+        "    ty=evsj;",
+        "    evsrt=y;",
+        "    evsid=zz;",
+        "  }",
+        "  unit=wait,,jp1admin,;",
+        "  {",
+        "    ty=evwj;",
+        "    evuid=2147483648;",
+        "    evwms=bare;",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepStrictEqual(
+      diagnostics.map((diagnostic) => ({
+        line: diagnostic.line,
+        column: diagnostic.column,
+        length: diagnostic.length,
+        severity: diagnostic.severity,
+        message: diagnostic.message,
+      })),
+      [
+        {
+          line: 4,
+          column: 2,
+          length: 2,
+          severity: "error",
+          message:
+            "Start time (st) must use schedule rule numbers 1..144 and times between 00:00 and 47:59.",
+        },
+        {
+          line: 11,
+          column: 4,
+          length: 2,
+          severity: "error",
+          message:
+            "Parent schedule rule (ln) must use schedule rule numbers between 1 and 144.",
+        },
+        {
+          line: 17,
+          column: 4,
+          length: 5,
+          severity: "error",
+          message:
+            "Event ID (evsid) must be hexadecimal within 00000000-00001FFF or 7FFF8000-7FFFFFFF.",
+        },
+        {
+          line: 16,
+          column: 4,
+          length: 5,
+          severity: "error",
+          message:
+            "Event arrival check (evsrt=y) requires an event destination host (evhst).",
+        },
+        {
+          line: 23,
+          column: 4,
+          length: 5,
+          severity: "error",
+          message:
+            "Event message filter (evwms) must be a quoted string between 1 and 1024 bytes.",
+        },
+      ],
+    );
+  });
+
   test("returns parser errors as UI-independent diagnostics", () => {
     const diagnostics = buildSyntaxDiagnostics(
       "unit=root,,jp1admin,;\n{\n  ty=g\n}\n",


### PR DESCRIPTION
## Summary

- add PR1 characterization coverage for flow-refactor diagnostics behavior
- add deep expanded-flow graph summary coverage using the existing sample fixture
- sync SDD task and plan state so PR2 diagnostics extraction is the next approval-gated slice

## Impact

This PR is tests-only for runtime behavior. It fixes expected behavior in place before the later flow-refactor slices split diagnostics rules, expanded-flow layout code, and flow viewer composition.

## Validation

- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`

`rtk pnpm run build` completed with existing webpack asset-size warnings.
