### PR TITLE
Refactor flow viewer PR4 composition

### DIFF
--- a/docs/specs/features/flow-refactor/SPECS.md
+++ b/docs/specs/features/flow-refactor/SPECS.md
@@ -94,6 +94,39 @@ boundaries and sliceability.
   user-visible diagnostic text or positions, flow layout/reveal behavior
   changes, DTO contract changes, parser changes, dependency upgrades, or
   `engines.vscode` changes
+- PR4 approval-sensitive scope:
+  `FlowContents.tsx` hook/presentation extraction may move flow-viewer
+  state, EventBridge subscriptions, search/reveal handlers, fit-to-view
+  scheduling, and ReactFlow data preparation into presentation-local hooks or
+  support modules. It must preserve existing component props, graph DTO
+  contracts, search/reveal behavior, nested-expansion behavior, current unit
+  selection, dialog behavior, desktop/web host assumptions, package
+  configuration, and `engines.vscode`.
+
+### PR4 Impact Investigation
+
+- Primary target:
+  `src/ui-component/editor/ajsFlow/FlowContents.tsx`
+- Direct type/import dependents:
+  `AjsFlowViewerApp.tsx`, `FlowSelector.tsx`, `FlowMenu.tsx`, `Header.tsx`,
+  `flowGraphView.ts`, and `nodes/AjsNode.tsx`
+- Flow behavior dependencies:
+  `buildExpandedFlowGraph.ts`, `flowGraphView.ts`, `flowSearch.ts`,
+  `nestedExpansion.ts`, and `revealUnit.ts`
+- Test impact:
+  existing flow-graph, expanded-flow, flow-search, nested-expansion,
+  flow-view mapping, desktop extension, and web smoke tests remain the
+  validation net. Add focused tests only if extraction creates a pure helper
+  with behavior that is not already covered.
+- Boundary decision:
+  keep extracted code under the flow-viewer presentation area for PR4. Do not
+  move React, XyFlow, EventBridge, or DOM scheduling responsibilities into
+  domain/application layers.
+- Breaking-change risk:
+  low-to-medium internal refactor risk, concentrated around stale React
+  callback dependencies, fit-to-view timing, search preservation across reveal
+  and scope changes, and exported state-type churn for node/header/selector
+  dependents.
 
 ## Compatibility
 

--- a/docs/specs/features/flow-refactor/TASKS.md
+++ b/docs/specs/features/flow-refactor/TASKS.md
@@ -12,13 +12,14 @@
 ## Current Status
 
 - Runtime status:
-  PR3 expanded-flow graph/layout extraction is implemented and validated.
+  PR4 `FlowContents.tsx` hook/presentation extraction is implemented and
+  validated and is ready for PR.
 - Active slice:
-  PR4 `FlowContents.tsx` hook/presentation extraction is the next planned
-  slice, pending fresh approval.
+  none on this branch; PR5 cleanup, naming review, and unnecessary export
+  reduction remains the next planned slice on a future approved scope.
 - Open follow-up:
-  request approval for PR4, then keep the remaining structural refactor slices
-  in the agreed PR order.
+  request approval for PR5 before editing runtime code/tests/configuration
+  beyond the completed PR4 scope.
 
 ## Human Approval
 
@@ -48,8 +49,14 @@ active implementation approval remains.
 - [x] Complete PR2 diagnostics rule-set extraction after PR1 lands.
 - [x] Complete PR2 support-module decomposition follow-up.
 - [x] Complete PR3 expanded-flow graph/layout extraction after PR2 lands.
-- [ ] Complete PR4 `FlowContents.tsx` hook/presentation extraction after PR3
-      lands.
+- [x] Refresh PR4 impact investigation for `FlowContents.tsx`
+      hook/presentation extraction and direct type/import dependents.
+- [x] Record human approval for PR4 before creating an implementation branch
+      or editing runtime code/tests/configuration.
+- [x] Complete PR4 `FlowContents.tsx` hook/presentation extraction after PR3
+      lands and PR4 approval is recorded.
+- [x] Fix PR4 flow-node display regression where identical name/comment values
+      rendered duplicate text below expandable nodes.
 - [ ] Complete PR5 cleanup, naming review, and unnecessary export reduction
       after PR4 lands.
 
@@ -60,6 +67,9 @@ active implementation approval remains.
 - [x] Confirm README or user documentation does not need updates because PR2
       changes internal structure only.
 - [x] Run relevant validation for the approved slice.
+- [x] Confirm PR4 preserved desktop and web flow-viewer build/test paths.
+- [x] Confirm duplicate name/comment display regression coverage and
+      validation.
 
 ## Notes
 

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -132,37 +132,44 @@ rules in `docs/specs/README.md`, not in this file.
    change.
 3. Keep deterministic expanded-flow layout and fit-to-view regression coverage
    visible while real nested-layout examples accumulate.
-4. Request approval for `flow-refactor` PR4 `FlowContents.tsx`
-   hook/presentation extraction before starting flow-viewer composition
-   changes.
+4. Request approval for `flow-refactor` PR5 cleanup, naming review, and
+   unnecessary export reduction before starting the final flow-refactor
+   cleanup slice.
 
 ## Current Branch Plan
 
-- Branch: `codex/flow-refactor-pr3-expanded-flow`
-- Objective: complete the PR3 expanded-flow graph/layout extraction after PR2
-  diagnostics decomposition.
+- Branch: `codex/flow-refactor-pr4-flowcontents-hooks`
+- Objective: complete PR4 `FlowContents.tsx` hook/presentation extraction
+  after PR3 expanded-flow graph/layout extraction.
 - Status: PR3 expanded-flow graph/layout extraction is implemented and
-  validated. PR4 `FlowContents.tsx` hook/presentation extraction is the next
-  planned slice, pending fresh approval in
-  `docs/specs/features/flow-refactor/TASKS.md`.
-- Scope delivered: split expanded-flow result/build context types,
+  validated. PR4 `FlowContents.tsx` hook/presentation extraction is
+  implemented, validated, and ready for PR. PR5 cleanup, naming review, and
+  unnecessary export reduction is the next planned slice, pending fresh
+  approval.
+- Prior scope delivered: split expanded-flow result/build context types,
   nested-node/edge projection helpers, and expanded layout/collision
   orchestration out of `buildExpandedFlowGraph.ts` while keeping the public
   `buildExpandedFlowGraph` entry point, graph DTO shape, expanded layout
   outputs, search/reveal/fit behavior, package configuration, and
   `engines.vscode` unchanged.
+- PR4 delivered scope: extracted flow-viewer state, EventBridge subscriptions,
+  search/reveal handlers, fit-to-view scheduling, and ReactFlow data
+  preparation from `FlowContents.tsx` into presentation-local hooks or support
+  modules while preserving existing user-visible behavior and contracts.
 - Out of scope: new flow-viewer behavior, parser changes, diagnostics changes,
-  `FlowContents.tsx` hook/presentation extraction, dependency updates,
-  `engines.vscode` changes, and user-visible behavior changes.
-- Impact summary: `buildExpandedFlowGraph.ts` now prepares the base graph and
-  delegates nested expansion layout to focused presentation-local modules.
-  `expandedFlowGraphTypes.ts` owns shared result/context/layout types,
-  `expandedFlowGraphNodes.ts` owns nested node and edge DTO projection, and
-  `expandedFlowGraphLayout.ts` owns expansion reveal, occupied bounds,
-  collision resolution, offsets, and panel decoration calculation.
-- Risks and assumptions: validation covered desktop and web flow-viewer build
-  paths plus expanded-flow regression tests; webpack bundle-size warnings
-  remain pre-existing build warnings.
+  graph DTO changes, dependency updates, `engines.vscode` changes,
+  configuration changes, and user-visible behavior changes.
+- Impact summary: `FlowContents.tsx` currently owns viewer state, selected
+  scope preservation, nested expansion, search/reveal state, document-change
+  subscription, DOM overflow setup, ReactFlow fit scheduling, and ReactFlow
+  node/edge preparation. Direct dependents import the component or its state
+  types from `AjsFlowViewerApp.tsx`, `FlowSelector.tsx`, `FlowMenu.tsx`,
+  `Header.tsx`, `flowGraphView.ts`, and `nodes/AjsNode.tsx`.
+- Risks and assumptions: PR4 should stay inside presentation-local flow-viewer
+  modules. Main risks are React dependency drift, search preservation during
+  reveal/scope changes, fit-to-view timing, and exported state-type churn.
+  Validation covered desktop and web flow-viewer build/test paths; webpack
+  bundle-size warnings remain pre-existing build warnings.
 - Alternatives considered: combining PR3 with `FlowContents.tsx` hook
   extraction remains rejected because PR4 is a separate reviewable slice in the
   agreed plan.

--- a/src/test/suite/flowNodeDisplay.test.ts
+++ b/src/test/suite/flowNodeDisplay.test.ts
@@ -1,0 +1,22 @@
+import * as assert from "assert";
+import { shouldRenderNodeComment } from "../../ui-component/editor/ajsFlow/nodes/AjsNode";
+
+suite("flow node display", () => {
+  test("does not render duplicate comments matching the label", () => {
+    assert.strictEqual(
+      shouldRenderNodeComment("branch_beta", "branch_beta"),
+      false,
+    );
+  });
+
+  test("renders distinct comments", () => {
+    assert.strictEqual(shouldRenderNodeComment("branch_beta", "comment"), true);
+  });
+
+  test("does not render empty comments", () => {
+    assert.strictEqual(
+      shouldRenderNodeComment("branch_beta", undefined),
+      false,
+    );
+  });
+});

--- a/src/ui-component/editor/ajsFlow/FlowContents.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowContents.tsx
@@ -1,14 +1,4 @@
-import React, {
-  useCallback,
-  Dispatch,
-  FC,
-  memo,
-  SetStateAction,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { FC, memo, useMemo } from "react";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
@@ -18,26 +8,12 @@ import {
   Background,
   BackgroundVariant,
   Controls,
-  Edge,
   MiniMap,
-  Node,
   NodeTypes,
   ReactFlow,
-  ReactFlowInstance,
   ReactFlowProvider,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import {
-  AjsDocument,
-  flattenAjsUnits,
-  findRootJobnet,
-} from "../../../domain/models/ajs/AjsDocument";
-import {
-  buildUnitDefinitionByPath,
-  UnitDefinitionDialogDto,
-} from "../../../application/unit-definition/buildUnitDefinition";
-import { UnitListDocumentDto } from "../../../application/unit-list/unitListDocument";
-import { toAjsDocument } from "../../../application/unit-list/unitListDocumentView";
 import UnitEntityDialog from "../UnitEntityDialog";
 import JobNode from "./nodes/JobNode";
 import JobNetNode from "./nodes/JobNetNode";
@@ -45,19 +21,7 @@ import JobGroupNode from "./nodes/JobGroupNode";
 import ConditionNode from "./nodes/ConditionNode";
 import Header from "./Header";
 import FlowSelector from "./FlowSelector";
-import { buildExpandedFlowGraph } from "./buildExpandedFlowGraph";
-import { createReactFlowData } from "./flowGraphView";
-import {
-  collapseExpandedNestedUnitIds,
-  collectExpandableNestedUnitIds,
-  hasExpandedAllNestedUnitIds,
-} from "./nestedExpansion";
-import { findFlowSearchResult } from "./flowSearch";
-import { REVEAL_UNIT } from "../../../shared/webviewEvents";
-import {
-  getRevealUnitAbsolutePath,
-  resolveFlowRevealTarget,
-} from "../revealUnit";
+import { useFlowContentsController } from "./useFlowContentsController";
 
 const defaultViewport = { x: 0, y: 0, zoom: 1.0 };
 
@@ -68,147 +32,10 @@ const nodeTypes: NodeTypes = {
   condition: ConditionNode,
 };
 
-export type DialogDataStateType = {
-  dialogData?: UnitDefinitionDialogDto;
-  setDialogData: Dispatch<SetStateAction<UnitDefinitionDialogDto | undefined>>;
-};
-
-type FlowMenuStatusType = {
-  menuItem1: boolean;
-};
-export type FlowMenuStateType = {
-  menuStatus: FlowMenuStatusType;
-  setMenuStatus: Dispatch<SetStateAction<FlowMenuStatusType>>;
-};
-export type DrawerWidthStateType = {
-  drawerWidth: number;
-  setDrawerWidth: Dispatch<SetStateAction<number>>;
-};
-export type CurrentUnitIdStateType = {
-  currentUnitId?: string;
-  setCurrentUnitId: Dispatch<SetStateAction<string | undefined>>;
-};
-export type NestedExpansionStateType = {
-  expandedUnitIds: ReadonlySet<string>;
-  toggleExpandedUnitId: (unitId: string) => void;
-};
-
 const FlowContents: FC = () => {
   console.log("render FlowContents.");
 
   const { isDarkMode } = useMyAppContext();
-
-  const [menuStatus, setMenuStatus] = useState<FlowMenuStatusType>({
-    menuItem1: true,
-  });
-  const [drawerWidth, setDrawerWidth] = useState<number>(0);
-
-  const [ajsDocument, setAjsDocument] = useState<AjsDocument>();
-  const [currentUnitId, setCurrentUnitId] = useState<string>();
-  const [expandedUnitIds, setExpandedUnitIds] = useState<string[]>([]);
-  const [searchedUnitId, setSearchedUnitId] = useState<string>();
-  const [searchMatchedUnitIds, setSearchMatchedUnitIds] = useState<string[]>(
-    [],
-  );
-  const reactFlowInstanceRef = useRef<ReactFlowInstance<Node, Edge> | null>(
-    null,
-  );
-  const fitViewFrameRef = useRef<number | undefined>(undefined);
-  const preserveSearchOnNextScopeChange = useRef<boolean>(false);
-  const prevUnitEntityId = useRef<string | undefined>(undefined);
-  const [nodes, setNodes] = useState<Node[]>([]);
-  const [edges, setEdges] = useState<Edge[]>([]);
-  const [dialogData, setDialogData] = useState<
-    UnitDefinitionDialogDto | undefined
-  >();
-  const allUnits = useMemo(
-    () => (ajsDocument ? flattenAjsUnits(ajsDocument.rootUnits) : []),
-    [ajsDocument],
-  );
-  const unitById = useMemo(
-    () => new Map(allUnits.map((unit) => [unit.id, unit])),
-    [allUnits],
-  );
-  const unitDefinitionByPath = useMemo(
-    () =>
-      ajsDocument
-        ? buildUnitDefinitionByPath(ajsDocument)
-        : new Map<string, UnitDefinitionDialogDto>(),
-    [ajsDocument],
-  );
-  const currentUnit = useMemo(
-    () => (currentUnitId ? unitById.get(currentUnitId) : undefined),
-    [currentUnitId, unitById],
-  );
-  const toggleExpandedUnitId = useCallback(
-    (unitId: string) => {
-      setExpandedUnitIds((prev) => {
-        if (!prev.includes(unitId)) {
-          return [...prev, unitId];
-        }
-
-        return collapseExpandedNestedUnitIds(
-          prev,
-          unitId,
-          unitById.get(unitId),
-        );
-      });
-    },
-    [unitById],
-  );
-  const expandedUnitIdSet = useMemo(
-    () => new Set(expandedUnitIds),
-    [expandedUnitIds],
-  );
-  const expandableNestedUnitIds = useMemo(
-    () => collectExpandableNestedUnitIds(currentUnit),
-    [currentUnit],
-  );
-  const hasExpandedAllNestedUnits = useMemo(
-    () =>
-      hasExpandedAllNestedUnitIds(expandableNestedUnitIds, expandedUnitIdSet),
-    [expandableNestedUnitIds, expandedUnitIdSet],
-  );
-  const toggleExpandAllNestedUnits = useCallback(() => {
-    if (expandableNestedUnitIds.length === 0) {
-      return;
-    }
-    setExpandedUnitIds((prev) => {
-      const prevSet = new Set(prev);
-      if (hasExpandedAllNestedUnitIds(expandableNestedUnitIds, prevSet)) {
-        return prev.filter(
-          (unitId) => !expandableNestedUnitIds.includes(unitId),
-        );
-      }
-      const next = new Set(prev);
-      for (const unitId of expandableNestedUnitIds) {
-        next.add(unitId);
-      }
-      return [...next];
-    });
-  }, [expandableNestedUnitIds]);
-  const nestedExpansionState = useMemo<NestedExpansionStateType>(
-    () => ({
-      expandedUnitIds: expandedUnitIdSet,
-      toggleExpandedUnitId,
-    }),
-    [expandedUnitIdSet, toggleExpandedUnitId],
-  );
-
-  const currentUnitIdState = useMemo<CurrentUnitIdStateType>(
-    () => ({
-      currentUnitId,
-      setCurrentUnitId,
-    }),
-    [currentUnitId],
-  );
-  const dialogDataState = useMemo<DialogDataStateType>(
-    () => ({
-      dialogData,
-      setDialogData,
-    }),
-    [dialogData],
-  );
 
   const theme = useMemo(
     () =>
@@ -220,203 +47,27 @@ const FlowContents: FC = () => {
     [isDarkMode],
   );
 
-  const updateNodesAndEdges = useCallback(
-    (selectedUnitId?: string) => {
-      if (!selectedUnitId) {
-        setNodes(() => []);
-        setEdges(() => []);
-        return;
-      }
-      if (!ajsDocument) {
-        setNodes(() => []);
-        setEdges(() => []);
-        return;
-      }
-      const { graph, positionOverrides, nodeDecorations } =
-        buildExpandedFlowGraph(
-          ajsDocument,
-          selectedUnitId,
-          expandedUnitIds,
-          theme.typography.htmlFontSize,
-        );
-      if (!graph) {
-        setNodes(() => []);
-        setEdges(() => []);
-        return;
-      }
-      const { nodes, edges } = createReactFlowData(
-        graph,
-        unitDefinitionByPath,
-        theme,
-        dialogDataState,
-        currentUnitIdState,
-        {
-          nodeDecorations,
-          searchMatchedUnitIds: new Set(searchMatchedUnitIds),
-          searchedUnitId,
-          unitById,
-          nestedExpansionState,
-          positionOverrides,
-        },
-      );
-      setNodes(() => nodes);
-      setEdges(() => edges);
-    },
-    [
-      ajsDocument,
-      currentUnitIdState,
-      dialogDataState,
-      expandedUnitIds,
-      nestedExpansionState,
-      theme,
-      unitDefinitionByPath,
-      unitById,
-      searchMatchedUnitIds,
-      searchedUnitId,
-    ],
-  );
-
-  const handleSearchSubmit = useCallback(
-    (query: string) => {
-      const result = findFlowSearchResult(currentUnit, query, unitById);
-      if (!result) {
-        setSearchedUnitId(undefined);
-        setSearchMatchedUnitIds([]);
-        return;
-      }
-
-      setExpandedUnitIds((prev) => {
-        const next = new Set(prev);
-        for (const unitId of result.expandedAncestorUnitIds) {
-          next.add(unitId);
-        }
-        return [...next];
-      });
-      setSearchMatchedUnitIds(result.matchedUnitIds);
-      setSearchedUnitId(result.matchedUnitId);
-    },
-    [currentUnit, unitById],
-  );
-  const handleSearchClear = useCallback(() => {
-    setSearchedUnitId(undefined);
-    setSearchMatchedUnitIds([]);
-  }, []);
-
-  const handleRevealUnit = useCallback(
-    (absolutePath: string) => {
-      const revealTarget = resolveFlowRevealTarget(unitById, absolutePath);
-      if (!revealTarget) {
-        return;
-      }
-      preserveSearchOnNextScopeChange.current = true;
-      setExpandedUnitIds(revealTarget.expandedAncestorUnitIds);
-      setCurrentUnitId(revealTarget.scopeUnitId);
-      setSearchMatchedUnitIds([revealTarget.revealedUnitId]);
-      setSearchedUnitId(revealTarget.revealedUnitId);
-    },
-    [unitById],
-  );
-
-  useEffect(() => {
-    updateNodesAndEdges(currentUnitId);
-    prevUnitEntityId.current = currentUnitId;
-  }, [currentUnitId, updateNodesAndEdges]);
-
-  useEffect(() => {
-    if (!reactFlowInstanceRef.current || nodes.length === 0) {
-      return undefined;
-    }
-
-    if (fitViewFrameRef.current) {
-      window.cancelAnimationFrame(fitViewFrameRef.current);
-    }
-
-    fitViewFrameRef.current = window.requestAnimationFrame(() => {
-      void reactFlowInstanceRef.current?.fitView({ padding: 0.22 });
-      fitViewFrameRef.current = undefined;
-    });
-
-    return () => {
-      if (fitViewFrameRef.current) {
-        window.cancelAnimationFrame(fitViewFrameRef.current);
-        fitViewFrameRef.current = undefined;
-      }
-    };
-  }, [nodes, edges]);
-
-  useEffect(() => {
-    setExpandedUnitIds((prev) => (prev.length === 0 ? prev : []));
-    if (preserveSearchOnNextScopeChange.current) {
-      preserveSearchOnNextScopeChange.current = false;
-      return;
-    }
-    setSearchedUnitId(undefined);
-    setSearchMatchedUnitIds([]);
-  }, [ajsDocument, currentUnitId]);
-
-  useEffect(() => {
-    const changeDocumentFn = (type: string, data: unknown) => {
-      const nextDocument = data
-        ? toAjsDocument(data as UnitListDocumentDto)
-        : undefined;
-      setAjsDocument(() => nextDocument);
-      setCurrentUnitId(() => {
-        const x = nextDocument ? flattenAjsUnits(nextDocument.rootUnits) : [];
-        return prevUnitEntityId.current
-          ? x.find((unit) => unit.id === prevUnitEntityId.current)?.id
-          : nextDocument
-            ? findRootJobnet(nextDocument)?.id
-            : undefined;
-      });
-    };
-    window.EventBridge.addCallback("changeDocument", changeDocumentFn);
-    window.vscode.postMessage({ type: "ready" });
-    return () => {
-      window.EventBridge.removeCallback("changeDocument", changeDocumentFn);
-    };
-  }, []); // fire this when mount.
-
-  useEffect(() => {
-    const revealUnitFn = (_type: string, data: unknown) => {
-      const absolutePath = getRevealUnitAbsolutePath(data);
-      if (!absolutePath) {
-        return;
-      }
-      handleRevealUnit(absolutePath);
-    };
-    window.EventBridge.addCallback(REVEAL_UNIT, revealUnitFn);
-    return () => {
-      window.EventBridge.removeCallback(REVEAL_UNIT, revealUnitFn);
-    };
-  }, [handleRevealUnit]);
-
-  useEffect(() => {
-    const root = document.getElementById("root");
-    document.documentElement.style.overflow = "hidden";
-    document.body.style.overflow = "hidden";
-    if (root) {
-      root.style.overflow = "hidden";
-      root.style.height = "100%";
-    }
-
-    return () => {
-      document.documentElement.style.overflow = "";
-      document.body.style.overflow = "";
-      if (root) {
-        root.style.overflow = "";
-        root.style.height = "";
-      }
-    };
-  }, []);
-
-  const flowMenuState = {
-    menuStatus: menuStatus,
-    setMenuStatus: setMenuStatus,
-  };
-  const drawerWidthState = {
-    drawerWidth: drawerWidth,
-    setDrawerWidth: setDrawerWidth,
-  };
+  const {
+    ajsDocument,
+    currentUnit,
+    currentUnitIdState,
+    dialogData,
+    drawerWidth,
+    drawerWidthState,
+    edges,
+    expandableNestedUnitIds,
+    flowMenuState,
+    handleSearchClear,
+    handleSearchSubmit,
+    hasExpandedAllNestedUnits,
+    menuStatus,
+    nodes,
+    reactFlowInstanceRef,
+    searchedUnitId,
+    setDialogData,
+    toggleExpandAllNestedUnits,
+    unitById,
+  } = useFlowContentsController({ theme });
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/ui-component/editor/ajsFlow/FlowMenu.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowMenu.tsx
@@ -6,7 +6,10 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import MenuIcon from "@mui/icons-material/Menu";
 import ViewColumnIcon from "@mui/icons-material/ViewColumn";
-import { DrawerWidthStateType, FlowMenuStateType } from "./FlowContents";
+import {
+  DrawerWidthStateType,
+  FlowMenuStateType,
+} from "./flowContentStateTypes";
 import { useMyAppContext } from "../MyContexts";
 import { LocaleKeyType, localeMap } from "../../../domain/services/i18n/nls";
 

--- a/src/ui-component/editor/ajsFlow/FlowSelector.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowSelector.tsx
@@ -20,7 +20,7 @@ import {
   CurrentUnitIdStateType,
   DrawerWidthStateType,
   FlowMenuStateType,
-} from "./FlowContents";
+} from "./flowContentStateTypes";
 
 type FlowSelectorProps = {
   rootUnits: AjsUnit[];

--- a/src/ui-component/editor/ajsFlow/Header.tsx
+++ b/src/ui-component/editor/ajsFlow/Header.tsx
@@ -30,7 +30,7 @@ import {
   CurrentUnitIdStateType,
   DrawerWidthStateType,
   FlowMenuStateType,
-} from "./FlowContents";
+} from "./flowContentStateTypes";
 import { localeMap } from "../../../domain/services/i18n/nls";
 import { useMyAppContext } from "../MyContexts";
 import { AjsUnit } from "../../../domain/models/ajs/AjsDocument";

--- a/src/ui-component/editor/ajsFlow/flowContentStateTypes.ts
+++ b/src/ui-component/editor/ajsFlow/flowContentStateTypes.ts
@@ -1,0 +1,31 @@
+import { Dispatch, SetStateAction } from "react";
+import { UnitDefinitionDialogDto } from "../../../application/unit-definition/buildUnitDefinition";
+
+export type DialogDataStateType = {
+  dialogData?: UnitDefinitionDialogDto;
+  setDialogData: Dispatch<SetStateAction<UnitDefinitionDialogDto | undefined>>;
+};
+
+type FlowMenuStatusType = {
+  menuItem1: boolean;
+};
+
+export type FlowMenuStateType = {
+  menuStatus: FlowMenuStatusType;
+  setMenuStatus: Dispatch<SetStateAction<FlowMenuStatusType>>;
+};
+
+export type DrawerWidthStateType = {
+  drawerWidth: number;
+  setDrawerWidth: Dispatch<SetStateAction<number>>;
+};
+
+export type CurrentUnitIdStateType = {
+  currentUnitId?: string;
+  setCurrentUnitId: Dispatch<SetStateAction<string | undefined>>;
+};
+
+export type NestedExpansionStateType = {
+  expandedUnitIds: ReadonlySet<string>;
+  toggleExpandedUnitId: (unitId: string) => void;
+};

--- a/src/ui-component/editor/ajsFlow/flowGraphView.ts
+++ b/src/ui-component/editor/ajsFlow/flowGraphView.ts
@@ -11,7 +11,7 @@ import {
   CurrentUnitIdStateType,
   DialogDataStateType,
   NestedExpansionStateType,
-} from "./FlowContents";
+} from "./flowContentStateTypes";
 import { ExpandedNodeDecoration } from "./buildExpandedFlowGraph";
 import { AjsNode } from "./nodes/AjsNode";
 import { calculateFlowGraphNodePosition } from "./flowGraphPosition";

--- a/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/AjsNode.tsx
@@ -5,7 +5,10 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import type { SxProps, Theme } from "@mui/material/styles";
 import { UnitDefinitionDialogDto } from "../../../../application/unit-definition/buildUnitDefinition";
-import { CurrentUnitIdStateType, DialogDataStateType } from "../FlowContents";
+import {
+  CurrentUnitIdStateType,
+  DialogDataStateType,
+} from "../flowContentStateTypes";
 import { TySymbol } from "../../../../domain/values/AjsType";
 import { tyDefinitionLang } from "../../../../domain/services/i18n/nls";
 import { useMyAppContext } from "../../MyContexts";
@@ -220,3 +223,20 @@ export const NameOrComment: React.FC<{
     </Tooltip>
   );
 };
+
+export const shouldRenderNodeComment = (
+  label?: string,
+  comment?: string,
+): boolean => !!comment && comment !== label;
+
+export const NodeNameAndComment: React.FC<{
+  label?: string;
+  comment?: string;
+}> = ({ label, comment }) => (
+  <>
+    <NameOrComment value={label} />
+    {shouldRenderNodeComment(label, comment) && (
+      <NameOrComment value={comment} />
+    )}
+  </>
+);

--- a/src/ui-component/editor/ajsFlow/nodes/ConditionNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/ConditionNode.tsx
@@ -10,7 +10,7 @@ import {
   AjsNode,
   buildNodeSxProps,
   nodeActionsSxProps,
-  NameOrComment,
+  NodeNameAndComment,
   TyTitle,
 } from "./AjsNode";
 import {
@@ -66,8 +66,7 @@ const ConditionNode: FC<ConditionNodeProps> = ({
           )}
         </Box>
       </Stack>
-      <NameOrComment value={label} />
-      <NameOrComment value={comment} />
+      <NodeNameAndComment label={label} comment={comment} />
     </>
   );
 };

--- a/src/ui-component/editor/ajsFlow/nodes/JobGroupNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobGroupNode.tsx
@@ -9,7 +9,7 @@ import {
   AjsNode,
   buildNodeSxProps,
   nodeActionsSxProps,
-  NameOrComment,
+  NodeNameAndComment,
   TyTitle,
 } from "./AjsNode";
 import {
@@ -58,8 +58,7 @@ const JobGroupNode: FC<JobGroupNodeProp> = ({ data }: JobGroupNodeProp) => {
           />
         </Box>
       </Stack>
-      <NameOrComment value={label} />
-      <NameOrComment value={comment} />
+      <NodeNameAndComment label={label} comment={comment} />
     </>
   );
 };

--- a/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNetNode.tsx
@@ -16,7 +16,7 @@ import {
   buildNodeSxProps,
   nodeBadgeSxProps,
   nodeActionsSxProps,
-  NameOrComment,
+  NodeNameAndComment,
   TyTitle,
   handleStyle,
 } from "./AjsNode";
@@ -142,8 +142,7 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
           <Handle type="target" position={Position.Left} style={handleStyle} />
         </>
       )}
-      <NameOrComment value={label} />
-      <NameOrComment value={comment} />
+      <NodeNameAndComment label={label} comment={comment} />
     </>
   );
 };

--- a/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
+++ b/src/ui-component/editor/ajsFlow/nodes/JobNode.tsx
@@ -10,7 +10,7 @@ import {
   AjsNode,
   buildNodeSxProps,
   nodeActionsSxProps,
-  NameOrComment,
+  NodeNameAndComment,
   TyTitle,
   handleStyle,
 } from "./AjsNode";
@@ -76,8 +76,7 @@ const JobNode: FC<JobNodeProps> = ({ data }: JobNodeProps) => {
       </Stack>
       <Handle type="source" position={Position.Right} style={handleStyle} />
       <Handle type="target" position={Position.Left} style={handleStyle} />
-      <NameOrComment value={label} />
-      <NameOrComment value={comment} />
+      <NodeNameAndComment label={label} comment={comment} />
     </>
   );
 };

--- a/src/ui-component/editor/ajsFlow/useFlowContentsController.ts
+++ b/src/ui-component/editor/ajsFlow/useFlowContentsController.ts
@@ -1,0 +1,379 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Theme } from "@mui/material/styles";
+import { Edge, Node, ReactFlowInstance } from "@xyflow/react";
+import {
+  AjsDocument,
+  flattenAjsUnits,
+  findRootJobnet,
+} from "../../../domain/models/ajs/AjsDocument";
+import {
+  buildUnitDefinitionByPath,
+  UnitDefinitionDialogDto,
+} from "../../../application/unit-definition/buildUnitDefinition";
+import { UnitListDocumentDto } from "../../../application/unit-list/unitListDocument";
+import { toAjsDocument } from "../../../application/unit-list/unitListDocumentView";
+import { REVEAL_UNIT } from "../../../shared/webviewEvents";
+import {
+  getRevealUnitAbsolutePath,
+  resolveFlowRevealTarget,
+} from "../revealUnit";
+import { buildExpandedFlowGraph } from "./buildExpandedFlowGraph";
+import {
+  CurrentUnitIdStateType,
+  DialogDataStateType,
+  DrawerWidthStateType,
+  FlowMenuStateType,
+  NestedExpansionStateType,
+} from "./flowContentStateTypes";
+import { createReactFlowData } from "./flowGraphView";
+import { findFlowSearchResult } from "./flowSearch";
+import {
+  collapseExpandedNestedUnitIds,
+  collectExpandableNestedUnitIds,
+  hasExpandedAllNestedUnitIds,
+} from "./nestedExpansion";
+
+type UseFlowContentsControllerParams = {
+  theme: Theme;
+};
+
+export const useFlowContentsController = ({
+  theme,
+}: UseFlowContentsControllerParams) => {
+  const [menuStatus, setMenuStatus] = useState({ menuItem1: true });
+  const [drawerWidth, setDrawerWidth] = useState<number>(0);
+  const [ajsDocument, setAjsDocument] = useState<AjsDocument>();
+  const [currentUnitId, setCurrentUnitId] = useState<string>();
+  const [expandedUnitIds, setExpandedUnitIds] = useState<string[]>([]);
+  const [searchedUnitId, setSearchedUnitId] = useState<string>();
+  const [searchMatchedUnitIds, setSearchMatchedUnitIds] = useState<string[]>(
+    [],
+  );
+  const reactFlowInstanceRef = useRef<ReactFlowInstance<Node, Edge> | null>(
+    null,
+  );
+  const fitViewFrameRef = useRef<number | undefined>(undefined);
+  const preserveSearchOnNextScopeChange = useRef<boolean>(false);
+  const prevUnitEntityId = useRef<string | undefined>(undefined);
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [dialogData, setDialogData] = useState<
+    UnitDefinitionDialogDto | undefined
+  >();
+
+  const allUnits = useMemo(
+    () => (ajsDocument ? flattenAjsUnits(ajsDocument.rootUnits) : []),
+    [ajsDocument],
+  );
+  const unitById = useMemo(
+    () => new Map(allUnits.map((unit) => [unit.id, unit])),
+    [allUnits],
+  );
+  const unitDefinitionByPath = useMemo(
+    () =>
+      ajsDocument
+        ? buildUnitDefinitionByPath(ajsDocument)
+        : new Map<string, UnitDefinitionDialogDto>(),
+    [ajsDocument],
+  );
+  const currentUnit = useMemo(
+    () => (currentUnitId ? unitById.get(currentUnitId) : undefined),
+    [currentUnitId, unitById],
+  );
+
+  const toggleExpandedUnitId = useCallback(
+    (unitId: string) => {
+      setExpandedUnitIds((prev) => {
+        if (!prev.includes(unitId)) {
+          return [...prev, unitId];
+        }
+
+        return collapseExpandedNestedUnitIds(
+          prev,
+          unitId,
+          unitById.get(unitId),
+        );
+      });
+    },
+    [unitById],
+  );
+  const expandedUnitIdSet = useMemo(
+    () => new Set(expandedUnitIds),
+    [expandedUnitIds],
+  );
+  const expandableNestedUnitIds = useMemo(
+    () => collectExpandableNestedUnitIds(currentUnit),
+    [currentUnit],
+  );
+  const hasExpandedAllNestedUnits = useMemo(
+    () =>
+      hasExpandedAllNestedUnitIds(expandableNestedUnitIds, expandedUnitIdSet),
+    [expandableNestedUnitIds, expandedUnitIdSet],
+  );
+  const toggleExpandAllNestedUnits = useCallback(() => {
+    if (expandableNestedUnitIds.length === 0) {
+      return;
+    }
+    setExpandedUnitIds((prev) => {
+      const prevSet = new Set(prev);
+      if (hasExpandedAllNestedUnitIds(expandableNestedUnitIds, prevSet)) {
+        return prev.filter(
+          (unitId) => !expandableNestedUnitIds.includes(unitId),
+        );
+      }
+      const next = new Set(prev);
+      for (const unitId of expandableNestedUnitIds) {
+        next.add(unitId);
+      }
+      return [...next];
+    });
+  }, [expandableNestedUnitIds]);
+  const nestedExpansionState = useMemo<NestedExpansionStateType>(
+    () => ({
+      expandedUnitIds: expandedUnitIdSet,
+      toggleExpandedUnitId,
+    }),
+    [expandedUnitIdSet, toggleExpandedUnitId],
+  );
+
+  const currentUnitIdState = useMemo<CurrentUnitIdStateType>(
+    () => ({
+      currentUnitId,
+      setCurrentUnitId,
+    }),
+    [currentUnitId],
+  );
+  const dialogDataState = useMemo<DialogDataStateType>(
+    () => ({
+      dialogData,
+      setDialogData,
+    }),
+    [dialogData],
+  );
+
+  const updateNodesAndEdges = useCallback(
+    (selectedUnitId?: string) => {
+      if (!selectedUnitId) {
+        setNodes(() => []);
+        setEdges(() => []);
+        return;
+      }
+      if (!ajsDocument) {
+        setNodes(() => []);
+        setEdges(() => []);
+        return;
+      }
+      const { graph, positionOverrides, nodeDecorations } =
+        buildExpandedFlowGraph(
+          ajsDocument,
+          selectedUnitId,
+          expandedUnitIds,
+          theme.typography.htmlFontSize,
+        );
+      if (!graph) {
+        setNodes(() => []);
+        setEdges(() => []);
+        return;
+      }
+      const { nodes, edges } = createReactFlowData(
+        graph,
+        unitDefinitionByPath,
+        theme,
+        dialogDataState,
+        currentUnitIdState,
+        {
+          nodeDecorations,
+          searchMatchedUnitIds: new Set(searchMatchedUnitIds),
+          searchedUnitId,
+          unitById,
+          nestedExpansionState,
+          positionOverrides,
+        },
+      );
+      setNodes(() => nodes);
+      setEdges(() => edges);
+    },
+    [
+      ajsDocument,
+      currentUnitIdState,
+      dialogDataState,
+      expandedUnitIds,
+      nestedExpansionState,
+      theme,
+      unitDefinitionByPath,
+      unitById,
+      searchMatchedUnitIds,
+      searchedUnitId,
+    ],
+  );
+
+  const handleSearchSubmit = useCallback(
+    (query: string) => {
+      const result = findFlowSearchResult(currentUnit, query, unitById);
+      if (!result) {
+        setSearchedUnitId(undefined);
+        setSearchMatchedUnitIds([]);
+        return;
+      }
+
+      setExpandedUnitIds((prev) => {
+        const next = new Set(prev);
+        for (const unitId of result.expandedAncestorUnitIds) {
+          next.add(unitId);
+        }
+        return [...next];
+      });
+      setSearchMatchedUnitIds(result.matchedUnitIds);
+      setSearchedUnitId(result.matchedUnitId);
+    },
+    [currentUnit, unitById],
+  );
+  const handleSearchClear = useCallback(() => {
+    setSearchedUnitId(undefined);
+    setSearchMatchedUnitIds([]);
+  }, []);
+
+  const handleRevealUnit = useCallback(
+    (absolutePath: string) => {
+      const revealTarget = resolveFlowRevealTarget(unitById, absolutePath);
+      if (!revealTarget) {
+        return;
+      }
+      preserveSearchOnNextScopeChange.current = true;
+      setExpandedUnitIds(revealTarget.expandedAncestorUnitIds);
+      setCurrentUnitId(revealTarget.scopeUnitId);
+      setSearchMatchedUnitIds([revealTarget.revealedUnitId]);
+      setSearchedUnitId(revealTarget.revealedUnitId);
+    },
+    [unitById],
+  );
+
+  useEffect(() => {
+    updateNodesAndEdges(currentUnitId);
+    prevUnitEntityId.current = currentUnitId;
+  }, [currentUnitId, updateNodesAndEdges]);
+
+  useEffect(() => {
+    if (!reactFlowInstanceRef.current || nodes.length === 0) {
+      return undefined;
+    }
+
+    if (fitViewFrameRef.current) {
+      window.cancelAnimationFrame(fitViewFrameRef.current);
+    }
+
+    fitViewFrameRef.current = window.requestAnimationFrame(() => {
+      void reactFlowInstanceRef.current?.fitView({ padding: 0.22 });
+      fitViewFrameRef.current = undefined;
+    });
+
+    return () => {
+      if (fitViewFrameRef.current) {
+        window.cancelAnimationFrame(fitViewFrameRef.current);
+        fitViewFrameRef.current = undefined;
+      }
+    };
+  }, [nodes, edges]);
+
+  useEffect(() => {
+    setExpandedUnitIds((prev) => (prev.length === 0 ? prev : []));
+    if (preserveSearchOnNextScopeChange.current) {
+      preserveSearchOnNextScopeChange.current = false;
+      return;
+    }
+    setSearchedUnitId(undefined);
+    setSearchMatchedUnitIds([]);
+  }, [ajsDocument, currentUnitId]);
+
+  useEffect(() => {
+    const changeDocumentFn = (_type: string, data: unknown) => {
+      const nextDocument = data
+        ? toAjsDocument(data as UnitListDocumentDto)
+        : undefined;
+      setAjsDocument(() => nextDocument);
+      setCurrentUnitId(() => {
+        const x = nextDocument ? flattenAjsUnits(nextDocument.rootUnits) : [];
+        return prevUnitEntityId.current
+          ? x.find((unit) => unit.id === prevUnitEntityId.current)?.id
+          : nextDocument
+            ? findRootJobnet(nextDocument)?.id
+            : undefined;
+      });
+    };
+    window.EventBridge.addCallback("changeDocument", changeDocumentFn);
+    window.vscode.postMessage({ type: "ready" });
+    return () => {
+      window.EventBridge.removeCallback("changeDocument", changeDocumentFn);
+    };
+  }, []);
+
+  useEffect(() => {
+    const revealUnitFn = (_type: string, data: unknown) => {
+      const absolutePath = getRevealUnitAbsolutePath(data);
+      if (!absolutePath) {
+        return;
+      }
+      handleRevealUnit(absolutePath);
+    };
+    window.EventBridge.addCallback(REVEAL_UNIT, revealUnitFn);
+    return () => {
+      window.EventBridge.removeCallback(REVEAL_UNIT, revealUnitFn);
+    };
+  }, [handleRevealUnit]);
+
+  useEffect(() => {
+    const root = document.getElementById("root");
+    document.documentElement.style.overflow = "hidden";
+    document.body.style.overflow = "hidden";
+    if (root) {
+      root.style.overflow = "hidden";
+      root.style.height = "100%";
+    }
+
+    return () => {
+      document.documentElement.style.overflow = "";
+      document.body.style.overflow = "";
+      if (root) {
+        root.style.overflow = "";
+        root.style.height = "";
+      }
+    };
+  }, []);
+
+  const flowMenuState = useMemo<FlowMenuStateType>(
+    () => ({
+      menuStatus,
+      setMenuStatus,
+    }),
+    [menuStatus],
+  );
+  const drawerWidthState = useMemo<DrawerWidthStateType>(
+    () => ({
+      drawerWidth,
+      setDrawerWidth,
+    }),
+    [drawerWidth],
+  );
+
+  return {
+    ajsDocument,
+    currentUnit,
+    currentUnitIdState,
+    dialogData,
+    drawerWidth,
+    drawerWidthState,
+    edges,
+    expandableNestedUnitIds,
+    flowMenuState,
+    handleSearchClear,
+    handleSearchSubmit,
+    hasExpandedAllNestedUnits,
+    menuStatus,
+    nodes,
+    reactFlowInstanceRef,
+    searchedUnitId,
+    setDialogData,
+    toggleExpandAllNestedUnits,
+    unitById,
+  };
+};


### PR DESCRIPTION
## Summary
- extract flow-viewer state, EventBridge wiring, search/reveal handling, fit-to-view scheduling, and ReactFlow data preparation out of `FlowContents.tsx` into a presentation-local controller hook
- move shared flow viewer state types into a dedicated module so flow node, header, selector, menu, and graph-view helpers no longer depend on `FlowContents.tsx` for type imports
- fix the PR4 display regression where identical node name/comment values rendered duplicate text below expandable nodes and add focused regression coverage

## Validation
- `rtk pnpm run qlty`
- `rtk pnpm run lint:md`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`

## Notes
- `engines.vscode`, flow graph DTOs, parser behavior, and package/configuration remain unchanged
- webpack bundle-size warnings remain pre-existing build warnings