### PR TITLE
[codex] Limit flow scopes to root jobnets

### DIFF
--- a/docs/specs/features/limit-flow-selector-to-root-jobnets/SPECS.md
+++ b/docs/specs/features/limit-flow-selector-to-root-jobnets/SPECS.md
@@ -1,0 +1,141 @@
+# SPECS: limit-flow-selector-to-root-jobnets
+
+## Purpose
+
+Temporarily limit flow selector selection to root jobnets while the selector may
+still display both job groups and root jobnets.
+
+## Origin
+
+- Feature kind: transient branch feature
+- Source:
+  user-reported flow selector behavior risk: selecting a job group can display
+  root jobnets that do not have display coordinates on top of each other.
+- Source use cases:
+  docs/requirements/use-cases/uc-build-flow-graph.md and
+  docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md
+- Related plan: docs/specs/plans.md
+
+## Requirements
+
+- The flow selector may continue to show job groups and root jobnets.
+- Only root jobnets are valid selectable flow scopes for this temporary
+  feature.
+- Job groups must not be selectable as flow scopes while selecting them would
+  render coordinate-less root jobnets overlapping each other.
+- The change must preserve existing root-jobnet selection behavior.
+- The implementation must not introduce parser-internal coupling into UI
+  components.
+
+## Behavioral Scenarios
+
+```gherkin
+Feature: Flow selector root-jobnet selection boundary
+
+Scenario: Root jobnets remain selectable
+  Given the flow selector contains job groups and root jobnets
+  When the user selects a root jobnet
+  Then the flow graph opens or focuses that root-jobnet scope
+
+Scenario: Job groups are not valid flow scopes
+  Given the flow selector contains a job group
+  When the user attempts to use that job group as a flow scope
+  Then the flow graph does not render coordinate-less root jobnets as
+    overlapping nodes
+```
+
+## Architecture
+
+- Domain: none expected for the temporary selector boundary.
+- Application:
+  should remain the preferred place for stable selectable-scope DTO rules if
+  implementation investigation shows the selector already consumes an
+  application-facing view model.
+- Presentation:
+  may enforce the temporary root-jobnet-only selectable state at the selector
+  boundary without parsing raw AJS grammar output.
+- Infrastructure: none expected.
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected callers, components, commands, adapters, tests, and docs:
+  flow selector presentation, any flow-scope DTO/view-model mapping that feeds
+  the selector, flow graph opening/focusing behavior, and related selector or
+  graph tests.
+- Propagation decision:
+  keep graph rendering, nested expansion, list view, CSV export, diagnostics,
+  hover, and telemetry behavior unchanged unless implementation investigation
+  proves they are directly affected.
+
+### Breaking Change Analysis
+
+- User-visible behavior:
+  job groups remain visible in the selector but are not valid selectable flow
+  scopes for this temporary feature.
+- API/DTO/schema compatibility:
+  no public API or persisted schema change expected; any DTO change requires
+  impact investigation and approval before implementation.
+- VS Code/web extension compatibility:
+  desktop and web hosts must keep the same selector behavior.
+- Changed scenarios:
+  temporary flow selector root-jobnet-only selection scenarios added in this
+  feature spec; durable use-case updates are deferred until the final selector
+  behavior is decided.
+
+### Alternative Considerations
+
+- Hide job groups from the selector:
+  rejected for this temporary feature because the stated behavior keeps job
+  groups visible while only root jobnets are selectable.
+- Generate or infer coordinates for root jobnets under a selected job group:
+  deferred because that is a larger flow layout behavior change.
+- Allow job groups and repair overlapping at render time:
+  deferred because it broadens the behavior beyond the immediate selector
+  boundary.
+
+### Approval Impact Decisions
+
+- Approval evidence owner: TASKS.md `Human Approval`
+- Scope changes requiring re-approval:
+  hiding job groups, adding inferred coordinates, changing graph layout rules,
+  changing parser/domain models, changing persisted DTO schemas, or changing
+  behavior outside flow selector selection.
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility:
+  the selector boundary must work without Node-only APIs and must preserve web
+  extension behavior.
+- Desktop extension compatibility:
+  desktop behavior must match web behavior for visible and selectable selector
+  entries.
+- Model, Serena, or agent choice does not change this behavior contract or the
+  SDD approval gate.
+
+## Acceptance Criteria
+
+- A root jobnet remains selectable from the flow selector.
+- A job group is not accepted as the active flow graph scope.
+- Attempting to use a job group does not produce overlapping coordinate-less
+  root jobnets.
+- Existing root-jobnet flow rendering remains unchanged.
+- Relevant tests or focused verification cover both selectable and
+  non-selectable selector entries.
+- Desktop and web compatibility impact is reported before implementation.
+
+## Non-Goals
+
+- Redesign the flow selector.
+- Hide job groups from the selector.
+- Add layout coordinates for root jobnets under a selected job group.
+- Change parser output, normalized domain models, CSV export, diagnostics,
+  hover, telemetry, or WebAPI import behavior.
+- Make a durable repository roadmap commitment before the temporary boundary is
+  validated.
+
+## Open Questions
+
+- None for feature intake.

--- a/docs/specs/features/limit-flow-selector-to-root-jobnets/TASKS.md
+++ b/docs/specs/features/limit-flow-selector-to-root-jobnets/TASKS.md
@@ -1,0 +1,50 @@
+# limit-flow-selector-to-root-jobnets Tasks
+
+## Current Task
+
+- Status: Proposed
+- Scope:
+  decide whether the temporary root-jobnet-only flow scope boundary should be
+  kept as durable behavior or removed after job-group flow layout is addressed.
+- Acceptance:
+  the completed implementation keeps job groups visible in the flow selector
+  and unit list, but direct selector interaction and unit-list-to-flow reveal
+  navigation resolve active flow scopes to root jobnets.
+- Validation:
+  future changes must keep focused selector and reveal-target coverage, plus
+  desktop and web validation when shared webview behavior changes.
+
+## Human Approval
+
+- Status: Pending
+- Approved at: none
+- Approved scope: none
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
+`Approved at` records the approval result only, such as `none` or `approved in
+current conversation`; do not copy the approval message.
+
+Reset this section back to Pending when the approved slice is complete and no
+active implementation approval remains.
+
+## Decision Notes
+
+- The approved implementation slice is complete.
+- Direct flow selector interaction no longer lets job groups set
+  `currentUnitId`.
+- Unit-list-to-flow reveal navigation for a job group now resolves to a
+  descendant root jobnet flow scope.
+- The implemented boundary is still temporary because job-group flow layout
+  behavior has not been decided.
+- The next decision is whether to preserve this as a durable selector/reveal
+  rule or replace it with explicit job-group flow layout support.
+
+## Use-Case Back-Propagation
+
+- No durable use-case update is needed while this remains a transient branch
+  feature.
+- If the root-jobnet-only selector and reveal boundary becomes permanent,
+  update `docs/requirements/use-cases/uc-build-flow-graph.md` or
+  `docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md`
+  before removing this feature folder.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -38,6 +38,10 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Active Feature Specs
 
+- `docs/specs/features/limit-flow-selector-to-root-jobnets/`:
+  transient branch feature for keeping flow selector job groups visible while
+  limiting selectable flow scopes to root jobnets until job-group flow layout
+  behavior is decided.
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
 

--- a/src/test/suite/flowSelector.test.ts
+++ b/src/test/suite/flowSelector.test.ts
@@ -1,0 +1,52 @@
+import * as assert from "assert";
+import { AjsUnit } from "../../domain/models/ajs/AjsDocument";
+import { isSelectableFlowScopeUnit } from "../../ui-component/editor/ajsFlow/FlowSelector";
+
+const createUnit = (overrides: Partial<AjsUnit>): AjsUnit => ({
+  id: overrides.id ?? "/root/jobnet",
+  name: overrides.name ?? "jobnet",
+  unitAttribute: "",
+  unitType: overrides.unitType ?? "n",
+  groupType: overrides.groupType,
+  absolutePath: overrides.absolutePath ?? "/root/jobnet",
+  depth: overrides.depth ?? 1,
+  parentId: overrides.parentId,
+  isRoot: overrides.isRoot ?? false,
+  isRootJobnet: overrides.isRootJobnet ?? true,
+  hasSchedule: false,
+  hasWaitedFor: false,
+  layout: { h: 0, v: 0 },
+  parameters: [],
+  relations: [],
+  children: [],
+});
+
+suite("Flow Selector", () => {
+  test("allows only root jobnets as selectable flow scopes", () => {
+    const rootJobnet = createUnit({
+      id: "/root/jobnet",
+      name: "jobnet",
+      unitType: "n",
+      isRootJobnet: true,
+    });
+    const jobGroup = createUnit({
+      id: "/root",
+      name: "root",
+      unitType: "g",
+      groupType: "n",
+      isRoot: true,
+      isRootJobnet: false,
+    });
+    const nestedJobnet = createUnit({
+      id: "/root/jobnet/nested",
+      name: "nested",
+      unitType: "n",
+      parentId: "/root/jobnet",
+      isRootJobnet: false,
+    });
+
+    assert.strictEqual(isSelectableFlowScopeUnit(rootJobnet), true);
+    assert.strictEqual(isSelectableFlowScopeUnit(jobGroup), false);
+    assert.strictEqual(isSelectableFlowScopeUnit(nestedJobnet), false);
+  });
+});

--- a/src/test/suite/revealUnit.test.ts
+++ b/src/test/suite/revealUnit.test.ts
@@ -52,6 +52,37 @@ suite("Reveal unit helpers", () => {
     );
   });
 
+  test("opens the first root jobnet when revealing a job group", () => {
+    const unitById = new Map([
+      [
+        "job-group",
+        {
+          id: "job-group",
+          absolutePath: "/job-group",
+          unitType: "g",
+          children: [{}],
+        },
+      ],
+      [
+        "root-jobnet",
+        {
+          id: "root-jobnet",
+          absolutePath: "/job-group/root-jobnet",
+          unitType: "n",
+          parentId: "job-group",
+          isRootJobnet: true,
+          children: [],
+        },
+      ],
+    ]);
+
+    assert.deepStrictEqual(resolveFlowRevealTarget(unitById, "/job-group"), {
+      scopeUnitId: "root-jobnet",
+      revealedUnitId: "job-group",
+      expandedAncestorUnitIds: [],
+    });
+  });
+
   test("opens the direct condition scope for units under .condition", () => {
     const unitById = new Map([
       [

--- a/src/ui-component/editor/ajsFlow/FlowSelector.tsx
+++ b/src/ui-component/editor/ajsFlow/FlowSelector.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import MuiAccordion, { type AccordionProps } from "@mui/material/Accordion";
 import MuiAccordionActions, {
@@ -40,13 +41,17 @@ type FlowSelectorProps = {
 type FlowSelectorTreeProps = {
   rootUnits: AjsUnit[];
   isAncestorOf: (target?: AjsUnit) => boolean;
+  isExpandedGroup: (unitId: string) => boolean;
   setCurrentUnitId: (unitId: string) => void;
+  setGroupExpanded: (unitId: string, expanded: boolean) => void;
 };
 
 type FlowSelectorUnitProps = {
   unit: AjsUnit;
   isAncestorOf: (target?: AjsUnit) => boolean;
+  isExpandedGroup: (unitId: string) => boolean;
   setCurrentUnitId: (unitId: string) => void;
+  setGroupExpanded: (unitId: string, expanded: boolean) => void;
 };
 
 type FlowSelectorToolbarProps = {
@@ -103,6 +108,9 @@ const AccordionActions = styled((props: AccordionActionsProps) => (
 
 const isRootJobnetUnit = (unit: AjsUnit): boolean =>
   unit.unitType === "n" && unit.isRootJobnet;
+
+export const isSelectableFlowScopeUnit = (unit: AjsUnit): boolean =>
+  isRootJobnetUnit(unit);
 
 const getParentUnit = (
   unit: AjsUnit,
@@ -174,7 +182,9 @@ const useDrawerWidthObserver = (
 const FlowGroupUnit: FC<FlowSelectorUnitProps> = ({
   unit,
   isAncestorOf,
+  isExpandedGroup,
   setCurrentUnitId,
+  setGroupExpanded,
 }) => (
   <Accordion
     key={unit.id}
@@ -187,14 +197,16 @@ const FlowGroupUnit: FC<FlowSelectorUnitProps> = ({
         ? "action.selected"
         : "background.paper",
     }}
-    expanded={isAncestorOf(unit)}
-    onChange={() => setCurrentUnitId(unit.id)}
+    expanded={isAncestorOf(unit) || isExpandedGroup(unit.id)}
+    onChange={(_event, expanded) => setGroupExpanded(unit.id, expanded)}
   >
     <AccordionSummary>{unit.name}</AccordionSummary>
     <FlowSelectorTree
       rootUnits={unit.children}
       isAncestorOf={isAncestorOf}
+      isExpandedGroup={isExpandedGroup}
       setCurrentUnitId={setCurrentUnitId}
+      setGroupExpanded={setGroupExpanded}
     />
   </Accordion>
 );
@@ -235,22 +247,28 @@ const FlowSelectorUnit: FC<FlowSelectorUnitProps> = ({
   unit,
   isAncestorOf,
   setCurrentUnitId,
+  isExpandedGroup,
+  setGroupExpanded,
 }) => {
   if (unit.unitType === "g") {
     return (
       <FlowGroupUnit
         unit={unit}
         isAncestorOf={isAncestorOf}
+        isExpandedGroup={isExpandedGroup}
         setCurrentUnitId={setCurrentUnitId}
+        setGroupExpanded={setGroupExpanded}
       />
     );
   }
-  if (isRootJobnetUnit(unit)) {
+  if (isSelectableFlowScopeUnit(unit)) {
     return (
       <RootJobnetUnit
         unit={unit}
         isAncestorOf={isAncestorOf}
+        isExpandedGroup={isExpandedGroup}
         setCurrentUnitId={setCurrentUnitId}
+        setGroupExpanded={setGroupExpanded}
       />
     );
   }
@@ -260,7 +278,9 @@ const FlowSelectorUnit: FC<FlowSelectorUnitProps> = ({
 const FlowSelectorTree: FC<FlowSelectorTreeProps> = ({
   rootUnits,
   isAncestorOf,
+  isExpandedGroup,
   setCurrentUnitId,
+  setGroupExpanded,
 }) => (
   <>
     {rootUnits.map((unit) => (
@@ -268,7 +288,9 @@ const FlowSelectorTree: FC<FlowSelectorTreeProps> = ({
         key={unit.id}
         unit={unit}
         isAncestorOf={isAncestorOf}
+        isExpandedGroup={isExpandedGroup}
         setCurrentUnitId={setCurrentUnitId}
+        setGroupExpanded={setGroupExpanded}
       />
     ))}
   </>
@@ -319,6 +341,9 @@ const FlowSelector: FC<FlowSelectorProps> = ({
   const { menuStatus, setMenuStatus } = flowMenuState;
   const { currentUnitId, setCurrentUnitId } = currentUnitIdState;
   const { setDrawerWidth } = drawerWidthState;
+  const [expandedGroupIds, setExpandedGroupIds] = useState<Set<string>>(
+    () => new Set<string>(),
+  );
 
   const handleClose = () => {
     setDrawerWidth(() => 0);
@@ -328,6 +353,21 @@ const FlowSelector: FC<FlowSelectorProps> = ({
   };
 
   const isAncestorOf = useAncestorMatcher(currentUnitId, unitById);
+  const isExpandedGroup = useCallback(
+    (unitId: string) => expandedGroupIds.has(unitId),
+    [expandedGroupIds],
+  );
+  const setGroupExpanded = useCallback((unitId: string, expanded: boolean) => {
+    setExpandedGroupIds((prev) => {
+      const next = new Set(prev);
+      if (expanded) {
+        next.add(unitId);
+      } else {
+        next.delete(unitId);
+      }
+      return next;
+    });
+  }, []);
   const drawerRef = useDrawerWidthObserver(setDrawerWidth);
 
   return (
@@ -352,7 +392,9 @@ const FlowSelector: FC<FlowSelectorProps> = ({
         <FlowSelectorTree
           rootUnits={rootUnits}
           isAncestorOf={isAncestorOf}
+          isExpandedGroup={isExpandedGroup}
           setCurrentUnitId={setCurrentUnitId}
+          setGroupExpanded={setGroupExpanded}
         />
       </Drawer>
     </>

--- a/src/ui-component/editor/revealUnit.ts
+++ b/src/ui-component/editor/revealUnit.ts
@@ -18,6 +18,7 @@ type FlowRevealUnit = {
   id: string;
   absolutePath: string;
   unitType: string;
+  isRootJobnet?: boolean;
   parentId?: string;
   children: Array<unknown>;
 };
@@ -48,6 +49,36 @@ const isConditionUnit = (unit: FlowRevealUnit | undefined): boolean =>
 const isJobnetUnit = (unit: FlowRevealUnit | undefined): boolean =>
   unit?.unitType === "n";
 
+const isJobGroupUnit = (unit: FlowRevealUnit | undefined): boolean =>
+  unit?.unitType === "g";
+
+const isRootJobnetUnit = (unit: FlowRevealUnit | undefined): boolean =>
+  unit?.unitType === "n" && unit.isRootJobnet === true;
+
+const isDescendantOf = (
+  unitById: ReadonlyMap<string, FlowRevealUnit>,
+  unit: FlowRevealUnit,
+  ancestor: FlowRevealUnit,
+): boolean => {
+  let current = findFlowRevealParentUnit(unitById, unit);
+  while (current) {
+    if (current.id === ancestor.id) {
+      return true;
+    }
+    current = findFlowRevealParentUnit(unitById, current);
+  }
+  return false;
+};
+
+const findFirstDescendantRootJobnet = (
+  unitById: ReadonlyMap<string, FlowRevealUnit>,
+  unit: FlowRevealUnit,
+): FlowRevealUnit | undefined =>
+  Array.from(unitById.values()).find(
+    (candidate) =>
+      isRootJobnetUnit(candidate) && isDescendantOf(unitById, candidate, unit),
+  );
+
 const findNearestJobnetAncestor = (
   unitById: ReadonlyMap<string, FlowRevealUnit>,
   unit: FlowRevealUnit | undefined,
@@ -63,6 +94,12 @@ const resolveFlowRevealScopeUnit = (
   unitById: ReadonlyMap<string, FlowRevealUnit>,
   revealedUnit: FlowRevealUnit,
 ): FlowRevealUnit => {
+  if (isJobGroupUnit(revealedUnit)) {
+    return (
+      findFirstDescendantRootJobnet(unitById, revealedUnit) ?? revealedUnit
+    );
+  }
+
   const directParent = findFlowRevealParentUnit(unitById, revealedUnit);
   if (isConditionUnit(directParent)) {
     return directParent;


### PR DESCRIPTION
## Summary

- Keep job groups visible in the flow selector while preventing them from becoming the active flow scope.
- Resolve unit-list-to-flow navigation from a job group to the first descendant root jobnet scope.
- Add focused selector and reveal-target regression tests.
- Add transient SDD feature docs for the temporary root-jobnet-only boundary.

## Why

Selecting or navigating to a job group could make the flow view use the job group as the active scope, which causes root jobnets without display coordinates to overlap. This keeps the temporary behavior constrained to root jobnet scopes until job-group flow layout is explicitly designed.

## Validation

- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build` succeeded with existing webpack bundle size warnings only.