### PR TITLE
Release 1.15.1

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,6 +11,9 @@ antlr/
 # codex
 .codex/
 
+# serena
+.serena/
+
 # github
 .github/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [1.15.0]
+
+- Added broader editor diagnostics for JP1/AJS definition parameters, including
+  job retry and end judgment settings, event sending and receiving jobs,
+  schedule rules, file monitoring, transfer jobs, and execution-interval
+  controls.
+- Improved the flow viewer so selectable flow scopes are limited to root
+  jobnets, and revealing a job group opens the first root jobnet while keeping
+  the target highlighted.
+- Stabilized expanded flow graph layout and search behavior for nested jobnets.
+- Improved JP1/AJS WebAPI import beta handling for desktop-only execution,
+  credential storage, HTTP status mapping, and malformed responses.
+- Updated dependencies and security overrides.
+
 ## [1.14.0]
 
 - Added read-only JP1/AJS WebAPI import as a beta command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.15.1]
+
+- Excluded local agent cache files from the published extension package.
+
 ## [1.15.0]
 
 - Added broader editor diagnostics for JP1/AJS definition parameters, including

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-ajsbutler",
   "displayName": "vscode-ajsbutler",
   "description": "Support tool for JP1/AJS3",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-ajsbutler",
   "displayName": "vscode-ajsbutler",
   "description": "Support tool for JP1/AJS3",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary

- Release the changes since `v1.14.0` as a minor release because the diff adds user-visible JP1/AJS diagnostics coverage and flow-viewer behavior improvements, not only bug fixes.
- Add `CHANGELOG.md` entries for `1.15.0` and `1.15.1`.
- Bump the package version with `pnpm version minor` to `1.15.0`, then `pnpm version patch` to `1.15.1` after excluding local `.serena/` cache files from the VSIX package.
- Publish `kittybbit.vscode-ajsbutler` versions `1.15.0` and corrected `1.15.1`; `1.15.1` is the intended release for users.

## User-facing changes

- Broader editor diagnostics for JP1/AJS definition parameters, including job retry/end judgment, event jobs, schedule rules, file monitoring, transfer jobs, and execution-interval controls.
- Flow viewer now limits selectable scopes to root jobnets and improves reveal behavior from job groups.
- Expanded flow graph layout and nested-jobnet search behavior are more stable.
- JP1/AJS WebAPI import beta has more robust desktop-only handling, credential storage, HTTP status mapping, and malformed-response handling.
- Dependencies and security overrides were updated.

## Validation

- `rtk pnpm run qlty`
- `rtk pnpm run build` (passes with existing webpack size warnings)
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm exec vsce publish --no-dependencies` for `1.15.1`

## Notes

- A first `vsce publish` without `--no-dependencies` failed because `vsce` invokes `npm list --production`, which does not understand this pnpm dependency layout.
- `1.15.0` was published before detecting that `.serena/` was included in the VSIX. `1.15.1` excludes it and is the corrected Marketplace version.