### PR TITLE
[codex] Document AJS metadata i18n separation

### DIFF
--- a/docs/specs/features/separate-ajs-metadata-from-i18n/SPECS.md
+++ b/docs/specs/features/separate-ajs-metadata-from-i18n/SPECS.md
@@ -1,0 +1,140 @@
+# SPECS: separate-ajs-metadata-from-i18n
+
+## Purpose
+
+Separate AJS definition metadata from i18n string resources so table columns
+and unit type labels have typed metadata boundaries instead of ad hoc
+translation-table access.
+
+## Origin
+
+- Feature kind: roadmap feature
+- Source:
+  user architecture review of `nls.ts`, `ajscolumn`, `ty`, and table column
+  definitions.
+- Source use cases:
+  docs/requirements/use-cases/uc-build-unit-list-view.md and
+  docs/requirements/use-cases/uc-show-unit-definition.md
+- Related plan: docs/specs/plans.md
+
+## Requirements
+
+- Keep i18n resolution focused on selecting locale-specific strings with
+  fallback behavior.
+- Keep AJS table column metadata separate from flat translation keys such as
+  `group1.col3`.
+- Keep AJS unit type metadata separate from generic i18n resource tables.
+- Provide a typed unit type label access boundary so UI code does not directly
+  index raw `ty` resource shapes such as `g.gty.p`.
+- Preserve existing English and Japanese user-visible labels except for clear
+  data defects such as unintended leading whitespace.
+- Preserve current unit list, unit definition, CSV, flow, diagnostics, hover,
+  telemetry, desktop, and web extension behavior unless a future approved slice
+  explicitly changes them.
+
+## Architecture
+
+- Domain:
+  may own stable AJS unit type codes or metadata helpers only if they express
+  JP1/AJS concepts independent of presentation.
+- Application:
+  may expose typed DTOs or label helpers when multiple presentation consumers
+  need the same AJS metadata boundary.
+- Presentation:
+  should consume typed column metadata and label accessors instead of flat
+  string keys or raw `ty` object traversal.
+- Infrastructure:
+  none expected.
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected callers, components, commands, adapters, tests, and docs:
+  `nls.ts`, locale resources for message, parameter, AJS table column, and
+  unit type labels, unit list table column definitions, unit definition display
+  code that reads unit type labels, and tests that assert labels or column
+  headers.
+- Propagation decision:
+  keep parser internals, normalized AJS document models, flow graph layout,
+  CSV export data semantics, diagnostics, hover content source, telemetry, and
+  WebAPI import behavior unchanged unless implementation investigation proves
+  direct dependency.
+
+### Breaking Change Analysis
+
+- User-visible behavior:
+  no intended behavior change; clear label data defects may be corrected when
+  covered by the approved implementation scope.
+- API/DTO/schema compatibility:
+  no public API or persisted schema change expected; internal DTO changes need
+  impact investigation before implementation.
+- VS Code/web extension compatibility:
+  shared metadata and i18n modules must avoid Node-only and VS Code-only APIs.
+- Changed scenarios:
+  none for feature intake; use-case updates are required only if a future slice
+  changes observable labels or behavior contracts.
+
+### Alternative Considerations
+
+- Only deduplicate `nls.ts` fallback merge logic:
+  rejected as the full feature purpose because it leaves AJS metadata mixed
+  into generic i18n resources.
+- Keep flat `ajscolumn` keys and add constants:
+  rejected as the target boundary because it still preserves string-key
+  coupling between resources and table column definitions.
+- Move all label metadata into domain immediately:
+  deferred until impact investigation shows which metadata is a JP1/AJS concept
+  versus presentation-only display structure.
+
+### Approval Impact Decisions
+
+- Approval evidence owner: TASKS.md `Human Approval`
+- Scope changes requiring re-approval:
+  changing user-visible label semantics beyond confirmed data defects, changing
+  parser/domain models, changing CSV output semantics, changing flow graph
+  behavior, changing diagnostics or hover behavior, adding runtime dependencies,
+  or introducing host-specific APIs.
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility:
+  metadata and i18n resolution must stay browser-safe and free of Node-only
+  APIs.
+- Desktop extension compatibility:
+  desktop labels and table behavior must remain consistent with web behavior.
+- Model, Serena, or agent choice does not change this behavior contract or the
+  SDD approval gate.
+
+## Acceptance Criteria
+
+- i18n fallback resolution is expressed through one shared resolver or
+  equivalent shared boundary.
+- AJS table column labels are available through typed structured metadata
+  rather than direct flat string keys in column definitions.
+- AJS unit type labels are available through a typed accessor or equivalent
+  boundary that handles unsupported or unknown unit type codes safely.
+- UI components do not directly traverse raw unit type metadata shapes for
+  display labels.
+- Existing English and Japanese labels remain stable except for explicitly
+  approved data-defect corrections.
+- Relevant tests or focused verification cover fallback resolution, structured
+  column label access, unit type label fallback behavior, and desktop/web-safe
+  shared module usage.
+
+## Non-Goals
+
+- Redesign the unit list table UI.
+- Change parser output or normalized AJS document shape.
+- Change CSV export data semantics.
+- Add new supported JP1/AJS unit types beyond the existing resource scope.
+- Replace the repository i18n approach with an external i18n framework.
+- Localize new product copy outside the AJS metadata separation scope.
+
+## Open Questions
+
+- Which parts of unit type metadata belong in domain/application helpers versus
+  presentation-only label metadata?
+- Should table column group metadata expose only labels, or also stable column
+  identities for future view-model mapping?

--- a/docs/specs/features/separate-ajs-metadata-from-i18n/TASKS.md
+++ b/docs/specs/features/separate-ajs-metadata-from-i18n/TASKS.md
@@ -1,0 +1,67 @@
+# TASKS: separate-ajs-metadata-from-i18n
+
+## Sync Rule
+
+- Update this file in the same commit whenever one task or follow-up is
+  completed, re-scoped, or intentionally dropped.
+- Update `docs/specs/plans.md` only when the branch starts, stops, or changes
+  an active feature.
+- Update `docs/specs/roadmap.md` when repository sequencing changes.
+- Keep this file focused on current state only; do not retain historical logs,
+  prior approvals, or long validation diaries once they stop being actionable.
+
+## Current Task
+
+- Status: Proposed
+- Scope:
+  investigate the i18n and AJS metadata boundary, then propose the first
+  behavior-preserving implementation slice.
+- Acceptance:
+  impact investigation names affected locale resources, table column
+  definitions, unit type label consumers, tests, compatibility risks, and
+  alternatives before runtime code or tests are edited.
+- Validation:
+  docs-only feature intake requires `rtk pnpm run qlty`.
+
+## Human Approval
+
+- Status: Pending
+- Approved at: none
+- Approved scope: none
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
+`Approved at` records the approval result only, such as `none` or `approved in
+current conversation`; do not copy the approval message.
+
+Reset this section back to Pending when the approved slice is complete and no
+active implementation approval remains.
+
+## Active Tasks
+
+- [ ] Complete impact investigation for i18n resolver, AJS table column
+      metadata, unit type metadata, and affected UI consumers.
+- [ ] Decide whether unit type codes and label helpers belong in domain,
+      application, or presentation for the first slice.
+- [ ] Request human approval for the first implementation slice before editing
+      runtime code, tests, generated artifacts, or configuration.
+- [ ] Preserve current labels except for explicitly approved data-defect
+      corrections such as unintended leading whitespace.
+- [ ] Update or add focused tests for fallback resolution, structured column
+      metadata access, and unknown unit type fallback behavior after approval.
+
+## Validation
+
+- [ ] Run `rtk pnpm run qlty` for feature intake.
+- [ ] For implementation slices, run relevant unit tests and the required
+      code-validation sequence from `docs/specs/README.md` unless the approved
+      scope narrows validation with documented rationale.
+
+## Use-Case Back-Propagation
+
+- No durable use-case update is needed while the feature only changes internal
+  metadata boundaries and preserves observable labels.
+- Update `docs/requirements/use-cases/uc-build-unit-list-view.md` or
+  `docs/requirements/use-cases/uc-show-unit-definition.md` if a future slice
+  changes observable column labels, unit type display behavior, or fallback
+  behavior.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -38,6 +38,10 @@ rules in `docs/specs/README.md`, not in this file.
 
 ## Active Feature Specs
 
+- `docs/specs/features/separate-ajs-metadata-from-i18n/`:
+  roadmap feature for separating AJS definition metadata from generic i18n
+  resources so table column labels and unit type labels have typed access
+  boundaries.
 - `docs/specs/features/limit-flow-selector-to-root-jobnets/`:
   transient branch feature for keeping flow selector job groups visible while
   limiting selectable flow scopes to root jobnets until job-group flow layout

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -54,6 +54,17 @@
      meaningful JP1/AJS concept, application use case, adapter boundary, or
      maintainability risk.
 
+5. Separate AJS definition metadata from i18n resources.
+
+   - Keep locale fallback and string resolution in a small shared i18n
+     boundary.
+   - Treat table column labels and unit type labels as AJS metadata consumers,
+     not generic flat translation-table lookups.
+   - Prefer typed metadata structures or accessors over UI components indexing
+     flat keys such as `group1.col3` or raw `ty` shapes such as `g.gty.p`.
+   - Preserve current labels and desktop/web behavior while extracting the
+     boundary; correct only explicit data defects inside an approved slice.
+
 ## Deferred / Optional Slices
 
 1. Build/test output-directory ownership cleanup is deferred until packaging,
@@ -64,8 +75,8 @@
    boundary, authentication model, and beta feedback are stable.
 4. Revisit viewer-specific bundle-size reductions only if a future
    compatibility, startup, or payload target creates stronger pressure.
-5. Consolidate i18n translation files only when duplication is high enough to
-   justify a targeted cleanup.
+5. Revisit broader i18n translation-file consolidation only after the AJS
+   metadata boundary is separated from generic string resolution.
 6. Add deeper JP1/AJS View interaction parity only after the current visual
    refresh and nested expansion behavior settle.
 7. Revisit directory structure under `src/extension/webview/` only if the


### PR DESCRIPTION
## Summary

- Add a roadmap feature spec for separating AJS definition metadata from generic i18n resources.
- Track the proposed investigation and approval boundary in the feature TASKS file.
- Register the feature in branch plans and promote the roadmap item from broad i18n cleanup to a typed AJS metadata boundary.

## Why

`ajscolumn` and `ty` currently carry AJS definition metadata as well as localized strings. Documenting the boundary first keeps future implementation slices focused on preserving behavior while improving type safety and avoiding direct raw metadata traversal from UI code.

## Validation

- `rtk pnpm run qlty`

## Notes

This is docs-only. Runtime code, tests, generated artifacts, and configuration are unchanged.