### PR TITLE
[codex] Document architecture migration roadmap features

### DIFF
--- a/docs/specs/current-state.md
+++ b/docs/specs/current-state.md
@@ -2,11 +2,21 @@
 
 ## Repository Shape
 
-The repository currently mixes legacy and target-oriented structure.
+The repository currently mixes legacy folder names with increasingly explicit
+application and adapter boundaries.
 
-- `src/domain` exists for emerging domain concepts and services
-- `src/extension` contains VS Code-facing behavior and bootstrap concerns
-- `src/ui-component` contains React/webview-oriented presentation code
+- `src/domain` contains raw parsed units, wrapper/interpreter models, normalized
+  AJS models, parameter semantics, and concrete ANTLR parser orchestration
+- `src/application` contains unit-list, flow-graph, unit-definition,
+  editor-feedback, telemetry-port, and WebAPI-import use cases or DTOs
+- `src/infrastructure` contains the concrete JP1/AJS3 WebAPI import adapter and
+  generated transport types
+- `src/extension` contains VS Code-facing adapters, explicit bootstrap wiring,
+  telemetry adapters, WebAPI command wiring, and webview orchestration
+- `src/ui-component` contains React/webview presentation code and
+  presentation-local flow layout state
+- `src/shared` contains host-neutral webview event contracts and shared app
+  resources
 - `src/generate/parser` contains generated parser artifacts
 - `src/test` contains extension test entry points
 - `sample` contains representative JP1/AJS definition files that can be reused
@@ -14,27 +24,32 @@ The repository currently mixes legacy and target-oriented structure.
 
 ## Current Architectural Tensions
 
-- activation and composition remain concentrated
-- parser-adjacent logic can still leak toward UI-oriented code
-- DTO and use-case boundaries are still being clarified
-- expanded flow layout is still vulnerable to order-sensitive nested-panel
-  collision handling, with layout growth responsibilities concentrated in one
-  presentation file
+- bootstrap is now split into lifecycle, runtime, subscription, viewer, and
+  WebAPI-import wiring modules, but all VS Code runtime construction still
+  converges in the extension adapter layer
+- concrete ANTLR orchestration still lives under `src/domain/services/parser`;
+  application use cases for unit-list building and syntax diagnostics import it
+  directly instead of depending on an application-facing parser port
+- raw `Unit` remains intentionally parser-adjacent, but semantic diagnostics
+  still operate directly on that raw model while normalized-model adoption is
+  further advanced in unit-list and flow-graph paths
+- flow rendering consumes application DTOs, while expanded nested-flow layout
+  remains presentation-local and is now split across focused geometry,
+  collision, growth, position, and reveal helpers
 - old folder names coexist with the target clean-architecture layout
-- package-management and validation workflow now center on `pnpm`, so local
-  docs, CI, and contributor instructions need to stay aligned with the pinned
-  lockfile and `packageManager` metadata
+- package-management and validation workflow center on the pinned `pnpm`
+  version and repository scripts
 - webview payload contracts are now plain DTOs and event objects, reducing
   serialization-boundary coupling across desktop and web hosts
-- webview bundle-size pressure remains visible in roadmap planning, especially
-  while shared dependencies continue to grow
 - `UnitEntity` wrapper ids now use deterministic UUID v5 values derived from
   absolute paths, while current application-facing normalized AJS ids continue
   to use absolute paths
-- JP1/AJS parameter interpretation and command generation are not yet described
-  as explicitly reference-aligned to one target manual edition
-- server-side definition loading through the JP1/AJS WebAPI is not yet part of
-  the documented product boundary
+- JP1/AJS parameter interpretation and command generation are aligned to the
+  version 13 reference for the currently documented slices
+- read-only server-side definition loading through the JP1/AJS WebAPI exists as
+  a desktop beta behind application and infrastructure boundaries; web-host
+  import remains explicitly unsupported and real-environment verification is
+  still pending
 
 ## Constraints To Preserve During Migration
 
@@ -46,14 +61,15 @@ The repository currently mixes legacy and target-oriented structure.
 - dependency upgrades should be routine, but compatibility exceptions must stay
   documented and reviewable
 
-## Immediate Documentation Need
+## Immediate Migration Need
 
-Each meaningful change should identify:
+The next focused architecture slice should:
 
-- the use case being improved
-- the current boundary problem
-- the intended extraction path
-- the checks needed to prove behavior is preserved
+- define an application-facing parser port for consumers of raw definition text
+- move concrete ANTLR construction and tree-walking behind an infrastructure
+  adapter
+- preserve raw `Unit` and parser-error behavior at the initial seam
+- keep desktop and web bundles free of new host-specific dependencies
 
 ## Fixture Baseline
 
@@ -72,7 +88,7 @@ When new parser, normalization, unit-list, or flow-graph tests are added,
 prefer these shared fixtures over ad hoc inline definitions unless the test is
 specifically about a narrow edge case.
 
-## Newly Confirmed Product Direction
+## Confirmed Product Direction
 
 - JP1 reference alignment should target JP1/Automatic Job Management System 3
   version 13 documentation
@@ -80,8 +96,8 @@ specifically about a narrow edge case.
   source
 - generated `ajs` command support should use the Command Reference as the
   normative source
-- JP1/AJS WebAPI support is currently planned as read-only import of server
-  definition data
+- JP1/AJS WebAPI support currently provides read-only desktop import as a beta;
+  broader endpoint and web-host support remain outside the active boundary
 - flow-graph improvements are currently aimed at visual resemblance to
   JP1/AJS View, progressive nested expansion, and explicit navigation between
   list and flow views when both are available

--- a/docs/specs/features/classify-vscode-adapter-layout/SPECS.md
+++ b/docs/specs/features/classify-vscode-adapter-layout/SPECS.md
@@ -1,0 +1,110 @@
+# Feature Specification: Classify VS Code Adapter Layout
+
+## Purpose
+
+Eliminate the legacy `src/extension` bucket by relocating its modules to the
+target presentation, infrastructure, or outer bootstrap boundary according to
+responsibility.
+
+## Origin
+
+- Feature kind: roadmap feature
+- Source: target structure in `AGENTS.md` and `docs/specs/architecture.md`
+- Related plan: `docs/specs/plans.md`
+- Dependency: `features/establish-extension-composition-root/`
+
+## Requirements
+
+- VS Code commands, diagnostics, language providers, and webview orchestration
+  move under a clearly named presentation boundary.
+- VS Code-backed telemetry and credential implementations move under
+  infrastructure while continuing to implement application-owned ports.
+- Activation, lifecycle, dependency construction, and subscription assembly
+  move to an outer bootstrap boundary that may compose presentation,
+  application, and infrastructure without becoming an inner-layer dependency.
+- The root desktop/web extension entry point remains compatible with webpack
+  entry configuration and VS Code activation.
+- All imports, test paths, TypeScript includes/aliases, and bundle references
+  affected by relocation are updated together.
+- File relocation must not be combined with logic redesign or behavior change.
+
+## Architecture
+
+- Domain and application: unchanged.
+- Presentation: owns VS Code interaction, commands, editor providers, viewer
+  orchestration, and adapter dependency types.
+- Infrastructure: owns SDK-backed telemetry, credential storage, and other
+  technical adapter implementations.
+- Composition: the root extension entry and bootstrap own activation,
+  construction, subscription assembly, and disposal across outer layers.
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected production scope: current `src/extension/**`, `src/extension.ts`,
+  imports from bootstrap and tests, webpack entries, and TypeScript test
+  includes.
+- Affected tests: extension lifecycle/runtime/subscriptions, commands,
+  diagnostics-facing wiring, telemetry, credential storage, webview mediator,
+  store, factory, routing, and viewer wiring tests.
+- Propagation decision: relocate only after composition ownership is explicit;
+  update every reference atomically while preserving module APIs where useful.
+
+### Breaking Change Analysis
+
+- User-visible behavior: none intended.
+- API/DTO/schema compatibility: no public, command, contribution, or webview
+  contract change.
+- VS Code/web extension compatibility: both webpack extension entry points and
+  browser-safe import chains must remain valid.
+- Changed scenarios: none.
+
+### Alternative Considerations
+
+- Rename `src/extension` wholesale to presentation: rejected because telemetry
+  and credential implementations have infrastructure responsibility.
+- Keep the legacy folder indefinitely: rejected because it obscures the target
+  dependency boundaries after responsibilities are explicit.
+
+### Approval Impact Decisions
+
+- Approval evidence owner: TASKS.md `Human Approval`.
+- Re-approval is required for logic changes, public module/DTO changes, command
+  changes, dependency changes, or a partial relocation that leaves ambiguous
+  ownership.
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility: preserve browser entry, fallbacks, and
+  host-guarded technical adapters.
+- Desktop extension compatibility: preserve activation, commands, diagnostics,
+  hover, viewers, telemetry, and WebAPI beta behavior.
+
+## Acceptance Criteria
+
+- No production module remains under the `src/extension/` directory after the
+  approved relocation; the webpack entry file `src/extension.ts` remains the
+  stable extension entry unless planning proves a path change is necessary.
+- Each relocated module has an explicit presentation, infrastructure, or outer
+  bootstrap owner.
+- Desktop and web bundles retain the existing entry points and contribution
+  behavior.
+- Tests verify activation, command registration, diagnostics, hover, viewers,
+  telemetry selection, and WebAPI host guards after path relocation.
+- All affected tests and import-resolution checks pass.
+- Quality checks, desktop tests, web tests, and production build pass.
+
+## Non-Goals
+
+- Refactoring module logic, changing use cases, or redesigning bootstrap
+  behavior.
+- Moving React webview code from `src/ui-component`.
+- Changing webpack behavior beyond paths required by relocation.
+- Renaming domain, application, shared, generated, or test directories.
+
+## Open Questions
+
+- Planning must classify each current extension module before any move and
+  split implementation commits if reviewability requires it.

--- a/docs/specs/features/classify-vscode-adapter-layout/TASKS.md
+++ b/docs/specs/features/classify-vscode-adapter-layout/TASKS.md
@@ -1,0 +1,40 @@
+# Feature Tasks: Classify VS Code Adapter Layout
+
+## Sync Rule
+
+- Update this file with task decisions, `plans.md` when active features change,
+  and `roadmap.md` when repository sequencing changes.
+- Keep only current approval, risk, validation, and next-decision state.
+
+## Current Status
+
+- Runtime status: not started; implementation approval is pending.
+- Active slice: classify current extension modules and plan relocation.
+- Open follow-up: record the destination of every module before approval.
+
+## Human Approval
+
+- Status: Pending
+- Approved at: none
+- Approved scope: none
+
+Implementation must not start while Status is Pending.
+
+## Active Tasks
+
+- [x] Feature boundary and initial impact recorded.
+- [ ] Use `sdd-plan-task` to classify every `src/extension` module.
+- [ ] Obtain implementation approval for the exact relocation map.
+- [ ] Verify production, test, webpack, and TypeScript references.
+- [ ] Relocate modules without logic changes.
+
+## Validation
+
+- [ ] Confirm no stale imports or production files remain in the
+      `src/extension/` directory while `src/extension.ts` remains resolvable.
+- [ ] Run `rtk pnpm run qlty`, desktop tests, web tests, and build.
+
+## Notes
+
+- Docs approval permits a docs-only PR, not runtime implementation.
+- Relocation must preserve git history where practical and remain reviewable.

--- a/docs/specs/features/establish-extension-composition-root/SPECS.md
+++ b/docs/specs/features/establish-extension-composition-root/SPECS.md
@@ -1,0 +1,105 @@
+# Feature Specification: Establish Extension Composition Root
+
+## Purpose
+
+Make extension bootstrap the single place that constructs concrete application
+and infrastructure dependencies and injects them into VS Code-facing adapters.
+
+## Origin
+
+- Feature kind: roadmap feature
+- Source: `AGENTS.md` activation/bootstrap concern and target dependency rules
+- Related plan: `docs/specs/plans.md`
+- Dependency: `features/extract-parser-adapter-boundary/`
+
+## Requirements
+
+- Bootstrap constructs concrete telemetry, parser, WebAPI, and application
+  dependencies needed by extension adapters.
+- Diagnostics, webview document delivery, commands, and other VS Code-facing
+  adapters receive explicit callable or typed dependencies instead of
+  constructing infrastructure or importing concrete application functions.
+- Existing lifecycle and disposal ownership remains explicit.
+- Do not introduce a service locator, dependency-injection framework, global
+  mutable registry, or new runtime dependency.
+- Preserve synchronous parser consumers and asynchronous WebAPI consumers.
+
+## Architecture
+
+- Domain: unchanged.
+- Application: exposes use cases and ports without VS Code types.
+- Presentation: receives application capabilities through explicit adapter
+  dependencies.
+- Infrastructure: concrete adapters are constructed by bootstrap and exposed
+  only through application-owned ports where applicable.
+- Composition: the outer extension entry/bootstrap may depend on presentation,
+  application, and infrastructure; those inner layers do not depend back on
+  bootstrap.
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected composition modules: extension activation, runtime, subscriptions,
+  viewer wiring, WebAPI-import wiring, and lifecycle ownership.
+- Affected adapters: diagnostics registration, webview document updates,
+  preview/import commands, telemetry, and credential-backed WebAPI import.
+- Affected tests: bootstrap/runtime/subscription/viewer wiring, diagnostics,
+  webview document delivery, command, telemetry, and WebAPI command tests.
+- Propagation decision: change construction and injection together while
+  leaving use-case output, commands, contribution points, and UI behavior
+  unchanged.
+
+### Breaking Change Analysis
+
+- User-visible behavior: none intended.
+- API/DTO/schema compatibility: public and webview DTOs remain unchanged;
+  internal adapter dependency types may change.
+- VS Code/web extension compatibility: both hosts retain the same extension
+  entry point and host-specific capability decisions.
+- Changed scenarios: none.
+
+### Alternative Considerations
+
+- Keep construction distributed across adapter modules: rejected because
+  concrete dependency ownership remains implicit.
+- Add a dependency-injection container: rejected as unnecessary complexity for
+  the current extension size.
+
+### Approval Impact Decisions
+
+- Approval evidence owner: TASKS.md `Human Approval`.
+- Re-approval is required for user-visible behavior, lifecycle timing,
+  contribution-point, DTO, telemetry-scope, or runtime-dependency changes.
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility: preserve current unsupported-host decisions and
+  keep the web bootstrap import chain free of newly introduced Node-only or
+  desktop-only dependencies.
+- Desktop extension compatibility: activation, disposal, commands, viewers,
+  diagnostics, telemetry, and WebAPI beta behavior remain stable.
+
+## Acceptance Criteria
+
+- Concrete application and infrastructure construction has one explicit
+  bootstrap owner.
+- VS Code adapter modules can be tested with fake dependencies without loading
+  concrete infrastructure.
+- Activation and disposal occur once and retain existing observable behavior.
+- Tests cover desktop/web host selection, dependency construction, command
+  registration, and single disposal without concrete network access.
+- Desktop tests, web tests, quality checks, and production build pass.
+- No new runtime dependency or minimum VS Code change is introduced.
+
+## Non-Goals
+
+- Changing parser, diagnostics, viewer, WebAPI, telemetry, or command behavior.
+- Moving source directories into the target presentation layout.
+- Introducing a general-purpose container or plugin system.
+
+## Open Questions
+
+- Planning must choose whether the smallest dependency bundle is a typed object
+  or focused factory functions.

--- a/docs/specs/features/establish-extension-composition-root/TASKS.md
+++ b/docs/specs/features/establish-extension-composition-root/TASKS.md
@@ -1,0 +1,39 @@
+# Feature Tasks: Establish Extension Composition Root
+
+## Sync Rule
+
+- Update this file with task decisions, `plans.md` when active features change,
+  and `roadmap.md` when repository sequencing changes.
+- Keep only current approval, risk, validation, and next-decision state.
+
+## Current Status
+
+- Runtime status: not started; implementation approval is pending.
+- Active slice: plan explicit dependency construction and injection.
+- Open follow-up: choose the smallest dependency bundle during planning.
+
+## Human Approval
+
+- Status: Pending
+- Approved at: none
+- Approved scope: none
+
+Implementation must not start while Status is Pending.
+
+## Active Tasks
+
+- [x] Feature boundary and initial impact recorded.
+- [ ] Use `sdd-plan-task` to map construction, injection, and disposal owners.
+- [ ] Obtain implementation approval for the planned slice.
+- [ ] Verify every affected reference after approval.
+- [ ] Implement only the approved composition-root slice.
+
+## Validation
+
+- [ ] Add or update bootstrap and fake-dependency adapter tests.
+- [ ] Run `rtk pnpm run qlty`, desktop tests, web tests, and build.
+
+## Notes
+
+- Docs approval permits a docs-only PR, not runtime implementation.
+- No durable behavior-contract change is expected.

--- a/docs/specs/features/extract-parser-adapter-boundary/SPECS.md
+++ b/docs/specs/features/extract-parser-adapter-boundary/SPECS.md
@@ -1,0 +1,148 @@
+# Feature Specification: Extract Parser Adapter Boundary
+
+## Purpose
+
+Move concrete ANTLR parser orchestration out of the domain layer behind an
+application-facing parser port, without changing parsing or user-visible
+behavior.
+
+## Origin
+
+- Feature kind: roadmap feature
+- Source use cases:
+  `docs/requirements/use-cases/uc-build-unit-list.md` and
+  `docs/requirements/use-cases/uc-provide-editor-feedback.md`
+- Roadmap source: `docs/specs/roadmap.md`, "Introduce stricter
+  parser/infrastructure boundaries"
+- Related plan: `docs/specs/plans.md`
+
+## Requirements
+
+- Application consumers of raw JP1/AJS definition text depend on a
+  repository-owned parser port rather than concrete ANTLR classes or a parser
+  implementation located in domain.
+- Concrete lexer creation, token-stream creation, parser invocation,
+  syntax-error listener wiring, parse-tree walking, and evaluator invocation
+  live in an infrastructure adapter.
+- The initial port preserves the existing parse result: raw root `Unit` values
+  and repository-owned parser errors with the same line, column, and message
+  semantics. ANTLR recognizer, offending-symbol, and exception types do not
+  cross into application contracts.
+- Existing unit-list and editor-feedback behavior remains unchanged.
+- Parser grammar, generated ANTLR artifacts, evaluator semantics, raw `Unit`,
+  normalization, and semantic diagnostic rules are not redesigned in this
+  feature.
+- Dependency injection remains explicit and small; do not introduce a general
+  service container.
+- Parsing remains synchronous for this slice so current editor diagnostics and
+  webview document-update paths do not acquire lifecycle or ordering changes.
+- No new runtime dependency is introduced.
+
+## Architecture
+
+- Domain: retains raw `Unit`, normalization, and parser-independent JP1/AJS
+  semantics; does not import generated parser or ANTLR runtime types.
+- Application: owns the parser port and parse-result/error contracts used by
+  application use cases.
+- Presentation: continues to consume existing DTOs; no parser dependency is
+  introduced.
+- Infrastructure: implements the parser port using the generated ANTLR lexer,
+  parser, syntax listener, tree walker, and parse-tree-to-`Unit` evaluator.
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected production callers: `buildUnitList` and `buildSyntaxDiagnostics`.
+- Affected concrete parser components: `AjsParser.ts`, `AjsEvaluator.ts`, and
+  `SyntaxErrorListener.ts`; their generated-parser and ANTLR-dependent
+  responsibilities move behind the infrastructure adapter.
+- Affected composition: parser adapter construction must be wired at the
+  nearest existing application/extension composition boundary used by both
+  desktop and web hosts.
+- Affected tests: application use-case tests need injectable parser coverage;
+  parser, normalization, parameter, wrapper, flow, and presentation tests that
+  currently import `parseAjs` need a stable test-facing adapter or fixture
+  boundary without weakening production dependencies.
+- Related docs: `current-state.md`, `architecture.md`, `plans.md`, `roadmap.md`,
+  and the two source use cases.
+- Propagation decision: update all production imports of the concrete parser
+  and all test imports broken by its relocation in the same approved slice;
+  leave raw-model consumers and semantic rules otherwise unchanged.
+
+### Breaking Change Analysis
+
+- User-visible behavior: none intended.
+- API/DTO/schema compatibility: existing unit-list document and diagnostic DTOs
+  remain unchanged. The internal `BuildUnitListResult.errors` contract changes
+  from ANTLR-owned error objects to repository-owned parser errors containing
+  the consumed position and message fields.
+- VS Code/web extension compatibility: both bundles must use the same
+  host-neutral parser adapter; no Node-only dependency may enter shared paths.
+- Changed scenarios: none; existing build-unit-list and editor-feedback
+  scenarios are regression contracts.
+
+### Alternative Considerations
+
+- Keep concrete parsing in domain: rejected because application use cases
+  remain coupled to ANTLR orchestration and the target dependency boundary is
+  not achieved.
+- Return only normalized `AjsDocument` from the first port: rejected for this
+  slice because semantic diagnostics still require raw `Unit` and combining
+  normalization migration would create a second independent purpose.
+- Keep the generated-type evaluator or listener in domain: rejected because it
+  would leave domain coupled to ANTLR mechanics after orchestration moves.
+
+### Approval Impact Decisions
+
+- Approval evidence owner: TASKS.md `Human Approval`.
+- Re-approval is required for parser grammar or generated-artifact changes,
+  evaluator behavior changes, raw/normalized model redesign, diagnostic-rule
+  changes, DTO changes, or a new runtime dependency.
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility: preserve the existing browser bundle and avoid
+  Node-only modules in the port and adapter import chain.
+- Desktop extension compatibility: preserve extension activation, parsing,
+  diagnostics, list, flow, and CSV behavior.
+- The parser port and adapter remain synchronous in both hosts.
+- Model, semantic-navigation, or agent choice does not change this behavior
+  contract or the SDD approval gate.
+
+## Acceptance Criteria
+
+- No application production module imports the concrete ANTLR parser
+  implementation from domain.
+- Domain code no longer owns concrete ANTLR runtime orchestration.
+- Domain production modules no longer import `antlr4ts` or generated parser
+  types.
+- Unit-list and syntax-diagnostic outputs remain compatible for valid and
+  invalid definitions.
+- Parser error line, column, and message semantics remain unchanged.
+- Infrastructure adapter tests cover successful nested-unit mapping and syntax
+  errors from invalid input.
+- Application tests use a fake parser port to prove unit-list and diagnostic
+  decisions do not require ANTLR-owned types or the concrete adapter.
+- Existing raw-model, normalization, flow, parameter, and wrapper tests retain
+  a clear test boundary and pass.
+- Desktop tests, web tests, quality checks, and production build pass.
+- `engines.vscode` and public contribution points remain unchanged.
+
+## Non-Goals
+
+- Changing JP1/AJS grammar, parse behavior, or generated parser artifacts.
+- Migrating semantic diagnostics from raw `Unit` to `AjsDocument`.
+- Moving raw `Unit`, normalization, or parser-independent JP1/AJS semantics
+  into infrastructure.
+- Renaming all legacy source folders or completing the full target directory
+  structure.
+- Refactoring bootstrap, webview, flow layout, CSV, telemetry, or WebAPI import.
+
+## Open Questions
+
+- The planning phase must choose the smallest port construction and injection
+  shape that supports both production use cases without a service container.
+- The planning phase must decide whether parser-focused tests import the
+  infrastructure adapter directly or use a dedicated test helper.

--- a/docs/specs/features/extract-parser-adapter-boundary/TASKS.md
+++ b/docs/specs/features/extract-parser-adapter-boundary/TASKS.md
@@ -1,0 +1,67 @@
+# Feature Tasks: Extract Parser Adapter Boundary
+
+## Sync Rule
+
+- Update this file in the same commit whenever a task is completed, re-scoped,
+  or intentionally dropped.
+- Update `docs/specs/plans.md` only when the branch starts, stops, or changes an
+  active feature.
+- Update `docs/specs/roadmap.md` when repository sequencing changes.
+- Keep this file focused on current state only; do not retain historical logs,
+  prior approvals, or long validation diaries once they stop being actionable.
+
+## Current Status
+
+- Runtime status: not started; implementation approval is pending.
+- Active slice: investigate and plan the parser port plus ANTLR adapter
+  extraction.
+- Open follow-up: choose injection and test-helper boundaries during
+  `sdd-plan-task` planning.
+
+## Human Approval
+
+- Status: Pending
+- Approved at: none
+- Approved scope: none
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
+`Approved at` records the approval result only; do not copy the approval
+message.
+
+Reset this section back to Pending when the approved slice is complete and no
+active implementation approval remains.
+
+## Active Tasks
+
+- [x] Impact investigation completed and recorded in SPECS/TASKS by
+      responsibility.
+- [ ] Human approval recorded.
+- [ ] Use `sdd-plan-task` to choose the exact parser port, adapter, composition,
+      test-helper, and file-move scope.
+- [ ] Verify references and call sites after approval before implementation.
+- [ ] Implement only the approved parser adapter boundary slice.
+- [ ] Update architecture/current-state/roadmap records after implementation
+      changes the repository state.
+
+## Validation
+
+- [ ] Add infrastructure adapter contract tests for valid nested input and
+      invalid-input position/message preservation.
+- [ ] Add or update application use-case tests using a fake parser port.
+- [ ] Confirm direct parser consumers and test imports use the approved
+      production or test boundary.
+- [ ] Run `rtk pnpm run qlty`.
+- [ ] Run `rtk pnpm test`.
+- [ ] Run `rtk pnpm run test:web`.
+- [ ] Run `rtk pnpm run build`.
+
+## Notes
+
+- Existing use-case behavior is preserved; no durable observable scenario
+  change is currently expected.
+- Approval of these feature documents permits a docs-only pull request; it does
+  not approve runtime implementation. Implementation approval remains pending
+  until `sdd-plan-task` records the exact implementation scope and a human
+  approves that scope.
+- Re-approval boundaries are listed in SPECS.md.

--- a/docs/specs/features/normalize-semantic-diagnostics-input/SPECS.md
+++ b/docs/specs/features/normalize-semantic-diagnostics-input/SPECS.md
@@ -1,0 +1,103 @@
+# Feature Specification: Normalize Semantic Diagnostics Input
+
+## Purpose
+
+Make semantic diagnostic rules consume normalized `AjsDocument` / `AjsUnit`
+data instead of parser-adjacent raw `Unit` trees.
+
+## Origin
+
+- Feature kind: roadmap feature
+- Source use cases: `uc-provide-editor-feedback.md` and
+  `uc-normalize-ajs-document.md`
+- Roadmap source: normalized-model convergence
+- Related plan: `docs/specs/plans.md`
+- Dependency: `features/extract-parser-adapter-boundary/`
+
+## Requirements
+
+- Syntax parsing errors continue to be reported before semantic validation.
+- Syntactically valid raw units are normalized once before semantic rules run.
+- Normalized parameters retain the source line, column, and length required for
+  diagnostics without exposing ANTLR types.
+- Semantic rule builders, lookup helpers, and validators consume normalized
+  units and parameters.
+- All existing JP1/AJS3 version 13 diagnostic messages, positions, severities,
+  effective defaults, ancestor lookups, and invalid-combination decisions are
+  preserved.
+- Do not expand the supported diagnostic rule set in this feature.
+
+## Architecture
+
+- Domain: normalized AJS types retain parser-independent source-location data
+  and lookup semantics needed by multiple application consumers.
+- Application: semantic diagnostics depend on normalized contracts and produce
+  existing diagnostic DTOs.
+- Presentation: VS Code mapping remains unchanged.
+- Infrastructure: parser adapter supplies raw units to the normalization seam;
+  no diagnostic policy moves into infrastructure.
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected domain components: normalized parameter types, normalization
+  mapping, and normalized lookup/navigation helpers.
+- Affected application components: semantic diagnostic core, rule builders,
+  rule sets, validators, and unit lookup helpers.
+- Affected tests: normalization tests and the full semantic-diagnostics suite.
+- Propagation decision: migrate all semantic diagnostic rules in one coherent
+  input-model change; leave parser syntax errors and hover behavior unchanged.
+
+### Breaking Change Analysis
+
+- User-visible behavior: none intended.
+- API/DTO/schema compatibility: diagnostic DTOs remain unchanged; normalized
+  parameter DTOs gain optional or required source-location fields as planning
+  determines from parser guarantees.
+- VS Code/web extension compatibility: shared pure TypeScript behavior remains
+  host-neutral.
+- Changed scenarios: none; all existing editor-feedback scenarios are
+  regression contracts.
+
+### Alternative Considerations
+
+- Migrate rules gradually with dual raw/normalized inputs: rejected because it
+  creates duplicate lookup semantics and inconsistent diagnostics.
+- Keep diagnostics permanently on raw units: rejected because it preserves the
+  remaining application/raw-parser coupling.
+
+### Approval Impact Decisions
+
+- Approval evidence owner: TASKS.md `Human Approval`.
+- Re-approval is required for new diagnostic rules, changed messages or
+  positions, parser behavior, public DTO changes, or normalization semantics
+  beyond source-location preservation.
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web and desktop compatibility: diagnostic output and host-neutral execution
+  remain unchanged in both extension hosts.
+
+## Acceptance Criteria
+
+- Semantic diagnostic production modules no longer import raw `Unit` or
+  `UnitParameter`.
+- Normalized parameters preserve diagnostic source positions exactly.
+- Existing semantic-diagnostic scenarios and messages pass unchanged.
+- Focused tests cover nested ancestor lookup, repeated parameters, effective
+  defaults, and source-position mapping through normalization.
+- Desktop tests, web tests, quality checks, and production build pass.
+
+## Non-Goals
+
+- Adding or removing JP1/AJS diagnostic rules.
+- Changing parser syntax errors or hover behavior.
+- Replacing unit-list or flow-graph normalized contracts.
+- Refactoring presentation adapters or source directories.
+
+## Open Questions
+
+- Planning must verify whether normalized parameter location fields can be
+  required for every parsed parameter without inventing fallback positions.

--- a/docs/specs/features/normalize-semantic-diagnostics-input/TASKS.md
+++ b/docs/specs/features/normalize-semantic-diagnostics-input/TASKS.md
@@ -1,0 +1,39 @@
+# Feature Tasks: Normalize Semantic Diagnostics Input
+
+## Sync Rule
+
+- Update this file with task decisions, `plans.md` when active features change,
+  and `roadmap.md` when repository sequencing changes.
+- Keep only current approval, risk, validation, and next-decision state.
+
+## Current Status
+
+- Runtime status: not started; implementation approval is pending.
+- Active slice: plan normalized source-location and diagnostic-rule migration.
+- Open follow-up: decide required versus optional normalized location fields.
+
+## Human Approval
+
+- Status: Pending
+- Approved at: none
+- Approved scope: none
+
+Implementation must not start while Status is Pending.
+
+## Active Tasks
+
+- [x] Feature boundary and initial impact recorded.
+- [ ] Use `sdd-plan-task` to inventory every raw-unit diagnostic dependency.
+- [ ] Obtain implementation approval for the complete migration slice.
+- [ ] Verify all rule, helper, and test references after approval.
+- [ ] Implement only the approved normalized-input migration.
+
+## Validation
+
+- [ ] Add normalized position and diagnostic parity tests.
+- [ ] Run `rtk pnpm run qlty`, desktop tests, web tests, and build.
+
+## Notes
+
+- Docs approval permits a docs-only PR, not runtime implementation.
+- Existing editor-feedback use-case scenarios remain the behavior contract.

--- a/docs/specs/features/relocate-react-webview-presentation/SPECS.md
+++ b/docs/specs/features/relocate-react-webview-presentation/SPECS.md
@@ -1,0 +1,92 @@
+# Feature Specification: Relocate React Webview Presentation
+
+## Purpose
+
+Relocate React webview presentation from `src/ui-component` to
+`src/presentation/webview` without changing viewer behavior.
+
+## Origin
+
+- Feature kind: roadmap feature
+- Source: target structure in `AGENTS.md` and `docs/specs/architecture.md`
+- Related plan: `docs/specs/plans.md`
+- Dependency: `features/classify-vscode-adapter-layout/`
+
+## Requirements
+
+- React table, flow, dialog, context, bootstrap, and presentation-local helper
+  modules move together under `src/presentation/webview`.
+- Webpack viewer entries, TypeScript aliases, imports, and test references are
+  updated to the new presentation path.
+- Application DTO and shared event dependencies remain unchanged.
+- Presentation-local search, table formatting, CSV view adaptation, flow
+  layout, and interaction logic are not redesigned during relocation.
+- No React, MUI, XyFlow, or webview dependency moves into domain/application.
+
+## Architecture
+
+- Domain, application, and infrastructure: unchanged.
+- Presentation: explicitly owns React webview components, controllers, layout,
+  view adapters, and browser entry modules.
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected production scope: current `src/ui-component/**`, webpack table/flow
+  viewer entries, TypeScript alias configuration, and imports from tests.
+- Affected tests: table filtering/export, flow graph view/layout/search,
+  selection, nested expansion, reveal, and unit-definition interactions.
+- Propagation decision: update the complete presentation subtree and all path
+  references together; do not alter application or shared contracts.
+
+### Breaking Change Analysis
+
+- User-visible behavior: none intended.
+- API/DTO/schema compatibility: unchanged.
+- VS Code/web extension compatibility: table and flow viewer bundles must retain
+  their current entry behavior in desktop and web hosts.
+- Changed scenarios: none.
+
+### Alternative Considerations
+
+- Keep `src/ui-component`: rejected because it hides the established
+  presentation-layer ownership.
+- Mix relocation with component cleanup: rejected to keep review focused and
+  behavior-preserving.
+
+### Approval Impact Decisions
+
+- Approval evidence owner: TASKS.md `Human Approval`.
+- Re-approval is required for UI behavior, DTO/event contracts, dependencies,
+  bundle topology, or component logic changes beyond required import paths.
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility: preserve table and flow browser bundles and
+  standard JSON event boundaries.
+- Desktop extension compatibility: preserve viewer rendering, interaction,
+  navigation, CSV export, and unit-definition behavior.
+
+## Acceptance Criteria
+
+- No production module remains under `src/ui-component`.
+- React/webview production code resides under `src/presentation/webview`.
+- Webpack entries and TypeScript aliases resolve the new paths.
+- Desktop and web viewer bundles expose the same table/flow entry behavior and
+  do not gain Node-only imports.
+- Existing table, flow, interaction, and presentation tests pass unchanged
+  except for import paths.
+- Quality checks, desktop tests, web tests, and production build pass.
+
+## Non-Goals
+
+- Component redesign, styling changes, or viewer behavior changes.
+- Moving VS Code extension adapters.
+- Changing application DTOs, shared events, dependencies, or bundle contents.
+- Refactoring presentation-local algorithms.
+
+## Open Questions
+
+- None.

--- a/docs/specs/features/relocate-react-webview-presentation/TASKS.md
+++ b/docs/specs/features/relocate-react-webview-presentation/TASKS.md
@@ -1,0 +1,39 @@
+# Feature Tasks: Relocate React Webview Presentation
+
+## Sync Rule
+
+- Update this file with task decisions, `plans.md` when active features change,
+  and `roadmap.md` when repository sequencing changes.
+- Keep only current approval, risk, validation, and next-decision state.
+
+## Current Status
+
+- Runtime status: not started; implementation approval is pending.
+- Active slice: plan the presentation subtree and path relocation.
+- Open follow-up: none before detailed reference inventory.
+
+## Human Approval
+
+- Status: Pending
+- Approved at: none
+- Approved scope: none
+
+Implementation must not start while Status is Pending.
+
+## Active Tasks
+
+- [x] Feature boundary and initial impact recorded.
+- [ ] Use `sdd-plan-task` to inventory source, test, alias, and webpack paths.
+- [ ] Obtain implementation approval for the exact relocation map.
+- [ ] Verify every affected reference after approval.
+- [ ] Relocate presentation files without logic changes.
+
+## Validation
+
+- [ ] Confirm no stale imports or production files remain in `src/ui-component`.
+- [ ] Run `rtk pnpm run qlty`, desktop tests, web tests, and build.
+
+## Notes
+
+- Docs approval permits a docs-only PR, not runtime implementation.
+- No durable behavior-contract change is expected.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -40,6 +40,18 @@ rules in `docs/specs/README.md`, not in this file.
 
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
+- `docs/specs/features/extract-parser-adapter-boundary/`:
+  approved roadmap documentation awaiting task planning and implementation
+  approval for the application parser port and infrastructure ANTLR adapter
+  boundary.
+- `docs/specs/features/establish-extension-composition-root/`:
+  roadmap feature awaiting planning after parser-boundary extraction.
+- `docs/specs/features/normalize-semantic-diagnostics-input/`:
+  roadmap feature awaiting planning for normalized diagnostic inputs.
+- `docs/specs/features/classify-vscode-adapter-layout/`:
+  roadmap feature awaiting composition-root completion and relocation planning.
+- `docs/specs/features/relocate-react-webview-presentation/`:
+  roadmap feature awaiting VS Code adapter layout classification.
 
 Completed feature-local folders should be removed after their durable behavior
 contracts, active decisions, and unresolved risks have been moved to the

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -32,17 +32,48 @@
    - JP1/AJS3 version 13 remains the normative product target for future
      parameter and command semantics; future manual-alignment work should start
      as a focused feature when new supported scope is introduced.
+   - Track semantic-diagnostic convergence in
+     `features/normalize-semantic-diagnostics-input/` after parser-boundary
+     extraction.
 
 3. Introduce stricter parser/infrastructure boundaries.
 
-   - Define an application-facing parser or document-loading port.
-   - Move concrete parser orchestration behind an adapter boundary when
-     practical.
+   - Track the active first slice in
+     `features/extract-parser-adapter-boundary/`.
+   - Define an application-facing parser port for raw definition text.
+   - Move concrete ANTLR orchestration behind an infrastructure adapter while
+     preserving raw `Unit` and parser-error behavior.
    - Keep generated ANTLR artifacts and parser-specific mechanics out of
      application use cases.
    - Preserve current desktop and web extension behavior while migrating.
+   - Defer normalized-only parsing and semantic-diagnostic model migration to
+     later single-purpose features.
 
-4. Use Qlty findings as architectural feedback when they expose a clear
+4. Establish an explicit extension composition root.
+
+   - Track dependency construction and injection in
+     `features/establish-extension-composition-root/`.
+   - Construct concrete application and infrastructure dependencies in
+     bootstrap and inject them into VS Code-facing adapters.
+   - Preserve lifecycle, disposal, desktop, and web behavior without adding a
+     service container.
+
+5. Classify legacy VS Code adapter layout.
+
+   - Track the relocation in `features/classify-vscode-adapter-layout/`.
+   - Move VS Code-facing modules to presentation, technical adapters to
+     infrastructure, and activation/composition modules to an outer bootstrap
+     boundary after ownership is explicit.
+   - Preserve the desktop and web extension entry points.
+
+6. Relocate React webview presentation.
+
+   - Track the relocation in
+     `features/relocate-react-webview-presentation/`.
+   - Move `src/ui-component` to `src/presentation/webview` without combining
+     relocation with UI or algorithm changes.
+
+7. Use Qlty findings as architectural feedback when they expose a clear
    responsibility or boundary concern.
 
    - The qlty-driven architecture refactoring feature is complete through the
@@ -68,9 +99,7 @@
    translation-resource maintenance creates a concrete blocker.
 6. Add deeper JP1/AJS View interaction parity only after the current visual
    refresh and nested expansion behavior settle.
-7. Revisit directory structure under `src/extension/webview/` only if the
-   remaining files stop reading as one cohesive viewer module.
-8. Add more expanded-flow layout regression fixtures only if real-world nested
+7. Add more expanded-flow layout regression fixtures only if real-world nested
    layout examples expose additional collision or refit gaps.
 
 ## Done Criteria For A Slice


### PR DESCRIPTION
## Summary

- refresh `current-state.md` against the current repository structure
- add five focused roadmap feature specifications for parser boundaries, composition, normalized diagnostics, VS Code adapter layout, and React webview placement
- update branch plans and repository sequencing
- preserve the SDD implementation gate; runtime implementation remains unapproved

## Impact

This is a docs-only change. It defines incremental architecture migration boundaries while preserving desktop and web extension compatibility expectations.

## Validation

- `rtk pnpm run qlty`
- `rtk pnpm run lint:md`
- `git diff --cached --check`

The feature content was reviewed independently three times for SDD scope, dependency direction, and compatibility/test coverage.