### PR TITLE
[codex] Add SDD review follow-up features

### DIFF
--- a/docs/specs/features/clarify-unit-list-document-rehydration/SPECS.md
+++ b/docs/specs/features/clarify-unit-list-document-rehydration/SPECS.md
@@ -1,0 +1,109 @@
+# Feature Specification: Clarify Unit-List Document Rehydration
+
+## Purpose
+
+Make the production purpose and allowed boundary of unit-list DTO-to-model
+rehydration explicit without changing list or flow-viewer behavior.
+
+## Origin
+
+- Source: architecture review finding that `toRootUnits` and `toAjsDocument`
+  are production exports whose intended ownership was unclear
+- Feature kind: transient branch feature
+- Related plan: `docs/specs/plans.md`
+
+## Requirements
+
+- Verify every production and test reference to `toRootUnits` and
+  `toAjsDocument` before changing their visibility or location.
+- Retain the production rehydration path required by the table and flow
+  viewers, and document why an application-owned DTO is converted back to the
+  normalized AJS model at that boundary.
+- Keep raw `Unit` reconstruction internal unless a production caller requires
+  it directly.
+- Move test-only helpers to test support when doing so does not duplicate or
+  expose production conversion mechanics.
+- Preserve the existing DTO shape and viewer behavior.
+- Do not introduce parser, VS Code, React, or webview-library dependencies into
+  domain or application model code.
+
+## Architecture
+
+- Domain: continue to own raw `Unit`, normalized `AjsDocument`, and
+  normalization behavior without presentation dependencies
+- Application: own the unit-list DTO contract and the explicit conversion from
+  that DTO into the normalized model when required by application consumers
+- Presentation: consume the application conversion instead of reconstructing
+  raw parser-adjacent models itself
+- Infrastructure: none
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Expected affected code:
+  `src/application/unit-list/unitListDocument.ts`, table and flow viewer
+  consumers, and `src/test/suite/buildUnitList.test.ts`.
+- Propagation decision: production `toAjsDocument` behavior remains available;
+  raw `Unit` reconstruction visibility should be reduced only after reference
+  analysis proves no production caller requires it.
+
+### Breaking Change Analysis
+
+- User-visible behavior: none
+- API/DTO/schema compatibility: preserve `UnitListDocumentDto` and its current
+  serialized shape
+- VS Code/web extension compatibility: preserve both desktop and web viewer
+  paths; add no host-specific dependency
+- Changed scenarios: none
+
+### Alternative Considerations
+
+- Move both functions directly to test support: rejected because
+  `toAjsDocument` has production table and flow-viewer consumers.
+- Leave the exports unexplained: rejected because the reverse conversion looks
+  accidental and invites unsafe removal or presentation-local reconstruction.
+- Rework the viewer transport contract: deferred because it is a broader
+  serialization-boundary change and not required to clarify current ownership.
+
+### Approval Impact Decisions
+
+- Approval evidence owner: `TASKS.md` `Human Approval`
+- Scope changes requiring re-approval: DTO schema changes, viewer transport
+  redesign, parser or normalization behavior changes, or changes to observable
+  list and flow behavior.
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility: preserve the existing plain-DTO transport and
+  host-neutral conversion path
+- Desktop extension compatibility: preserve current list and flow behavior
+- Model, Serena, or agent choice does not change this behavior contract or the
+  SDD approval gate.
+
+## Acceptance Criteria
+
+- The production reason for DTO-to-`AjsDocument` rehydration is explicit at the
+  owning boundary.
+- `toAjsDocument` remains available to its production viewer consumers unless
+  an approved replacement is introduced.
+- `toRootUnits` is not exported for test convenience alone; its visibility is
+  justified by production references or reduced safely.
+- Unit-list DTO shape, normalization results, table behavior, and flow-viewer
+  behavior remain unchanged.
+- Relevant desktop and web checks pass after implementation.
+
+## Non-Goals
+
+- Redesigning webview serialization or viewer message contracts
+- Removing `UnitListDocumentDto`
+- Changing normalization semantics, parser output, list rows, flow nodes, or
+  user-visible behavior
+- Retiring `docs/specs/current-state.md`
+
+## Open Questions
+
+- Whether `toRootUnits` should become a private implementation detail of
+  `toAjsDocument` or remain exported for a production requirement must be
+  decided from complete reference analysis during task planning.

--- a/docs/specs/features/clarify-unit-list-document-rehydration/TASKS.md
+++ b/docs/specs/features/clarify-unit-list-document-rehydration/TASKS.md
@@ -1,0 +1,57 @@
+# Feature Tasks: Clarify Unit-List Document Rehydration
+
+## Sync Rule
+
+- Update this file in the same commit whenever a task is completed, re-scoped,
+  or intentionally dropped.
+- Update `docs/specs/plans.md` only when the branch starts, stops, or changes
+  an active feature.
+- Update `docs/specs/roadmap.md` when repository sequencing changes.
+- Keep this file focused on current state only; do not retain historical logs,
+  prior approvals, or long validation diaries once they stop being actionable.
+
+## Current Status
+
+- Runtime status: not started
+- Active slice: investigate and document the production rehydration boundary
+- Open follow-up: decide whether `toRootUnits` needs production visibility
+
+## Human Approval
+
+- Status: Pending
+- Approved at: none
+- Approved scope: none
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
+`Approved at` records the approval result only, such as `none` or `approved in
+current conversation`; do not copy the human approval message.
+
+Reset this section back to Pending when the approved slice is complete and no
+active implementation approval remains.
+
+## Active Tasks
+
+- [ ] Complete reference and call-site analysis for `toRootUnits`,
+      `toAjsDocument`, and `UnitListDocumentDto`.
+- [ ] Confirm why table and flow viewers require DTO rehydration and whether
+      that responsibility remains at the application boundary.
+- [ ] Propose the smallest visibility or documentation change that preserves
+      production behavior.
+- [ ] Record implementation impact and request human approval.
+- [ ] After approval, update focused tests for the retained boundary.
+
+## Validation
+
+- [ ] Run `rtk pnpm run qlty`.
+- [ ] Run relevant unit tests.
+- [ ] Run `rtk pnpm run test:web` and `rtk pnpm run build` because both viewer
+      hosts consume the shared DTO boundary.
+
+## Notes
+
+- Initial search confirms production `toAjsDocument` consumers in both table
+  and flow-viewer presentation paths; it must not be moved wholesale to test
+  support.
+- No use-case contract update is expected while DTO shape and observable
+  behavior remain unchanged.

--- a/docs/specs/features/retire-current-state-snapshot/SPECS.md
+++ b/docs/specs/features/retire-current-state-snapshot/SPECS.md
@@ -1,0 +1,105 @@
+# Feature Specification: Retire Current-State Snapshot
+
+## Purpose
+
+Retire the stale `docs/specs/current-state.md` snapshot after relocating only
+the information that remains useful for durable guidance or active work.
+
+## Origin
+
+- Source: architecture review finding that `current-state.md` no longer
+  matches the implementation, including its description of semantic
+  diagnostics as raw-model consumers
+- Feature kind: transient branch feature
+- Related plan: `docs/specs/plans.md`
+
+## Requirements
+
+- Remove `current-state.md` only after every still-relevant statement has an
+  explicit destination or is confirmed redundant with existing documentation.
+- Move reusable fixture guidance to `docs/specs/README.md` or an appropriate
+  testing document.
+- Keep confirmed product direction in `docs/specs/roadmap.md` or
+  `docs/specs/architecture.md` only when it is not already represented there.
+- Keep unresolved JP1/AJS WebAPI beta verification in the existing
+  `import-definition-via-webapi` feature tasks and branch plan.
+- Keep actionable architecture migration priorities in
+  `docs/specs/architecture.md`.
+- Remove `current-state.md` from the recommended reading order and document
+  role list when the snapshot is deleted.
+- Avoid copying stale implementation inventories into another long-lived
+  snapshot.
+
+## Architecture
+
+- Domain: none
+- Application: none
+- Presentation: none
+- Infrastructure: none
+- Documentation boundary: durable architecture decisions belong in
+  `architecture.md`, repository sequencing in `roadmap.md`, active WebAPI
+  evidence in its feature `TASKS.md`, and contributor workflow in `README.md`.
+
+## Impact Analysis
+
+### Dependency Impact
+
+- Affected docs: `docs/specs/current-state.md`, `docs/specs/README.md`,
+  `docs/specs/architecture.md`, `docs/specs/roadmap.md`,
+  `docs/specs/plans.md`, and potentially the active WebAPI feature tasks.
+- Propagation decision: preserve only current, non-duplicated guidance; runtime
+  code, tests, generated artifacts, configuration, and use-case contracts stay
+  unchanged.
+
+### Breaking Change Analysis
+
+- User-visible behavior: none
+- API/DTO/schema compatibility: none
+- VS Code/web extension compatibility: none; this is documentation-only
+- Changed scenarios: none
+
+### Alternative Considerations
+
+- Refresh `current-state.md`: rejected because a manually maintained
+  implementation snapshot will become stale again and duplicates architecture,
+  roadmap, plans, and feature-task responsibilities.
+- Delete it without relocation review: rejected because fixture guidance and
+  unresolved work could be lost.
+
+### Approval Impact Decisions
+
+- Approval evidence owner: `TASKS.md` `Human Approval`
+- Scope changes requiring re-approval: runtime, test, generated-artifact, or
+  configuration edits; new product behavior; or unrelated documentation
+  restructuring.
+
+## Compatibility
+
+- VS Code compatibility follows `package.json` `engines.vscode`.
+- Web extension compatibility: unaffected
+- Desktop extension compatibility: unaffected
+- Model, Serena, or agent choice does not change this documentation boundary or
+  the SDD approval gate.
+
+## Acceptance Criteria
+
+- `current-state.md` is removed only after its current, useful content is
+  retained in the responsible durable or active document.
+- No stale claim about semantic diagnostics consuming the raw model remains.
+- The SDD reading order and document-role guidance no longer reference
+  `current-state.md`.
+- Existing WebAPI beta verification remains visible in its active feature.
+- Documentation validation passes.
+
+## Non-Goals
+
+- Refactoring `UnitListDocumentDto` conversion exports in
+  `src/application/unit-list/unitListDocument.ts`
+- Changing parser, diagnostics, normalization, WebAPI, bootstrap, telemetry,
+  desktop, or web-extension behavior
+- Creating a replacement implementation-state snapshot
+
+## Open Questions
+
+- Whether fixture guidance belongs directly in `docs/specs/README.md` or in a
+  dedicated existing testing document should be decided during task planning.

--- a/docs/specs/features/retire-current-state-snapshot/TASKS.md
+++ b/docs/specs/features/retire-current-state-snapshot/TASKS.md
@@ -1,0 +1,54 @@
+# Feature Tasks: Retire Current-State Snapshot
+
+## Sync Rule
+
+- Update this file in the same commit whenever a task is completed, re-scoped,
+  or intentionally dropped.
+- Update `docs/specs/plans.md` only when the branch starts, stops, or changes
+  an active feature.
+- Update `docs/specs/roadmap.md` when repository sequencing changes.
+- Keep this file focused on current state only; do not retain historical logs,
+  prior approvals, or long validation diaries once they stop being actionable.
+
+## Current Status
+
+- Runtime status: documentation intake only; no runtime change planned
+- Active slice: plan relocation of current guidance before deleting the stale
+  snapshot
+- Open follow-up: decide the durable home for shared fixture guidance
+
+## Human Approval
+
+- Status: Pending
+- Approved at: none
+- Approved scope: none
+
+Implementation must not start while Status is Pending.
+Only clear human approval can change Status to Approved.
+`Approved at` records the approval result only, such as `none` or `approved in
+current conversation`; do not copy the human approval message.
+
+Reset this section back to Pending when the approved slice is complete and no
+active implementation approval remains.
+
+## Active Tasks
+
+- [ ] Inventory each section of `current-state.md` as retain, relocate, or
+      discard because it is stale or duplicated.
+- [ ] Confirm exact destination documents and link impact.
+- [ ] Record the docs-only implementation impact and request human approval.
+- [ ] After approval, relocate current guidance and remove the stale snapshot.
+- [ ] Remove reading-order and document-role references to the snapshot.
+
+## Validation
+
+- [ ] Run `rtk pnpm run qlty`.
+- [ ] Run `rtk pnpm run lint:md` for Markdown structure and link validation.
+- [ ] Confirm the change remains within the repository's docs-only file set.
+
+## Notes
+
+- This transient feature should be removed after the snapshot is retired and
+  all durable guidance has reached its responsible document.
+- The `unitListDocument.ts` conversion-export finding is a separate potential
+  implementation feature and is outside this feature's approval boundary.

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -40,6 +40,12 @@ rules in `docs/specs/README.md`, not in this file.
 
 - `docs/specs/features/import-definition-via-webapi/`:
   active beta feature with real-environment smoke verification still pending.
+- `docs/specs/features/retire-current-state-snapshot/`:
+  transient documentation feature to relocate current guidance and retire the
+  stale implementation-state snapshot without changing runtime behavior.
+- `docs/specs/features/clarify-unit-list-document-rehydration/`:
+  transient boundary feature to document and constrain production rehydration
+  from unit-list DTOs to the normalized AJS model without behavior changes.
 
 Completed feature-local folders should be removed after their durable behavior
 contracts, active decisions, and unresolved risks have been moved to the


### PR DESCRIPTION
## Summary

- add a transient feature for safely retiring the stale `current-state.md` snapshot
- add a separate transient feature for clarifying the production unit-list DTO rehydration boundary
- register both features in the branch-level SDD plan

## Why

The architecture review found no major refactoring omissions, but identified two focused follow-ups: stale current-state documentation and unclear ownership of reverse conversion exports in `unitListDocument.ts`. Separate feature folders keep those purposes and approval boundaries independent.

Reference inspection confirmed that `toAjsDocument` is used by production table and flow-viewer paths, so its feature preserves that behavior instead of treating it as test-only code.

## Impact

Documentation and planning only. Runtime behavior, DTO shapes, desktop support, web-extension support, and `engines.vscode` are unchanged. Implementation approval remains pending in each feature task file.

## Validation

- `rtk pnpm run qlty`
- `rtk pnpm run lint:md`