### PR TITLE
[codex] Improve flow graph node actions

### DIFF
--- a/docs/requirements/use-cases/uc-build-flow-graph.md
+++ b/docs/requirements/use-cases/uc-build-flow-graph.md
@@ -80,6 +80,9 @@ The user opens or refreshes a flow-oriented view for a selected unit scope.
   selection, search, and relationship-focus states
 - node presentation may become card-based, but node dimensions must remain
   compatible with deterministic positioning and expanded nested layout
+- node presentation may use a two-row card structure where the header carries
+  type, status, open-scope, and nested expansion affordances, and the content
+  row keeps the unit name/comment centered in the remaining node body
 - flow selector entries may show job groups, but the active flow graph scope
   must resolve to a root jobnet rather than a job group
 

--- a/docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md
+++ b/docs/requirements/use-cases/uc-navigate-between-unit-list-and-flow-graph.md
@@ -34,6 +34,9 @@ other viewer when that counterpart view is available.
   document context
 - if navigation changes the visible graph bounds or selected row, the target
   viewer should preserve its normal focus and fit behavior
+- flow-to-unit-list and unit-list-to-flow navigation should open the counterpart
+  viewer when it is available for the same document but not already open, then
+  reveal the target unit after the viewer is ready
 - when unit-list-to-flow navigation starts from a job group, the target flow
   viewer should resolve the active flow scope to a descendant root jobnet while
   still revealing or highlighting the original job group when possible

--- a/src/bootstrap/extension/viewerWiring.ts
+++ b/src/bootstrap/extension/viewerWiring.ts
@@ -118,10 +118,6 @@ export const revealCounterpartPanel = (
     return;
   }
 
-  if (targetViewType !== AJS_FLOW_VIEWER_TYPE) {
-    return;
-  }
-
   const newPanel = targetFactory.getPanel(document);
   pendingRevealByPanel.set(newPanel, absolutePath);
   mountPanel(newPanel, targetViewType);

--- a/src/presentation/webview/editor/ajsFlow/FlowContents.tsx
+++ b/src/presentation/webview/editor/ajsFlow/FlowContents.tsx
@@ -25,6 +25,7 @@ import Header from "./Header";
 import FlowSelector from "./FlowSelector";
 import FlowNodeDetailPanel from "./FlowNodeDetailPanel";
 import { useFlowViewerController } from "./useFlowViewerController";
+import { navigateToTable } from "./nodes/Utils";
 import {
   resolveFlowMiniMapNodeFill,
   resolveFlowMiniMapNodeStroke,
@@ -92,6 +93,13 @@ const FlowContents: FC = () => {
     treeHoveredUnit,
     unitById,
   } = useFlowViewerController({ theme });
+  const openSelectedNodeUnitList = useMemo(
+    () =>
+      selectedNodeDetail
+        ? () => navigateToTable(selectedNodeDetail.absolutePath)
+        : () => undefined,
+    [selectedNodeDetail],
+  );
   const miniMapColors = useMemo(
     () => ({
       both: theme.palette.warning.main,
@@ -259,6 +267,7 @@ const FlowContents: FC = () => {
                   onClose={clearSelectedUnit}
                   onOpenDefinition={openSelectedNodeDefinition}
                   onOpenScope={openSelectedNodeScope}
+                  onOpenUnitList={openSelectedNodeUnitList}
                   focusModeEnabled={focusModeEnabled}
                   onToggleFocusMode={toggleFocusMode}
                 />

--- a/src/presentation/webview/editor/ajsFlow/FlowNodeDetailPanel.tsx
+++ b/src/presentation/webview/editor/ajsFlow/FlowNodeDetailPanel.tsx
@@ -2,6 +2,7 @@ import React, { FC, memo, useMemo } from "react";
 import DescriptionIcon from "@mui/icons-material/Description";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import CenterFocusStrongIcon from "@mui/icons-material/CenterFocusStrong";
+import TableChartIcon from "@mui/icons-material/TableChart";
 import { unitTypeLabel } from "../../../../domain/services/i18n/nls";
 import { useMyAppContext } from "../MyContexts";
 import type { FlowNodeDetail } from "./flowNodeDetail";
@@ -16,6 +17,7 @@ type FlowNodeDetailPanelProps = {
   onClose: VoidFunction;
   onOpenDefinition: VoidFunction;
   onOpenScope: VoidFunction;
+  onOpenUnitList: VoidFunction;
   focusModeEnabled: boolean;
   onToggleFocusMode: VoidFunction;
 };
@@ -59,12 +61,14 @@ export const buildFlowNodeDetailActions = ({
   focusModeEnabled,
   onOpenDefinition,
   onOpenScope,
+  onOpenUnitList,
   onToggleFocusMode,
 }: {
   canOpenAsScope: boolean;
   focusModeEnabled: boolean;
   onOpenDefinition: VoidFunction;
   onOpenScope: VoidFunction;
+  onOpenUnitList: VoidFunction;
   onToggleFocusMode: VoidFunction;
 }): SharedUnitDetailPaneAction[] => [
   {
@@ -77,6 +81,11 @@ export const buildFlowNodeDetailActions = ({
     label: "Open definition details",
     icon: <DescriptionIcon />,
     onClick: onOpenDefinition,
+  },
+  {
+    label: "Open in unit list",
+    icon: <TableChartIcon />,
+    onClick: onOpenUnitList,
   },
   ...(canOpenAsScope
     ? [
@@ -95,6 +104,7 @@ const FlowNodeDetailPanel: FC<FlowNodeDetailPanelProps> = ({
   onClose,
   onOpenDefinition,
   onOpenScope,
+  onOpenUnitList,
   focusModeEnabled,
   onToggleFocusMode,
 }) => {
@@ -115,6 +125,7 @@ const FlowNodeDetailPanel: FC<FlowNodeDetailPanelProps> = ({
         focusModeEnabled,
         onOpenDefinition,
         onOpenScope,
+        onOpenUnitList,
         onToggleFocusMode,
       }),
     [
@@ -122,6 +133,7 @@ const FlowNodeDetailPanel: FC<FlowNodeDetailPanelProps> = ({
       focusModeEnabled,
       onOpenDefinition,
       onOpenScope,
+      onOpenUnitList,
       onToggleFocusMode,
     ],
   );

--- a/src/presentation/webview/editor/ajsFlow/nodes/AjsNode.tsx
+++ b/src/presentation/webview/editor/ajsFlow/nodes/AjsNode.tsx
@@ -169,6 +169,10 @@ export const NodeNameAndComment: React.FC<{
       boxSizing: "border-box",
       width: "100%",
       minWidth: 0,
+      flex: 1,
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "center",
       paddingX: "0.6em",
     }}
   >
@@ -212,15 +216,30 @@ const statusPresentation: Record<
   },
 };
 
+export type FlowNodeHeaderItemKind = "rootBadge" | FlowNodeStatus | "action";
+
+export const getFlowNodeHeaderItemKinds = (
+  data: Pick<AjsNode, "hasSchedule" | "hasWaitedFor" | "isRootJobnet">,
+  hasHeaderAction: boolean,
+): FlowNodeHeaderItemKind[] => [
+  ...(data.isRootJobnet
+    ? (["rootBadge"] satisfies FlowNodeHeaderItemKind[])
+    : []),
+  ...resolveFlowNodeStatuses(data),
+  ...(hasHeaderAction ? (["action"] satisfies FlowNodeHeaderItemKind[]) : []),
+];
+
 const NodeStatusIndicators: FC<{ data: AjsNode }> = ({ data }) => {
-  const statuses = resolveFlowNodeStatuses(data);
+  const statuses = getFlowNodeHeaderItemKinds(data, false).filter(
+    (itemKind): itemKind is FlowNodeStatus =>
+      itemKind === "schedule" || itemKind === "waitedFor",
+  );
   if (statuses.length === 0) {
     return null;
   }
   return (
     <Box
       sx={{
-        minHeight: "1em",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
@@ -253,7 +272,7 @@ export const FlowNodeCard: FC<{
   kind: FlowNodeKind;
   className?: string;
   headerAction?: React.ReactNode;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }> = ({ data, kind, className, headerAction, children }) => (
   <Stack id={data.unitId} sx={buildNodeSxProps(data)} className={className}>
     <Box
@@ -272,11 +291,11 @@ export const FlowNodeCard: FC<{
       <TyTitle ty={data.ty} gty={data.gty} />
       <Box sx={{ display: "flex", alignItems: "center", gap: "0.25em" }}>
         {data.isRootJobnet && <Box sx={nodeBadgeSxProps}>ROOT</Box>}
+        <NodeStatusIndicators data={data} />
         {headerAction}
       </Box>
     </Box>
     <NodeNameAndComment label={data.label} comment={data.comment} />
-    <NodeStatusIndicators data={data} />
-    <Box sx={nodeActionsSxProps}>{children}</Box>
+    {children && <Box sx={nodeActionsSxProps}>{children}</Box>}
   </Stack>
 );

--- a/src/presentation/webview/editor/ajsFlow/nodes/ConditionNode.tsx
+++ b/src/presentation/webview/editor/ajsFlow/nodes/ConditionNode.tsx
@@ -1,14 +1,8 @@
 import React, { FC, memo } from "react";
 import { Node, NodeProps } from "@xyflow/react";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
-import TableChartIcon from "@mui/icons-material/TableChart";
 import { ActionIcon, AjsNode, FlowNodeCard } from "./AjsNode";
-import {
-  handleClickChildOpen,
-  handleClickNavigateToTable,
-  handleKeyDownChildOpen,
-  handleKeyDownNavigateToTable,
-} from "./Utils";
+import { handleClickChildOpen, handleKeyDownChildOpen } from "./Utils";
 
 type ConditionNode = Node<AjsNode, "condition">;
 type ConditionNodeProps = NodeProps<ConditionNode>;
@@ -25,24 +19,18 @@ const ConditionNode: FC<ConditionNodeProps> = ({
         data={data}
         kind="condition"
         className={isCurrent ? "current" : undefined}
-      >
-        <ActionIcon
-          title="Open the matching unit in the unit list."
-          ariaLabel="Open the matching unit in the unit list."
-          onClick={handleClickNavigateToTable(data)}
-          onKeyDown={handleKeyDownNavigateToTable(data)}
-          icon={<TableChartIcon fontSize="inherit" />}
-        />
-        {!isCurrent && (
-          <ActionIcon
-            title="Open the condition."
-            ariaLabel="Open the condition."
-            onClick={handleClickChildOpen(data)}
-            onKeyDown={handleKeyDownChildOpen(data)}
-            icon={<FolderOpenIcon fontSize="inherit" />}
-          />
-        )}
-      </FlowNodeCard>
+        headerAction={
+          !isCurrent ? (
+            <ActionIcon
+              title="Open the condition."
+              ariaLabel="Open the condition."
+              onClick={handleClickChildOpen(data)}
+              onKeyDown={handleKeyDownChildOpen(data)}
+              icon={<FolderOpenIcon fontSize="inherit" />}
+            />
+          ) : undefined
+        }
+      />
     </>
   );
 };

--- a/src/presentation/webview/editor/ajsFlow/nodes/JobGroupNode.tsx
+++ b/src/presentation/webview/editor/ajsFlow/nodes/JobGroupNode.tsx
@@ -1,11 +1,6 @@
 import React, { FC, memo } from "react";
 import { Node, NodeProps } from "@xyflow/react";
-import TableChartIcon from "@mui/icons-material/TableChart";
-import { ActionIcon, AjsNode, FlowNodeCard } from "./AjsNode";
-import {
-  handleClickNavigateToTable,
-  handleKeyDownNavigateToTable,
-} from "./Utils";
+import { AjsNode, FlowNodeCard } from "./AjsNode";
 import classNames from "classnames";
 
 type JobGroupNode = Node<AjsNode, "jobgroup">;
@@ -22,15 +17,7 @@ const JobGroupNode: FC<JobGroupNodeProp> = ({ data }: JobGroupNodeProp) => {
         className={classNames({
           ancestor: isAncestor,
         })}
-      >
-        <ActionIcon
-          title="Open the matching unit in the unit list."
-          ariaLabel="Open the matching unit in the unit list."
-          onClick={handleClickNavigateToTable(data)}
-          onKeyDown={handleKeyDownNavigateToTable(data)}
-          icon={<TableChartIcon fontSize="inherit" />}
-        />
-      </FlowNodeCard>
+      />
     </>
   );
 };

--- a/src/presentation/webview/editor/ajsFlow/nodes/JobNetNode.tsx
+++ b/src/presentation/webview/editor/ajsFlow/nodes/JobNetNode.tsx
@@ -1,22 +1,34 @@
 import React, { FC, memo } from "react";
+import Box from "@mui/material/Box";
 import { Handle, Node, NodeProps, Position } from "@xyflow/react";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
-import TableChartIcon from "@mui/icons-material/TableChart";
 import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
 import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 import classNames from "classnames";
 import { ActionIcon, AjsNode, FlowNodeCard, handleStyle } from "./AjsNode";
 import {
   handleClickChildOpen,
-  handleClickNavigateToTable,
   handleClickNestedToggle,
   handleKeyDownChildOpen,
-  handleKeyDownNavigateToTable,
   handleKeyDownNestedToggle,
 } from "./Utils";
 
 type JobNetNode = Node<AjsNode, "jobnet">;
 type JobNetNodeProps = NodeProps<JobNetNode>;
+type JobNetHeaderActionKind = "openScope" | "toggleNested";
+
+export const getJobNetHeaderActionKinds = ({
+  canExpandNested,
+  isCurrent,
+}: Pick<AjsNode, "canExpandNested" | "isCurrent">): JobNetHeaderActionKind[] =>
+  isCurrent
+    ? []
+    : [
+        "openScope",
+        ...(canExpandNested
+          ? (["toggleNested"] satisfies JobNetHeaderActionKind[])
+          : []),
+      ];
 
 const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
   console.log("render JobNetNode.");
@@ -28,6 +40,7 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
     canExpandNested,
     isExpandedNested,
   } = data;
+  const headerActionKinds = getJobNetHeaderActionKinds(data);
 
   return (
     <>
@@ -39,48 +52,47 @@ const JobNetNode: FC<JobNetNodeProps> = ({ data }: JobNetNodeProps) => {
           ancestor: isAncestor,
         })}
         headerAction={
-          !isCurrent && canExpandNested ? (
-            <ActionIcon
-              title={
-                isExpandedNested
-                  ? "Collapse the nested jobnet."
-                  : "Expand the nested jobnet."
-              }
-              ariaLabel={
-                isExpandedNested
-                  ? "Collapse the nested jobnet."
-                  : "Expand the nested jobnet."
-              }
-              onClick={handleClickNestedToggle(data)}
-              onKeyDown={handleKeyDownNestedToggle(data)}
-              icon={
-                isExpandedNested ? (
-                  <UnfoldLessIcon fontSize="inherit" />
+          headerActionKinds.length > 0 ? (
+            <Box sx={{ display: "flex", alignItems: "center", gap: "0.25em" }}>
+              {headerActionKinds.map((actionKind) =>
+                actionKind === "openScope" ? (
+                  <ActionIcon
+                    key={actionKind}
+                    title="Open the jobnet."
+                    ariaLabel="Open the jobnet."
+                    onClick={handleClickChildOpen(data)}
+                    onKeyDown={handleKeyDownChildOpen(data)}
+                    icon={<FolderOpenIcon fontSize="inherit" />}
+                  />
                 ) : (
-                  <UnfoldMoreIcon fontSize="inherit" />
-                )
-              }
-            />
+                  <ActionIcon
+                    key={actionKind}
+                    title={
+                      isExpandedNested
+                        ? "Collapse the nested jobnet."
+                        : "Expand the nested jobnet."
+                    }
+                    ariaLabel={
+                      isExpandedNested
+                        ? "Collapse the nested jobnet."
+                        : "Expand the nested jobnet."
+                    }
+                    onClick={handleClickNestedToggle(data)}
+                    onKeyDown={handleKeyDownNestedToggle(data)}
+                    icon={
+                      isExpandedNested ? (
+                        <UnfoldLessIcon fontSize="inherit" />
+                      ) : (
+                        <UnfoldMoreIcon fontSize="inherit" />
+                      )
+                    }
+                  />
+                ),
+              )}
+            </Box>
           ) : undefined
         }
-      >
-        <ActionIcon
-          title="Open the matching unit in the unit list."
-          ariaLabel="Open the matching unit in the unit list."
-          onClick={handleClickNavigateToTable(data)}
-          onKeyDown={handleKeyDownNavigateToTable(data)}
-          icon={<TableChartIcon fontSize="inherit" />}
-        />
-        {!isCurrent && (
-          <ActionIcon
-            title="Open the jobnet."
-            ariaLabel="Open the jobnet."
-            onClick={handleClickChildOpen(data)}
-            onKeyDown={handleKeyDownChildOpen(data)}
-            icon={<FolderOpenIcon fontSize="inherit" />}
-          />
-        )}
-      </FlowNodeCard>
+      />
       {!isRootJobnet && !isCurrent && (
         <>
           <Handle type="source" position={Position.Right} style={handleStyle} />

--- a/src/presentation/webview/editor/ajsFlow/nodes/JobNode.tsx
+++ b/src/presentation/webview/editor/ajsFlow/nodes/JobNode.tsx
@@ -1,11 +1,6 @@
 import React, { FC, memo } from "react";
 import { Handle, Node, NodeProps, Position } from "@xyflow/react";
-import TableChartIcon from "@mui/icons-material/TableChart";
-import { ActionIcon, AjsNode, FlowNodeCard, handleStyle } from "./AjsNode";
-import {
-  handleClickNavigateToTable,
-  handleKeyDownNavigateToTable,
-} from "./Utils";
+import { AjsNode, FlowNodeCard, handleStyle } from "./AjsNode";
 
 type JobNode = Node<AjsNode, "job">;
 type JobNodeProps = NodeProps<JobNode>;
@@ -14,15 +9,7 @@ const JobNode: FC<JobNodeProps> = ({ data }: JobNodeProps) => {
 
   return (
     <>
-      <FlowNodeCard data={data} kind="job">
-        <ActionIcon
-          title="Open the matching unit in the unit list."
-          ariaLabel="Open the matching unit in the unit list."
-          onClick={handleClickNavigateToTable(data)}
-          onKeyDown={handleKeyDownNavigateToTable(data)}
-          icon={<TableChartIcon fontSize="inherit" />}
-        />
-      </FlowNodeCard>
+      <FlowNodeCard data={data} kind="job" />
       <Handle type="source" position={Position.Right} style={handleStyle} />
       <Handle type="target" position={Position.Left} style={handleStyle} />
     </>

--- a/src/presentation/webview/editor/ajsFlow/nodes/Utils.ts
+++ b/src/presentation/webview/editor/ajsFlow/nodes/Utils.ts
@@ -25,15 +25,6 @@ export const handleKeyDownNestedToggle =
     }
   };
 
-export const handleClickNavigateToTable = (data: AjsNode) => () => {
-  window.vscode.postMessage(createNavigationEvent("table", data.absolutePath));
+export const navigateToTable = (absolutePath: string): void => {
+  window.vscode.postMessage(createNavigationEvent("table", absolutePath));
 };
-
-export const handleKeyDownNavigateToTable =
-  (data: AjsNode) => (event: React.KeyboardEvent<HTMLElement>) => {
-    if (event.key === "Enter") {
-      window.vscode.postMessage(
-        createNavigationEvent("table", data.absolutePath),
-      );
-    }
-  };

--- a/src/test/suite/flowNodeDetail.test.ts
+++ b/src/test/suite/flowNodeDetail.test.ts
@@ -234,10 +234,16 @@ suite("Flow Node Detail", () => {
           focusModeEnabled: false,
           onOpenDefinition: () => undefined,
           onOpenScope: () => undefined,
+          onOpenUnitList: () => undefined,
           onToggleFocusMode: () => undefined,
         }),
       ),
-      ["Focus relationships", "Open definition details", "Open as graph scope"],
+      [
+        "Focus relationships",
+        "Open definition details",
+        "Open in unit list",
+        "Open as graph scope",
+      ],
     );
   });
 });

--- a/src/test/suite/flowNodeDisplay.test.ts
+++ b/src/test/suite/flowNodeDisplay.test.ts
@@ -1,9 +1,11 @@
 import * as assert from "assert";
+import { getFlowNodeHeaderItemKinds } from "../../presentation/webview/editor/ajsFlow/nodes/AjsNode";
 import {
-  resolveFlowNodeStatuses,
   resolveFlowNodeHeaderTone,
+  resolveFlowNodeStatuses,
   shouldRenderNodeComment,
 } from "../../presentation/webview/editor/ajsFlow/nodes/flowNodeDisplay";
+import { getJobNetHeaderActionKinds } from "../../presentation/webview/editor/ajsFlow/nodes/JobNetNode";
 
 suite("flow node display", () => {
   test("does not render duplicate comments matching the label", () => {
@@ -49,6 +51,55 @@ suite("flow node display", () => {
         ),
       ),
       ["neutral", "primary", "warning", "info"],
+    );
+  });
+
+  test("places jobnet open-scope before nested expand in the header", () => {
+    assert.deepStrictEqual(
+      getJobNetHeaderActionKinds({
+        canExpandNested: true,
+        isCurrent: false,
+      }),
+      ["openScope", "toggleNested"],
+    );
+    assert.deepStrictEqual(
+      getJobNetHeaderActionKinds({
+        canExpandNested: false,
+        isCurrent: false,
+      }),
+      ["openScope"],
+    );
+    assert.deepStrictEqual(
+      getJobNetHeaderActionKinds({
+        canExpandNested: true,
+        isCurrent: true,
+      }),
+      [],
+    );
+  });
+
+  test("keeps status indicators in the header before node actions", () => {
+    assert.deepStrictEqual(
+      getFlowNodeHeaderItemKinds(
+        {
+          hasSchedule: true,
+          hasWaitedFor: true,
+          isRootJobnet: true,
+        },
+        true,
+      ),
+      ["rootBadge", "schedule", "waitedFor", "action"],
+    );
+    assert.deepStrictEqual(
+      getFlowNodeHeaderItemKinds(
+        {
+          hasSchedule: false,
+          hasWaitedFor: false,
+          isRootJobnet: false,
+        },
+        false,
+      ),
+      [],
     );
   });
 });

--- a/src/test/suite/viewerWiring.test.ts
+++ b/src/test/suite/viewerWiring.test.ts
@@ -7,7 +7,10 @@ import {
   revealCounterpartPanel,
 } from "../../bootstrap/extension/viewerWiring";
 import { ViewerFactory } from "../../presentation/vscode/webview/ViewerFactory";
-import { AJS_FLOW_VIEWER_TYPE } from "../../presentation/vscode/webview/constant";
+import {
+  AJS_FLOW_VIEWER_TYPE,
+  AJS_TABLE_VIEWER_TYPE,
+} from "../../presentation/vscode/webview/constant";
 
 suite("Viewer wiring", () => {
   test("creates viewer subscriptions for both table and flow viewers", () => {
@@ -126,6 +129,51 @@ suite("Viewer wiring", () => {
       "reveal",
       "document",
       "post:revealUnit:/root/latest",
+    ]);
+  });
+
+  test("opens a missing table panel and reveals after document readiness", () => {
+    const calls: string[] = [];
+    const document = { uri: {} } as vscode.TextDocument;
+    const panel = {
+      viewColumn: vscode.ViewColumn.Beside,
+      reveal: () => calls.push("reveal"),
+      webview: {
+        postMessage: (message: {
+          type: string;
+          data: { absolutePath: string };
+        }) => calls.push(`post:${message.type}:${message.data.absolutePath}`),
+      },
+    } as unknown as vscode.WebviewPanel;
+    const factory = {
+      getExistingPanel: () => undefined,
+      getPanel: () => panel,
+    } as unknown as ViewerFactory;
+    const pendingRevealByPanel = new WeakMap<vscode.WebviewPanel, string>();
+
+    revealCounterpartPanel(
+      {
+        document,
+        targetViewType: AJS_TABLE_VIEWER_TYPE,
+        absolutePath: "/root/job",
+      },
+      {
+        factoryByViewType: new Map([[AJS_TABLE_VIEWER_TYPE, factory]]),
+        mountPanel: () => calls.push("mount"),
+        pendingRevealByPanel,
+      },
+    );
+
+    assert.deepStrictEqual(calls, ["mount", "reveal"]);
+    createViewerReadyHandler(
+      () => calls.push("document"),
+      pendingRevealByPanel,
+    )(document, panel);
+    assert.deepStrictEqual(calls, [
+      "mount",
+      "reveal",
+      "document",
+      "post:revealUnit:/root/job",
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Move flow-to-unit-list navigation into the selected flow node detail pane.
- Open a missing unit-list viewer automatically before revealing the target unit.
- Move node header actions/status into a two-row flow node layout and center node body content vertically.
- Preserve durable behavior contracts in the flow graph and cross-view navigation use cases.

## Validation

- `rtk pnpm run qlty`
- `rtk pnpm test`
- `rtk pnpm run test:web`
- `rtk pnpm run build`
- `rtk pnpm run lint:md`

`rtk pnpm run build` passes with existing webpack bundle-size warnings.