### PR TITLE
[codex] Open viewers in active pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "category": "View",
         "title": "Open JP1/AJS flow viewer",
         "shortTitle": "JP1/AJS flow viewer",
-        "icon": "$(circuit-board)"
+        "icon": "$(type-hierarchy)"
       },
       {
         "enablement": "editorLangId == 'jp1ajs'",
@@ -65,7 +65,7 @@
         "category": "View",
         "title": "Open JP1/AJS table viewer",
         "shortTitle": "JP1/AJS table viewer",
-        "icon": "$(output)"
+        "icon": "$(table)"
       },
       {
         "command": "ajsbutler.importDefinitionViaWebApiBeta",

--- a/src/presentation/vscode/webview/ViewerFactory.ts
+++ b/src/presentation/vscode/webview/ViewerFactory.ts
@@ -134,7 +134,7 @@ export class ViewerFactory {
     const panel = this.#deps.createWebviewPanel(
       this.#viewType,
       path.basename(document.fileName),
-      vscode.ViewColumn.Beside,
+      vscode.ViewColumn.Active,
       {
         enableScripts: true,
         retainContextWhenHidden: true,

--- a/src/test/suite/packageManifest.test.ts
+++ b/src/test/suite/packageManifest.test.ts
@@ -1,0 +1,38 @@
+import * as assert from "assert";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+type CommandContribution = {
+  command: string;
+  icon?: string;
+};
+
+type PackageJson = {
+  contributes: {
+    commands: CommandContribution[];
+  };
+};
+
+function readPackageJson(): PackageJson {
+  return JSON.parse(
+    readFileSync(join(__dirname, "../../..", "package.json"), "utf8"),
+  ) as PackageJson;
+}
+
+suite("Package manifest", () => {
+  test("uses detail-pane aligned codicons for editor title viewer commands", () => {
+    const commands = readPackageJson().contributes.commands;
+    const byCommand = new Map(
+      commands.map((command) => [command.command, command]),
+    );
+
+    assert.strictEqual(
+      byCommand.get("open.ajsbutler.flowViewer")?.icon,
+      "$(type-hierarchy)",
+    );
+    assert.strictEqual(
+      byCommand.get("open.ajsbutler.tableViewer")?.icon,
+      "$(table)",
+    );
+  });
+});

--- a/src/test/suite/viewerFactory.test.ts
+++ b/src/test/suite/viewerFactory.test.ts
@@ -75,6 +75,9 @@ suite("ViewerFactory", () => {
     let readyArgs:
       | { document: vscode.TextDocument; panel: vscode.WebviewPanel }
       | undefined;
+    let createdShowOptions:
+      | Parameters<typeof vscode.window.createWebviewPanel>[2]
+      | undefined;
 
     const factory = new ViewerFactory(
       "ajsbutler.testViewer",
@@ -94,7 +97,8 @@ suite("ViewerFactory", () => {
       () => {},
       undefined,
       {
-        createWebviewPanel() {
+        createWebviewPanel(_viewType, _title, viewColumn) {
+          createdShowOptions = viewColumn;
           return createdPanel;
         },
       },
@@ -107,6 +111,7 @@ suite("ViewerFactory", () => {
       document,
       panel: createdPanel,
     });
+    assert.strictEqual(createdShowOptions, vscode.ViewColumn.Active);
     assert.deepStrictEqual(added, [{ uri: document.uri, panel: createdPanel }]);
   });
 


### PR DESCRIPTION
## Summary
- Open new flow graph and unit list webviews in the active editor pane instead of beside the source editor.
- Align editor/title viewer command codicons with the detail-pane flow/table navigation actions.
- Add focused tests for panel placement and package manifest command icons.

## Validation
- CI=true rtk pnpm run qlty
- CI=true rtk pnpm test
- CI=true rtk pnpm run test:web
- CI=true rtk pnpm run build

## Notes
- Command IDs, custom editor viewTypes, telemetry payloads, parser/application/domain behavior, and engines.vscode are unchanged.
- The temporary feature directory was removed after implementation and validation.