### PR TITLE
[codex] Align SDD workflow documentation

### DIFF
--- a/.agent.md
+++ b/.agent.md
@@ -66,7 +66,7 @@ This file declares the AI agent configuration for this repository. Both
 **All agents reference these files** (never duplicate rules):
 
 - `AGENTS.md` - **Authoritative** routing guide and architecture rules
-- `docs/specs/` - SDD specifications and use cases
+- `docs/specs/` - SDD workflow and feature artifacts
 - `README.md` - Build/test commands
 
 ## How Agents Use This Repository
@@ -85,7 +85,7 @@ This file declares the AI agent configuration for this repository. Both
 2. Finds reference to `AGENTS.md` § "AI Agent Routing Guide"
 3. Looks up task type in routing matrix
 4. Reads relevant `docs/specs/` for context
-5. Executes with editor integration
+5. Executes the SDD skill workflow with editor integration
 
 ## Maintenance
 

--- a/.codex/skills/sdd-create-feature/SKILL.md
+++ b/.codex/skills/sdd-create-feature/SKILL.md
@@ -9,8 +9,8 @@ description: Use when creating a new vscode-ajsbutler SDD feature folder, clarif
 
 Create one well-scoped SDD feature entry for `vscode-ajsbutler` while keeping
 the existing implementation gate intact. Use this skill only for feature
-intake and documentation setup; hand off task selection to `sdd-plan-task` and
-approved implementation to `sdd-implement-task`.
+intake and documentation setup; hand off feature implementation planning to
+`sdd-plan-task` and approved implementation slices to `sdd-implement-task`.
 
 ## Inputs
 
@@ -36,6 +36,10 @@ Before creating or editing feature docs, explicitly establish:
 - feature name and slug
 - one concrete purpose
 - source use case, roadmap item, bug, risk, or branch goal
+- JP1/AJS source reference:
+  - command reference
+  - definition/config reference
+  - undocumented or inferred behavior
 - expected behavior or boundary decision
 - non-goals
 - desktop and web compatibility expectations
@@ -49,6 +53,10 @@ Ask the user to choose the feature kind when it is not already explicit:
   durable decisions move to use cases, roadmap, or plans
 
 Do not infer the kind from tone, size, or urgency.
+
+If the feature depends on JP1/AJS behavior, record the reference basis. Use
+`undocumented or inferred behavior` only when no command or definition/config
+reference is available, and keep the inference explicit.
 
 ## Scope Gate
 
@@ -81,34 +89,75 @@ Too broad for one feature:
 1. Confirm the intake and scope gates.
 2. Choose a lowercase hyphenated slug under `docs/specs/features/<slug>/`.
 3. Check that the slug does not duplicate an active feature folder.
+   Also inspect related use cases and active features, then record the
+   duplicate/overlap decision in the final intake summary.
 4. Create the feature folder from the repository templates:
    - `SPECS.md` from `SPECS.template.md`
    - `TASKS.md` from `TASKS.template.md`
-5. Fill `SPECS.md` with only feature-level purpose, origin, requirements,
+5. Create `TRACEABILITY.md` when the feature needs explicit traceability.
+6. Fill `SPECS.md` with only feature-level purpose, origin, requirements,
    architecture boundaries, compatibility, acceptance criteria, non-goals, and
    open questions.
-6. Fill `TASKS.md` with current status, approval state, active planning tasks,
+7. Fill `TASKS.md` with current status, approval state, active planning tasks,
    validation expectations, unresolved risks, and use-case back-propagation
    notes. Keep `Human Approval` pending unless the user has already given
    clear approval for a specific implementation scope in the current
    conversation.
-7. Update `docs/specs/plans.md` when the branch starts, stops, or changes an
+8. Update `docs/specs/plans.md` when the branch starts, stops, or changes an
    active feature.
-8. Update `docs/specs/roadmap.md` only for `roadmap feature` work or when the
+9. Update `docs/specs/roadmap.md` only for `roadmap feature` work or when the
    new feature changes repository-level ordering, remaining debt, or deferred
    work.
-9. Update or create `docs/requirements/use-cases/` only when the new feature
-   changes a durable behavior contract.
-10. Run docs-only validation through `rtk`.
+10. Update or create `docs/requirements/use-cases/` only when the new feature
+    changes a durable behavior contract.
+11. Run docs-only validation through `rtk`.
+
+## Traceability
+
+Create or update `docs/specs/features/<feature>/TRACEABILITY.md` when the
+feature:
+
+- changes user-visible behavior
+- affects JP1/AJS definition-file interpretation or compatibility
+- is likely to split into multiple implementation slices
+- needs explicit use-case correspondence
+
+Do not create `TRACEABILITY.md` for purely temporary investigations or minor
+docs-only changes where use-case, requirement, slice, and validation mapping is
+obvious and short-lived.
+
+When created, `TRACEABILITY.md` must map at least:
+
+- Use Case
+- Requirement
+- `SPECS.md` section
+- Implementation Slice
+- Test file or validation plan
+
+## Completion Checklist
+
+Before finishing, verify:
+
+- no template placeholder remains
+- `Purpose` contains one concrete observable result or boundary decision
+- `Requirements` are testable
+- `Architecture` maps responsibilities to Domain, Application, Presentation,
+  and Infrastructure
+- `Compatibility` mentions both desktop and web
+- `Acceptance Criteria` can be validated
+- `Human Approval` remains `Pending` unless explicit approval exists
 
 ## Document Responsibilities
 
 - `SPECS.md`: durable feature requirements, architecture boundaries,
   compatibility notes, acceptance criteria, alternatives, non-goals, and open
   questions.
-- `TASKS.md`: current executable planning state, current approval evidence,
-  validation expectations, unresolved risks, and follow-up that affects the
-  next decision.
+- `TASKS.md`: feature implementation-slice plan, current approval evidence,
+  validation expectations, unresolved risks, feature exit readiness, and
+  follow-up that affects implementation or closure decisions.
+- `TRACEABILITY.md`: feature-level mapping from use cases and requirements to
+  `SPECS.md`, implementation slices, and tests or validation plans. Create it
+  only when the Traceability rules require it.
 - `docs/specs/plans.md`: branch-level active features and branch-wide
   assumptions.
 - `docs/specs/roadmap.md`: repository-level sequence, roadmap-visible
@@ -134,16 +183,25 @@ Before finishing, report:
 - Feature folder:
 - Purpose:
 - Source:
+- JP1/AJS source reference:
+  - Command reference:
+  - Definition/config reference:
+  - Undocumented or inferred behavior:
+- Duplicate/overlap check:
+- Existing related features:
+- Existing related use cases:
 - Scope split considered:
 - Ambiguities resolved:
 - Roadmap impact:
 - Plans impact:
 - Use-case impact:
+- Traceability:
 - Validation:
 
 ## Next Step
 
-Use `sdd-plan-task` to investigate and propose the first implementation slice.
+Use `sdd-plan-task` to decompose the feature into implementation slices and
+prepare the feature-level implementation plan.
 ```
 
 ## Validation

--- a/.codex/skills/sdd-create-feature/SKILL.md
+++ b/.codex/skills/sdd-create-feature/SKILL.md
@@ -28,6 +28,11 @@ Read these first:
 Inspect existing feature folders under `docs/specs/features/` to avoid
 duplicate or overlapping feature entries.
 
+Use `docs/specs/README.md` as the Single Source of Truth for Trivial Change
+Criteria. Skip feature creation only when that section says the change is
+trivial; when uncertain, treat the request as non-trivial and continue feature
+intake.
+
 ## Intake Gate
 
 Before creating or editing feature docs, explicitly establish:
@@ -218,6 +223,7 @@ need focused validation.
 ## Rules
 
 - Preserve the `docs/specs/README.md` Implementation Change Gate.
+- Preserve the `docs/specs/README.md` Trivial Change Criteria.
 - Do not create a feature until the feature kind is explicit.
 - Do not create a feature until it has one concrete purpose.
 - Do not infer missing behavior, compatibility scope, or roadmap intent.

--- a/.codex/skills/sdd-implement-task/SKILL.md
+++ b/.codex/skills/sdd-implement-task/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: sdd-implement-task
-description: Use when implementing an approved vscode-ajsbutler SDD task from docs/specs/features/<feature>/TASKS.md, including confirming approved scope, completing code and tests, running three independent self-reviews, applying review fixes, updating TASKS.md after human completion approval, committing the work, and confirming a clean workspace.
+description: Use when implementing exactly one approved vscode-ajsbutler SDD implementation slice from docs/specs/features/<feature>/TASKS.md after the feature plan has been created, reviewed, and human-approved, including baseline checks, scoped implementation, staged validation, production readiness gates, non-functional quality gates, readability and diff-minimality checks, TRACEABILITY.md updates, implementation feedback capture, knowledge propagation decisions, three independent self-reviews, applying review fixes, updating slice status after human completion approval, committing the work, and confirming a clean workspace. This skill must not plan new slices or change approval boundaries.
 ---
 
 # sdd-implement-task
 
 ## Purpose
 
-Implement one approved task from feature `TASKS.md`, validate it, review it
-independently three times, apply necessary fixes, and finish with a commit and
-clean workspace after human completion approval.
+Implement exactly one planned, reviewed, and human-approved implementation
+slice from feature `TASKS.md`. Do not plan new slices. Stop and return to
+`sdd-plan-task` when the approved plan or approval boundary is no longer
+sufficient.
 
 ## Preconditions
 
@@ -26,37 +27,87 @@ Read these first:
 Implementation may start only when feature `TASKS.md` records:
 
 ```md
-## Human Approval
+## Plan Status
+
+- Status: Approved | In Progress
+- Review status: Reviewed
+- Human approval: Approved
+
+## Implementation Slices
+
+### Slice <n>: <name>
 
 - Status: Approved
-- Approved at: <approval result>
-- Approved scope: <human-approved boundary>
+- Approval Boundary: <human-approved slice boundary>
 ```
 
-If approval is missing, stale, ambiguous, or narrower than the required work,
-stop and use `sdd-plan-task` to refresh investigation and request approval.
+If approval is missing, stale, ambiguous, narrower than the required work, or
+not tied to a specific slice, stop. Use `sdd-plan-task` for replanning or
+`sdd-review-plan` for plan-quality review before implementation resumes.
+
+## Replanning Boundary
+
+Stop implementation and return to `sdd-plan-task` when:
+
+- a new implementation slice is needed
+- scope changes
+- a new design decision is needed
+- the approval boundary changes
+- impact is wider than planned
+- the approved slice cannot be validated as written
+- feature completion must be evaluated
+
+Do not solve these cases by silently editing `TASKS.md` into a new plan.
+
+## Baseline Check
+
+Before editing, record enough baseline context to distinguish new regressions
+from existing problems:
+
+- target slice
+- approval boundary
+- existing tests and nearest fast validation command
+- known risks from `TASKS.md`, `SPECS.md`, and related use cases
+- current quality issues in the touched area when visible from existing
+  diagnostics, qlty output, tests, or code inspection
+
+Do not expand scope to fix baseline issues unless they are required by the
+approved slice.
 
 ## Implementation Workflow
 
-1. Confirm the current task, approved scope, acceptance criteria, validation
-   plan, unresolved risks, and use-case back-propagation notes from
-   `TASKS.md`.
-2. Enumerate affected references before editing:
+1. Select exactly one approved slice from `TASKS.md`.
+2. Confirm the slice scope, approval boundary, acceptance criteria, validation
+   plan, dependencies, unresolved risks, and out-of-scope changes.
+3. Perform the baseline check.
+4. Enumerate affected references before editing:
    - direct files, symbols, commands, components, adapters, tests, and docs
    - desktop and web entry points
    - parser, application, presentation, infrastructure, and telemetry
      boundaries
    - transitive references when a public type, DTO, command, or use case
      changes
-3. Implement in small meaningful blocks.
-4. Run the closest useful check after each block when practical.
-5. Add or update tests when touching parser, list, flow, CSV, adapter,
-   diagnostics, hover, telemetry, or user-visible behavior.
-6. Stop for re-approval before editing outside the approved scope or making a
+5. Implement only the approved slice in small meaningful blocks.
+6. Add or update tests required by the approved slice when touching parser,
+   list, flow, CSV, adapter, diagnostics, hover, telemetry, or user-visible
+   behavior.
+7. Run staged validation according to the validation strategy below.
+8. Stop for replanning before editing outside the approved slice or making a
    new specification, compatibility, destructive, or design decision.
-7. Run the required validation through `rtk` before review.
+9. Run the required final validation through `rtk` before review.
 
-For code changes, default validation order is:
+## Validation Execution Strategy
+
+Run validation progressively, balancing confidence and feedback speed:
+
+1. nearest fast validation for the changed code
+2. tests related to the approved slice
+3. `rtk pnpm run qlty`
+4. needed web tests
+5. build
+
+Use the full default validation order for meaningful code changes when the
+slice risk justifies it:
 
 ```bash
 rtk pnpm run qlty
@@ -68,12 +119,151 @@ rtk pnpm run build
 For docs-only changes, run `rtk pnpm run qlty`; add `rtk pnpm run lint:md`
 when markdown structure or links need focused validation.
 
+Avoid:
+
+- running build after every small edit
+- running validations in parallel when they are not independent
+- repeating the same validation without a new relevant change
+- running broad checks before a nearby fast check would catch obvious issues
+
+Run only the validation needed for final confidence, and explain any skipped
+expected check.
+
+## Quality Gates
+
+### Production Readiness
+
+Before completion, verify:
+
+- failure modes are handled intentionally
+- user-facing errors, diagnostics, or fallback behavior are understandable
+- existing JP1/AJS definition files remain compatible unless the approved
+  scope intentionally changes compatibility
+- large, malformed, or edge-case inputs do not cause avoidable slowdowns or
+  crashes
+- desktop and web behavior are both considered
+- README or user documentation is updated only when user-facing behavior
+  changes
+- CHANGELOG update need is evaluated when user-facing behavior,
+  compatibility, or workflow changes
+
+### Non-Functional Quality
+
+Before completion, verify the slice did not unnecessarily:
+
+- add serious code smells
+- worsen qlty metrics
+- increase cyclomatic complexity
+- add dependencies
+- degrade performance
+- introduce memory retention or unnecessary recomputation
+
+If non-functional quality worsens, explain why the tradeoff is necessary and
+within the approved scope.
+
+### Readability
+
+Prefer readable, maintainable implementation over clever compactness:
+
+- use JP1/AJS and domain terminology in names
+- keep control flow clear
+- split responsibilities where it improves understanding
+- preserve an understandable processing sequence
+
+Do not optimize for line count, DRY-only extraction, generic abstraction, or
+short code at the expense of clarity.
+
+### Diff Minimality
+
+Keep the diff necessary for the approved slice:
+
+- no incidental fixes
+- no unrelated refactors
+- no unnecessary formatting churn
+- no speculative future-proof abstraction
+
+Every changed file should support the approved slice, its tests, validation,
+or required documentation.
+
+### User Impact
+
+Before completion, state:
+
+- user-visible changes, or that there are none
+- compatibility impact, or that there is none
+- desktop and web impact
+- setting, definition-file, or JP1/AJS compatibility impact
+
+## Implementation Feedback
+
+Before asking for slice completion approval, capture only feedback that can
+improve future planning or implementation:
+
+- whether the slice boundary was appropriate
+- estimation or complexity mismatch
+- dependencies discovered during implementation
+- validation improvements
+- a better slice boundary discovered in hindsight
+- planning investigation that was missing
+- JP1/AJS knowledge discovered during implementation
+- VS Code API or web/desktop differences discovered during implementation
+
+Do not record ordinary work logs, temporary investigation notes, review
+conversation, or resolved issue history as implementation feedback.
+
+## Traceability
+
+When the feature has `TRACEABILITY.md`, update the implemented slice's test or
+validation result before completion approval. If no traceability update is
+needed, state why.
+
+The slice traceability entry should connect:
+
+- Use Case
+- Requirement
+- `SPECS.md` section
+- Implementation Slice
+- Test file or validation result
+
+## Knowledge Propagation
+
+Evaluate implementation feedback for durable reuse. Propagate only knowledge
+that passes the Durable Documentation Gate to the smallest appropriate durable
+document, such as:
+
+- use cases
+- design guides
+- development guides
+- README
+- AGENTS
+- other cross-feature repository documentation
+
+Feature-specific or temporary feedback should remain only in feature docs while
+it is actionable, then disappear when the feature folder is removed.
+
+## Durable Documentation Gate
+
+Before updating durable docs, verify the knowledge:
+
+- is reusable beyond this feature
+- describes durable behavior, specification, design policy, or repository
+  operating policy
+- helps future planning or implementation
+- does not duplicate another durable document
+- is not a temporary investigation result
+- is not implementation history
+- is not review commentary
+- is not a record of a resolved issue
+
+Do not update durable docs just because implementation happened. Update them
+only when leaving the knowledge out would make future work worse.
+
 ## Independent Reviews
 
 After implementation and initial validation, review the work three times.
 Each review must be independent:
 
-1. Review pass 1: inspect the final diff against the approved scope,
+1. Review pass 1: inspect the final diff against the approved slice scope,
    acceptance criteria, and architecture rules.
 2. Review pass 2: start fresh from `TASKS.md`, related specs, and the final
    diff; do not refer to pass 1 results while finding issues.
@@ -91,6 +281,14 @@ For each pass, look for:
 - direct `vscode` imports outside extension, presentation, or infrastructure
   boundaries
 - telemetry privacy issues
+- non-functional quality regressions
+- readability regressions
+- unnecessary diff or out-of-scope edits
+- unexplained user impact or compatibility impact
+- production readiness gaps
+- missing TRACEABILITY.md update or missing not-required reason
+- missing implementation feedback that would improve future planning
+- durable documentation updates that fail the Durable Documentation Gate
 - out-of-scope changes
 
 After all three passes, merge duplicate findings, apply required fixes, and
@@ -100,24 +298,62 @@ rerun the relevant validation.
 
 When implementation, reviews, fixes, and validation are complete:
 
-1. Summarize changed files, validation, compatibility risk, and any remaining
-   follow-up.
-2. Ask the human to approve task completion before rewriting `TASKS.md` for
-   the next decision.
-3. After completion approval, update `TASKS.md`:
-   - clear the current task
-   - reset active approval to `Status: Pending` unless another approved task
-     remains active
-   - keep only follow-up, risk, validation caveat, and use-case
-     back-propagation notes needed for later decisions
+1. Confirm completion criteria:
+   - acceptance criteria are met
+   - required tests are added or updated
+   - validation is complete
+   - non-functional quality is preserved or justified
+   - readability is preserved or improved
+   - the approved scope is not exceeded
+   - unresolved risks are recorded
+   - production readiness is confirmed
+   - the implemented slice's test or validation result is reflected in
+     `TRACEABILITY.md`, or a not-required reason is stated
+   - implementation feedback is captured or explicitly unnecessary
+   - reusable knowledge is propagated through the Durable Documentation Gate
+2. Summarize changed files, validation, non-functional quality, production
+   readiness, user impact, compatibility risk, implementation feedback,
+   knowledge propagation, and any remaining follow-up:
+   - Production readiness:
+   - Failure modes:
+   - Diagnostics / user-facing errors:
+   - JP1/AJS compatibility:
+   - Large or malformed input risk:
+   - Desktop/web readiness:
+   - README/docs impact:
+   - CHANGELOG impact:
+3. Ask the human to approve slice completion before updating `TASKS.md`.
+4. After completion approval, update only the implemented slice status and
+   plan state:
+   - mark the slice `Status: Complete`
+   - preserve remaining approved slices for continued implementation
+   - set `Active implementation slice` to the next approved slice when one is
+     ready
+   - set plan `Status: Replan Required` only when a replanning trigger exists
+   - keep follow-up, risk, validation caveat, and use-case back-propagation
+     notes needed for later slices
    - remove work-log details that no longer affect future decisions
-4. Commit the approved work with a focused message.
-5. Confirm `git status --short --branch` is clean.
+5. Commit the approved slice with a focused message.
+6. Confirm `git status --short --branch` is clean.
 
 ## Rules
 
-- Do not implement without recorded `TASKS.md` approval.
+- Implement exactly one approved slice.
+- Do not plan new slices.
 - Do not broaden approved scope silently.
+- Return to `sdd-plan-task` when replanning is required.
+- Preserve non-functional quality unless a justified approved tradeoff is
+  necessary.
+- Preserve production readiness unless a justified approved tradeoff is
+  necessary.
+- Evaluate CHANGELOG update need when user-facing behavior, compatibility, or
+  workflow changes.
+- Prefer readability and maintainability over brevity, DRY-only extraction, or
+  generic abstraction.
+- Keep diffs minimal and tied to the approved slice.
+- Capture implementation feedback only when it improves future planning or
+  implementation.
+- Apply the Durable Documentation Gate before updating long-lived docs.
 - Preserve `engines.vscode` unless explicitly approved.
 - Preserve desktop and web extension behavior.
 - Keep domain independent of `vscode`, React, MUI, XyFlow, and webview code.

--- a/.codex/skills/sdd-implement-task/SKILL.md
+++ b/.codex/skills/sdd-implement-task/SKILL.md
@@ -144,8 +144,7 @@ Before completion, verify:
 - desktop and web behavior are both considered
 - README or user documentation is updated only when user-facing behavior
   changes
-- CHANGELOG update need is evaluated when user-facing behavior,
-  compatibility, or workflow changes
+- CHANGELOG update need is evaluated using `docs/specs/README.md`
 
 ### Non-Functional Quality
 
@@ -346,8 +345,8 @@ When implementation, reviews, fixes, and validation are complete:
   necessary.
 - Preserve production readiness unless a justified approved tradeoff is
   necessary.
-- Evaluate CHANGELOG update need when user-facing behavior, compatibility, or
-  workflow changes.
+- Evaluate CHANGELOG update need using `docs/specs/README.md` as the Single
+  Source of Truth.
 - Prefer readability and maintainability over brevity, DRY-only extraction, or
   generic abstraction.
 - Keep diffs minimal and tied to the approved slice.

--- a/.codex/skills/sdd-implement-task/agents/openai.yaml
+++ b/.codex/skills/sdd-implement-task/agents/openai.yaml
@@ -1,7 +1,7 @@
 ---
 interface:
   display_name: "SDD Implement Task"
-  short_description: "Implement an approved SDD task with reviews"
+  short_description: "Implement one approved SDD slice"
   default_prompt: >-
-    Use $sdd-implement-task to implement the current TASKS.md item and update
-    completion state.
+    Use $sdd-implement-task to implement one approved TASKS.md slice and update
+    its completion state.

--- a/.codex/skills/sdd-plan-task/SKILL.md
+++ b/.codex/skills/sdd-plan-task/SKILL.md
@@ -77,7 +77,8 @@ Use Planning Mode to create the initial full feature implementation plan.
    - JP1/AJS command/config reference impact
    - definition-file compatibility risk
    - large or malformed input risk
-   - README, user docs, or CHANGELOG update need
+   - README or user docs impact
+   - CHANGELOG update need using `docs/specs/README.md`
    - undocumented behavior or assumption
    - changed, added, or removed behavior scenarios when scenarios exist
    - breaking-change and VS Code compatibility risk
@@ -120,8 +121,10 @@ Use Feature Exit Mode only when implementation slices appear complete.
 4. Apply the Durable Documentation Gate before updating long-lived docs.
 5. Summarize evidence from `SPECS.md`, `TASKS.md`, `TRACEABILITY.md` when
    present, use cases, plans, and roadmap.
-6. Ask for explicit approval to close the feature.
-7. After approval, close the feature as described below.
+6. Report the Feature Exit Review using the standard output template in
+   `docs/specs/README.md`.
+7. Ask for explicit approval to close the feature.
+8. After approval, close the feature as described below.
 
 Do not perform Planning Mode or Replanning Mode work during Feature Exit Mode.
 
@@ -172,7 +175,8 @@ Before updating `TASKS.md`, explicitly establish:
   - JP1/AJS compatibility
   - large or malformed input risk
   - desktop/web impact
-  - README, user docs, or CHANGELOG update need
+  - README or user docs impact
+  - CHANGELOG update need using `docs/specs/README.md`
 - risks and unresolved assumptions
 - out-of-scope changes
 
@@ -287,8 +291,10 @@ When all planned slices appear complete, switch to Feature Exit Mode:
 2. Apply the Feature Definition of Done as the only completion standard.
 3. Summarize the evidence from `SPECS.md`, `TASKS.md`, use cases, plans, and
    roadmap.
-4. Ask for explicit approval to close the feature.
-5. Do not remove the feature folder before approval.
+4. Report the Feature Exit Review using the standard output template in
+   `docs/specs/README.md`.
+5. Ask for explicit approval to close the feature.
+6. Do not remove the feature folder before approval.
 
 ## Feature Definition of Done
 
@@ -413,6 +419,8 @@ implementation.
 - Keep use cases and other durable docs concise, reusable, and free of
   implementation history.
 - Apply the Durable Documentation Gate before updating long-lived docs.
+- Use `docs/specs/README.md` as the Single Source of Truth for Feature Exit
+  Review output and CHANGELOG update criteria.
 - Plan the feature as a whole; do not plan only the next edit unless
   replanning is explicitly scoped to one discovered gap.
 - Do not decompose by file, layer, or mechanical edit without standalone

--- a/.codex/skills/sdd-plan-task/SKILL.md
+++ b/.codex/skills/sdd-plan-task/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: sdd-plan-task
-description: Use when choosing the next SDD task for vscode-ajsbutler, investigating an active feature, updating feature TASKS.md, deciding whether a feature has no remaining tasks, moving completed feature notes into use cases, removing completed feature docs, or proposing the next feature from roadmap.md and plans.md. This planning skill stops before runtime code, tests, generated artifacts, or configuration changes.
+description: Use when creating or revising the full implementation-slice plan for an active vscode-ajsbutler SDD feature, including mode-selecting Planning/Replanning/Feature Exit work, decomposing the feature into approval-ready implementation slices, ordering dependencies, updating feature TASKS.md and TRACEABILITY.md, deciding whether replanning is required, performing Feature Exit Review, applying the Feature Definition of Done, moving durable completed feature knowledge into use cases or other long-lived docs, removing completed feature docs, or proposing the next feature from roadmap.md and plans.md. This planning skill stops before runtime code, tests, generated artifacts, or configuration changes.
 ---
 
 # sdd-plan-task
 
 ## Purpose
 
-Decide the next implementation task for an active SDD feature and record only
-the planning state needed for the next decision. Use this skill for task
-selection, feature completion checks, feature handoff, and repository-level
-next-feature proposals.
+Create or revise the full implementation plan for one active SDD feature, or
+run Feature Exit when implementation is complete. Use exactly one explicit
+mode per run: Planning Mode, Replanning Mode, or Feature Exit Mode.
 
 ## Inputs
 
@@ -29,71 +28,220 @@ Read these first:
 Use semantic code navigation from `docs/specs/README.md` only when a concrete
 symbol, component, command, adapter, or use case needs impact confirmation.
 
-## Workflow
+## SDD Workflow
+
+Default flow:
+
+```md
+sdd-create-feature -> sdd-plan-task -> sdd-review-plan -> Human Approval -> sdd-implement-task -> sdd-implement-task -> Feature Complete
+```
+
+Do not return to `sdd-plan-task` during normal implementation progress.
+Replan only when:
+
+- a new implementation slice is needed
+- scope changes
+- a new design decision is needed
+- the approval boundary changes
+- the impact is wider than planned
+- feature completion must be evaluated
+
+## Mode Selection
+
+Use this skill in exactly one mode:
+
+- Planning Mode: create the initial feature implementation-slice plan
+- Replanning Mode: revise the implementation-slice plan after a discovered gap
+- Feature Exit Mode: apply the Feature Definition of Done and prepare closure
+
+Do not mix Planning Mode, Replanning Mode, and Feature Exit Mode in one run.
+
+## Planning Mode
+
+Use Planning Mode to create the initial full feature implementation plan.
 
 1. Identify the active feature from the user request, `docs/specs/plans.md`,
-   or the feature folders under `docs/specs/features/`.
+   or feature folders under `docs/specs/features/`.
 2. Compare feature `SPECS.md`, feature `TASKS.md`, related use cases,
    `roadmap.md`, and `plans.md`.
-3. Decide the smallest useful next task. Prefer a vertical slice that can be
-   approved, implemented, reviewed, tested, and committed independently.
-4. Investigate impact enough to make the task concrete:
+3. Decompose the whole feature into implementation slices that cover the
+   feature-level requirements and acceptance criteria.
+4. Order slices by dependency and value. Prefer early slices that reduce
+   uncertainty, confirm boundary decisions, or unlock later implementation.
+5. Investigate impact enough to make each slice concrete:
    - affected files, symbols, commands, components, docs, and tests
    - desktop and web extension impact
+   - failure modes and user-facing error or diagnostic behavior
    - parser, application, presentation, infrastructure, and telemetry
      boundaries
+   - JP1/AJS command/config reference impact
+   - definition-file compatibility risk
+   - large or malformed input risk
+   - README, user docs, or CHANGELOG update need
+   - undocumented behavior or assumption
    - changed, added, or removed behavior scenarios when scenarios exist
    - breaking-change and VS Code compatibility risk
-5. Update or create feature `TASKS.md` with the current task, approval state,
-   unresolved risks, validation expectations, and minimal use-case
-   back-propagation notes.
-6. Keep feature `SPECS.md` focused on feature-level functional requirements,
+6. Update feature `TASKS.md` with the full implementation-slice plan,
+   dependency order, approval boundaries, validation methods, risks, and
+   out-of-scope changes.
+7. Create or update `TRACEABILITY.md` when required.
+8. Keep feature `SPECS.md` focused on feature-level functional requirements,
    compatibility requirements, acceptance criteria, and non-goals.
-7. Update `docs/specs/plans.md` only when the active feature set, branch-wide
+9. Update `docs/specs/plans.md` only when the active feature set, branch-wide
    assumptions, or repository sequencing changes.
-8. Update `docs/specs/roadmap.md` only when repository-level ordering,
-   remaining debt, or deferred work changes.
+10. Update `docs/specs/roadmap.md` only when repository-level ordering,
+    remaining debt, or deferred work changes.
+11. Hand off the completed plan to `sdd-review-plan` before implementation
+    approval.
 
-## No Remaining Feature Tasks
+## Replanning Mode
 
-When the active feature appears complete:
+Use Replanning Mode only after implementation or review discovers a gap.
 
-1. Report that no next task is apparent inside the feature.
-2. Summarize the evidence from `SPECS.md`, `TASKS.md`, use cases, plans, and
-   roadmap.
-3. Ask for explicit approval to close the feature.
-4. Do not remove the feature folder before approval.
+1. Identify the approved plan, affected slice, and discovered gap.
+2. Record why the current plan cannot continue unchanged.
+3. Revise the smallest necessary part of the implementation-slice plan.
+4. Update slice dependencies, approval boundaries, validation, production
+   readiness risks, and traceability only where the gap affects them.
+5. Preserve completed slices and unrelated approved slices.
+6. Send the revised plan to `sdd-review-plan` when slice boundaries,
+   dependencies, production readiness, or approval boundaries changed.
 
-After approval to close the feature:
+Do not use Replanning Mode to redesign the whole feature unless the discovered
+gap invalidates the whole plan.
 
-1. Move only durable behavior contracts into the relevant use-case files.
-2. Move only repository-level sequencing, remaining debt, or deferred work into
-   `roadmap.md` or `plans.md`.
-3. Remove the completed feature folder when it no longer carries active
-   requirements, active task decisions, unresolved risk, or useful follow-up.
-4. Re-read `roadmap.md` and `plans.md`, then propose the next feature.
+## Feature Exit Mode
+
+Use Feature Exit Mode only when implementation slices appear complete.
+
+1. Run the Feature Exit Review.
+2. Apply the Feature Definition of Done as the only completion standard.
+3. Confirm required `TRACEABILITY.md` updates are complete.
+4. Apply the Durable Documentation Gate before updating long-lived docs.
+5. Summarize evidence from `SPECS.md`, `TASKS.md`, `TRACEABILITY.md` when
+   present, use cases, plans, and roadmap.
+6. Ask for explicit approval to close the feature.
+7. After approval, close the feature as described below.
+
+Do not perform Planning Mode or Replanning Mode work during Feature Exit Mode.
+
+## Smallest Useful Implementation Slice
+
+A task is not required to minimize edit volume. It must be the smallest useful
+implementation slice.
+
+A slice must satisfy one of:
+
+- one user value
+- one domain meaning
+- one architecture responsibility
+
+A slice must also be independently:
+
+- reviewable
+- testable
+- committable
+- approvable
+
+Slices may touch multiple files when those files must change together to
+deliver the value, domain meaning, or architecture responsibility.
+
+Do not split a slice by file, layer, or mechanical edit when the resulting
+pieces cannot be validated meaningfully or do not provide standalone value.
+
+## Planning Gate
+
+Before updating `TASKS.md`, explicitly establish:
+
+- active feature folder
+- feature-level requirements and acceptance criteria covered by the plan
+- implementation slice list
+- implementation order
+- slice dependencies
+- why each slice is the smallest useful slice
+- user-visible, domain, or architecture value for each slice
+- cohesive component group for each slice
+- approval boundary for each slice
+- validation method for each slice
+- traceability mapping for each slice:
+  - corresponding use case or requirement
+  - `SPECS.md` requirement or acceptance criterion
+  - test file or validation plan
+- production readiness for each slice:
+  - failure mode
+  - JP1/AJS compatibility
+  - large or malformed input risk
+  - desktop/web impact
+  - README, user docs, or CHANGELOG update need
+- risks and unresolved assumptions
+- out-of-scope changes
+
+## Slice Sizing Rules
+
+A slice is too small when:
+
+- it only changes one file but cannot be validated alone
+- it leaves the feature in a knowingly broken or unusable intermediate state
+- it separates tests from the behavior they prove
+- it splits tightly coupled components that must be reviewed together
+- it is only a layer-level or mechanical edit with no standalone value
+
+A slice is too large when:
+
+- it contains multiple independent user outcomes
+- it mixes unrelated refactors with behavior changes
+- it changes parser, UI, export, telemetry, and docs for different reasons
+- it cannot be summarized as one approval boundary
+- it cannot be reviewed, tested, committed, or approved independently
 
 ## TASKS.md Shape
 
-Keep `TASKS.md` short and decision-focused. Prefer these sections:
+Keep `TASKS.md` focused on the feature's implementation-slice plan. Prefer
+these sections:
 
 ```md
 # <Feature> Tasks
 
-## Current Task
+## Plan Status
 
-- Status: Proposed | Pending Approval | Approved | In Progress | Blocked
+- Status: Proposed | Review Needed | Pending Approval | Approved | In Progress | Replan Required | Complete
+- Planning scope:
+- Review status:
+- Human approval:
+- Active implementation slice:
+
+## Implementation Slices
+
+### Slice 1: <name>
+
+- Status: Proposed | Approved | In Progress | Complete | Blocked | Replan Required
 - Scope:
+- User / Domain Value:
+- Cohesive Change Group:
 - Acceptance:
 - Validation:
+- Production Readiness:
+  - Failure mode:
+  - JP1/AJS compatibility:
+  - Large or malformed input risk:
+  - Desktop/web impact:
+  - README/docs impact:
+  - CHANGELOG impact:
+- Approval Boundary:
+- Dependencies:
+- Risks:
+- Out of Scope:
 
-## Human Approval
+## Traceability
 
-- Status: Pending | Approved
-- Approved at:
-- Approved scope:
+- TRACEABILITY.md required: yes | no
+- Reason:
 
-## Decision Notes
+## Cross-Slice Dependencies
+
+- ...
+
+## Feature-Level Risks
 
 - ...
 
@@ -103,35 +251,157 @@ Keep `TASKS.md` short and decision-focused. Prefer these sections:
 ```
 
 Remove completed task history once it no longer affects approval, unresolved
-risk, validation, or use-case back-propagation.
+risk, validation, or use-case back-propagation. Keep completed slice status and
+any remaining dependencies that affect later slices.
+
+## Traceability
+
+Create or update `docs/specs/features/<feature>/TRACEABILITY.md` when the
+feature is non-trivial, changes user-visible behavior, affects JP1/AJS
+definition-file interpretation or compatibility, splits into multiple slices,
+or needs explicit use-case correspondence.
+
+`TRACEABILITY.md` must map:
+
+- Use Case
+- Requirement
+- `SPECS.md` section
+- Implementation Slice
+- Test file or validation plan
+
+During Planning Mode and Replanning Mode, ensure each slice states:
+
+- which use case or requirement it supports
+- which `SPECS.md` requirement or acceptance criterion it implements
+- which test or validation will prove it
+
+During Feature Exit Mode, verify required traceability is updated. Do not
+create unnecessary traceability records for minor docs-only or temporary
+investigation work.
+
+## No Remaining Feature Tasks
+
+When all planned slices appear complete, switch to Feature Exit Mode:
+
+1. Run the Feature Exit Review.
+2. Apply the Feature Definition of Done as the only completion standard.
+3. Summarize the evidence from `SPECS.md`, `TASKS.md`, use cases, plans, and
+   roadmap.
+4. Ask for explicit approval to close the feature.
+5. Do not remove the feature folder before approval.
+
+## Feature Definition of Done
+
+A feature is complete only when all of these are true:
+
+- every implementation slice is `Complete`
+- feature acceptance criteria are satisfied
+- feature requirements are satisfied
+- required validation is complete
+- non-functional quality is preserved or justified
+- durable use-case updates are complete
+- required `TRACEABILITY.md` updates are complete, or not required with a clear
+  reason
+- `docs/specs/plans.md` is updated
+- `docs/specs/roadmap.md` is updated when repository-level sequencing,
+  remaining debt, or deferred work changed
+- unresolved risks are resolved, accepted, or recorded as follow-up
+
+Do not close a feature by partial evidence, elapsed effort, or lack of obvious
+next tasks. Use this Definition of Done as the sole completion criterion.
+
+## Feature Exit Review
+
+Before closing a feature, verify:
+
+- all implementation slices are complete
+- feature acceptance criteria are met
+- feature requirements are met
+- validation is complete
+- non-functional quality is preserved
+- unresolved risks are organized
+- use-case propagation is complete
+- required `TRACEABILITY.md` is updated
+- `plans.md` propagation is complete
+- `roadmap.md` propagation is complete when needed
+- the feature folder can be removed without losing active requirements,
+  approval decisions, unresolved risks, or reusable knowledge
+
+Feature Close may happen only after this review passes and the human approves
+closure.
+
+## Durable Documentation Gate
+
+Before moving feature knowledge into use cases, `plans.md`, `roadmap.md`,
+README, AGENTS, design guides, development guides, or other long-lived docs,
+verify the information:
+
+- is reusable beyond this feature
+- describes durable behavior, specification, design policy, or repository
+  operating policy
+- helps future planning or implementation
+- does not duplicate another durable document
+- is not a temporary investigation result
+- is not implementation history
+- is not review commentary
+- is not a record of a resolved issue
+
+Update only the smallest necessary durable document surface. Leave
+feature-specific work notes in feature docs until closure, then remove them
+with the feature folder.
+
+After approval to close the feature:
+
+1. Move only knowledge that passes the Durable Documentation Gate into the
+   relevant durable docs.
+2. Move repository-level sequencing, remaining debt, or deferred work into
+   `roadmap.md` or `plans.md` only when it passes the gate.
+3. Remove the completed feature folder when it no longer carries active
+   requirements, active task decisions, unresolved risk, or useful follow-up.
+4. Re-read `roadmap.md` and `plans.md`, then propose the next feature.
 
 ## Approval Boundary
 
 This skill may update SDD documents, record investigation, organize
-alternatives, and ask for approval. It must not edit runtime code, tests,
-generated artifacts, configuration, implementation branches, implementation
-commits, implementation refactors, or incidental fixes.
+alternatives, and ask for plan review or human approval. It must not edit
+runtime code, tests, generated artifacts, configuration, implementation
+branches, implementation commits, implementation refactors, or incidental
+fixes.
 
-Before handing off to implementation, report:
+Before handing off to review or approval, report:
 
 ```md
-## Impact Investigation Summary
+## Feature Implementation Plan Summary
 
-- Planned change:
-- Affected files:
-- Affected functions/classes/components:
-- Affected features:
-- Affected tests:
-- Related docs:
-- Breaking-change risk:
-- Alternatives:
+- Feature:
+- Planning scope:
+- Slice count:
+- Implementation order:
+- Cross-slice dependencies:
+- JP1/AJS command/config reference impact:
+- Definition-file compatibility risk:
+- Undocumented behavior or assumption:
+- Desktop/web compatibility risk:
+- TRACEABILITY.md required:
+- TRACEABILITY.md status:
+- Out of scope:
 
-## Approval Request
+## Slices
 
-Please approve implementation before I edit runtime code, tests,
-generated artifacts, or configuration.
+- Slice:
+  - User / Domain Value:
+  - Cohesive Change Group:
+  - Approval Boundary:
+  - Validation:
+  - Traceability:
+  - Production Readiness:
+  - Dependencies:
+  - Risks:
 
-Implementation will not proceed until approval is given.
+## Next Step
+
+Use `sdd-review-plan` to review the full plan before human approval and
+implementation.
 ```
 
 ## Rules
@@ -140,7 +410,13 @@ Implementation will not proceed until approval is given.
 - Preserve desktop and web extension behavior.
 - Prefer KISS and YAGNI before adding abstractions.
 - Document assumptions instead of hiding them.
-- Keep use cases durable and feature docs temporary.
+- Keep use cases and other durable docs concise, reusable, and free of
+  implementation history.
+- Apply the Durable Documentation Gate before updating long-lived docs.
+- Plan the feature as a whole; do not plan only the next edit unless
+  replanning is explicitly scoped to one discovered gap.
+- Do not decompose by file, layer, or mechanical edit without standalone
+  value.
 - Treat Serena or equivalent semantic tooling as supplemental evidence, not as
   proof that a change is safe.
 - Run docs-only validation through `rtk` before finishing; use

--- a/.codex/skills/sdd-plan-task/agents/openai.yaml
+++ b/.codex/skills/sdd-plan-task/agents/openai.yaml
@@ -1,6 +1,7 @@
 ---
 interface:
   display_name: "SDD Plan Task"
-  short_description: "Plan the next SDD task and feature handoff"
+  short_description: "Plan feature implementation slices"
   default_prompt: >-
-    Use $sdd-plan-task to decide the next SDD task and update TASKS.md.
+    Use $sdd-plan-task to decompose the active SDD feature into implementation
+    slices and update TASKS.md.

--- a/.codex/skills/sdd-review-plan/SKILL.md
+++ b/.codex/skills/sdd-review-plan/SKILL.md
@@ -45,7 +45,7 @@ Evaluate at least these dimensions:
   `SPECS.md` sections, implementation slices, and tests or validation plans
 - Production Readiness: failure modes, diagnostics, JP1/AJS compatibility,
   large or malformed input risk, desktop/web readiness, README/docs impact,
-  and CHANGELOG impact can be validated by later slices
+  and CHANGELOG impact can be evaluated using `docs/specs/README.md`
 - Cross-Slice Architectural Consistency: naming, DTOs, view models, entities,
   public interfaces, layer responsibilities, dependencies, and architecture
   boundaries remain consistent across the whole feature
@@ -88,7 +88,8 @@ Evaluate at least these dimensions:
    - JP1/AJS command/config reference impact
    - definition-file compatibility risk
    - large or malformed input validation need
-   - README, user docs, or CHANGELOG update need
+   - README or user docs impact
+   - CHANGELOG update need using `docs/specs/README.md`
    - undocumented behavior or assumptions
    - breaking-change and VS Code compatibility risk
 7. Check traceability artifact quality:
@@ -175,3 +176,5 @@ approved slice scope.
 - Preserve `engines.vscode` unless explicitly approved.
 - Keep the review focused on plan quality, not code style.
 - Send unclear or changed scope back to `sdd-plan-task`.
+- Use `docs/specs/README.md` as the Single Source of Truth for CHANGELOG
+  update criteria and trivial-change classification.

--- a/.codex/skills/sdd-review-plan/SKILL.md
+++ b/.codex/skills/sdd-review-plan/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: sdd-review-plan
+description: Use when reviewing a prepared vscode-ajsbutler SDD feature implementation plan before human approval or implementation, especially to assess implementation-slice granularity, slice ordering, dependencies, cohesion, independence, cross-slice architectural consistency, approval boundaries, impact investigation, TRACEABILITY.md quality, traceability to SPECS/TASKS/use cases, production readiness outlook, acceptance criteria, validation plans, and whether replanning is required. This review skill does not create plans, approve work, or edit runtime code.
+---
+
+# sdd-review-plan
+
+## Purpose
+
+Review a prepared feature implementation plan before human approval and
+implementation. Use this skill after `sdd-plan-task` creates or revises the
+full slice plan, and before `sdd-implement-task` implements any slice.
+
+## Inputs
+
+Read these first:
+
+1. `AGENTS.md`
+2. `docs/specs/README.md`
+3. `docs/specs/plans.md`
+4. the relevant `docs/specs/features/<feature>/SPECS.md`
+5. the relevant `docs/specs/features/<feature>/TASKS.md`
+6. related `docs/requirements/use-cases/` files when behavior contracts may
+   be affected
+
+Inspect referenced code symbols, components, adapters, commands, tests, or docs
+only enough to validate the plan's claims. Do not edit runtime code, tests,
+generated artifacts, configuration, or implementation branches.
+
+## Review Criteria
+
+Evaluate at least these dimensions:
+
+- Value: every slice has one user-visible value, domain meaning, or
+  architecture responsibility
+- Cohesion: each slice groups files and components around one coherent intent
+- Independence: each slice can be approved, implemented, reviewed, validated,
+  and committed independently
+- Testability: acceptance criteria and validation can prove each slice
+- Approval Boundary: in-scope and out-of-scope work are explicit for each
+  slice and for the feature plan
+- Risk: desktop/web compatibility, VS Code compatibility, JP1/AJS definition
+  compatibility, parser/UI boundary, and telemetry risks are addressed
+- Traceability: required `TRACEABILITY.md` maps use cases, requirements,
+  `SPECS.md` sections, implementation slices, and tests or validation plans
+- Production Readiness: failure modes, diagnostics, JP1/AJS compatibility,
+  large or malformed input risk, desktop/web readiness, README/docs impact,
+  and CHANGELOG impact can be validated by later slices
+- Cross-Slice Architectural Consistency: naming, DTOs, view models, entities,
+  public interfaces, layer responsibilities, dependencies, and architecture
+  boundaries remain consistent across the whole feature
+
+## Review Workflow
+
+1. Identify the active feature and full implementation-slice plan from
+   `TASKS.md`.
+2. Check whether the plan covers the feature requirements and acceptance
+   criteria without unrelated scope.
+3. Evaluate slice granularity:
+   - propose merging slices that are too small
+   - propose splitting slices that are too large
+   - propose moving slices when ordering or dependency direction is wrong
+4. Evaluate cross-slice architectural consistency:
+   - naming conventions are consistent
+   - DTO, ViewModel, and Entity responsibilities align
+   - layer responsibilities stay consistent
+   - public interfaces are coherent across slices
+   - slice dependencies are justified and ordered correctly
+   - architecture boundaries hold across the whole feature
+5. Confirm each slice records:
+   - scope
+   - user/domain value or architecture responsibility
+   - cohesive change group
+   - acceptance
+   - validation
+   - traceability to use case or requirement
+   - production readiness risks and validation
+   - approval boundary
+   - dependencies
+   - risks
+   - out of scope
+6. Check impact investigation coverage:
+   - affected files, symbols, commands, components, docs, and tests
+   - desktop and web extension impact
+   - failure mode validation plan
+   - parser, application, presentation, infrastructure, and telemetry
+     boundaries
+   - JP1/AJS command/config reference impact
+   - definition-file compatibility risk
+   - large or malformed input validation need
+   - README, user docs, or CHANGELOG update need
+   - undocumented behavior or assumptions
+   - breaking-change and VS Code compatibility risk
+7. Check traceability artifact quality:
+   - required `TRACEABILITY.md` exists or has a clear not-required reason
+   - slices map to use cases or requirements
+   - slices map to `SPECS.md` requirements or acceptance criteria
+   - tests or validation plans are explicit
+   - unnecessary traceability records are not created for trivial work
+8. Repeat review recommendations until the plan is ready for human approval,
+   or clearly report why it remains blocked.
+9. Report findings without rewriting the plan unless the user explicitly asks
+   for edits.
+
+## Sizing Rules
+
+A slice is too small when:
+
+- it only changes one file but cannot be validated alone
+- it leaves the feature in a knowingly broken or unusable intermediate state
+- it separates tests from the behavior they prove
+- it splits tightly coupled components that must be reviewed together
+- it is only a layer-level or mechanical edit with no standalone value
+
+A slice is too large when:
+
+- it contains multiple independent user outcomes
+- it mixes unrelated refactors with behavior changes
+- it changes parser, UI, export, telemetry, and docs for different reasons
+- it cannot be summarized as one approval boundary
+- it cannot be reviewed, tested, committed, or approved independently
+
+## Output
+
+Report:
+
+```md
+## Plan Review
+
+- Verdict: Ready for approval | Needs revision | Split recommended | Replan required
+- Value:
+- Cohesion:
+- Independence:
+- Testability:
+- Approval Boundary:
+- Risk:
+- Traceability:
+- Production Readiness:
+- Cross-Slice Architectural Consistency:
+
+## Slice Review
+
+- Slice:
+  - Verdict:
+  - Notes:
+
+## Findings
+
+- ...
+
+## Recommended Changes
+
+- Merge:
+- Split:
+- Reorder:
+- Add validation:
+- Adjust approval boundary:
+- Update traceability:
+- Adjust production readiness:
+
+## Next Step
+
+If ready, request human approval for the reviewed plan. Use
+`sdd-implement-task` only after `TASKS.md` records the approved plan and
+approved slice scope.
+```
+
+## Rules
+
+- Do not implement the plan.
+- Do not approve on behalf of the user.
+- Do not broaden scope silently.
+- Prefer concrete revision recommendations over vague critique.
+- Preserve desktop and web extension compatibility expectations.
+- Preserve `engines.vscode` unless explicitly approved.
+- Keep the review focused on plan quality, not code style.
+- Send unclear or changed scope back to `sdd-plan-task`.

--- a/.codex/skills/sdd-review-plan/agents/openai.yaml
+++ b/.codex/skills/sdd-review-plan/agents/openai.yaml
@@ -1,0 +1,7 @@
+---
+interface:
+  display_name: "SDD Review Plan"
+  short_description: "Review a feature implementation plan"
+  default_prompt: >-
+    Use $sdd-review-plan to review a prepared SDD feature implementation plan
+    before human approval.

--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -34,7 +34,7 @@
 - [ ] desktop scenario checked
 - [ ] web scenario checked if relevant
 - [ ] Production readiness reviewed
-- [ ] CHANGELOG update need evaluated
+- [ ] CHANGELOG update need evaluated against `docs/specs/README.md`
 
 ## Risks
 

--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -22,7 +22,9 @@
 ## SDD (Software Design Document)
 
 - [ ] related spec updated
-- [ ] `PLANS.md` updated for non-trivial work
+- [ ] `TASKS.md` slice plan/status updated when non-trivial work changed
+- [ ] `TRACEABILITY.md` updated or not required
+- [ ] Feature Exit / Definition of Done considered when completing a feature
 
 ## Validation
 
@@ -31,6 +33,8 @@
 - [ ] tests
 - [ ] desktop scenario checked
 - [ ] web scenario checked if relevant
+- [ ] Production readiness reviewed
+- [ ] CHANGELOG update need evaluated
 
 ## Risks
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,8 +26,8 @@ Read these in order before making changes
 
    - `plans.md` - Branch status and priorities
    - `features/*/SPECS.md` - Feature requirements
-   - `features/*/PLANS.md` - Implementation design
-   - `features/*/TASKS.md` - Execution checklist
+   - `features/*/TASKS.md` - Implementation-slice plan and approval state
+   - `features/*/TRACEABILITY.md` - Requirement to validation mapping when required
 
 3. **`README.md`** - Build/test commands and quick reference
 
@@ -81,7 +81,8 @@ or adapter boundaries:
 - Add or update unit/integration tests
 - Run `rtk pnpm run qlty`, `rtk pnpm test`, and
   `rtk pnpm run test:web`
-- For docs-only changes, `rtk pnpm run lint:md` is sufficient
+- For docs-only changes, run `rtk pnpm run qlty`; add
+  `rtk pnpm run lint:md` when markdown-specific validation is useful
 
 ## Key Constraints
 
@@ -128,8 +129,12 @@ routing matrix first.
 ## Next Steps
 
 - For complex changes, follow the SDD workflow in `AGENTS.md` § "SDD Workflow"
-- Refer to `docs/specs/features/` for use-case examples
-- Keep assumptions and design decisions documented in feature `PLANS.md`
+- Refer to `docs/specs/README.md` and `.codex/skills/` for the authoritative
+  SDD gates
+- Keep assumptions and design decisions in the responsible SDD artifact:
+  use cases for durable behavior, `SPECS.md` for feature requirements,
+  `TASKS.md` for slice plans, and `TRACEABILITY.md` for requirement-to-test
+  mapping when required
 - Run full validation (`rtk pnpm run qlty`, `rtk pnpm test`,
   `rtk pnpm run test:web`, `rtk pnpm run build`) before pushing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ Primary goals of this repository:
 
 1. Keep VS Code compatibility stable.
 2. Modernize dependencies without breaking extension behavior.
-3. Incrementally migrate to Specification-Driven Development (SDD).
+3. Use Specification-Driven Development (SDD) as the standard development
+   process for non-trivial work.
 4. Refactor toward Domain-Driven Design (DDD) and Clean Architecture.
 5. Preserve behavior for parser, list view, flow view, CSV export, diagnostics, hover, and telemetry.
 
@@ -62,22 +63,42 @@ Good first slices:
 
 ## SDD Workflow
 
-For non-trivial changes, follow this order:
+SDD is the only standard process for non-trivial changes. Do not use an
+alternate implementation flow when SDD applies.
 
-1. Read `docs/specs/README.md` first, especially the
-   Implementation Change Gate.
-2. Read relevant feature and roadmap docs in `docs/specs/`.
-3. Follow the semantic code navigation guidance in `docs/specs/README.md`
-   when Serena or an equivalent tool is available.
-4. Update or create the relevant use-case spec.
-5. Write or update a short implementation plan in `PLANS.md`.
-6. Confirm acceptance criteria and required approval gates before editing
-   runtime code, tests, generated artifacts, or configuration.
-7. Implement.
-8. Run quality checks.
-9. Summarize impact and remaining risks.
+Follow this lifecycle:
 
-If the requested change is ambiguous, prefer documenting assumptions explicitly in `PLANS.md` instead of making hidden assumptions.
+1. Start feature intake with `sdd-create-feature`.
+2. Create or revise the feature implementation-slice plan with
+   `sdd-plan-task`.
+3. Review the plan with `sdd-review-plan`.
+4. Obtain clear Human Approval for the reviewed plan and approved slice scope.
+5. Implement only approved slices with `sdd-implement-task`.
+6. Replan with `sdd-plan-task` only when scope, design decisions, impact, or
+   approval boundaries change.
+7. Close the feature only through Feature Exit Mode after the Feature
+   Definition of Done passes.
+
+Before editing runtime code, tests, generated artifacts, or configuration,
+the active feature must have an approved implementation slice recorded in
+`TASKS.md`. If the requested change is ambiguous, document assumptions in the
+right SDD artifact and stop for clarification or approval instead of making
+hidden assumptions.
+
+Document responsibilities:
+
+- Use Case: durable behavior contract.
+- `SPECS.md`: feature requirements, boundaries, compatibility, and acceptance.
+- `TASKS.md`: implementation-slice plan, approval state, validation, risks,
+  and feature exit readiness.
+- `TRACEABILITY.md`: mapping from use case or requirement through `SPECS.md`,
+  slice, and test or validation when required.
+- `docs/specs/plans.md`: branch-level active features and branch-wide
+  decisions.
+- `docs/specs/roadmap.md`: repository-level direction, sequence, remaining
+  debt, and deferred work.
+- README: user/developer overview and command reference.
+- AGENTS: agent-facing repository rules and SDD entrypoint.
 
 ## Branch Naming
 
@@ -96,15 +117,22 @@ If the requested change is ambiguous, prefer documenting assumptions explicitly 
 - Avoid unnecessary framework coupling.
 - Prefer pure functions in domain/application layers.
 - Keep functions small.
+- Prefer readability and maintainability over brevity, DRY-only extraction, or
+  generic abstraction.
 - Do not mix UI formatting logic with parsing/domain logic.
 - Avoid large files when extracting new use cases or adapters is practical.
 - Keep naming aligned with JP1/AJS business concepts.
+- Keep implementation diffs limited to the approved slice scope.
+- Do not plan new work during implementation; return to `sdd-plan-task` when
+  replanning is required.
 
 ## Testing Policy
 
 Before finishing a task, run the most relevant checks available.
 
-For docs-only changes, markdown lint is sufficient.
+For docs-only changes, run `rtk pnpm run qlty`; add
+`rtk pnpm run lint:md` when markdown structure or links need focused
+validation.
 
 Minimum expectation for meaningful code changes:
 
@@ -121,6 +149,29 @@ Recommended test layers:
 - DTO/view model mapping tests
 - VS Code integration tests for desktop
 - web extension smoke tests
+
+Production readiness checks must cover failure modes, understandable
+diagnostics or fallback behavior, JP1/AJS definition-file compatibility, large
+or malformed input risk, desktop/web behavior, README or user-doc impact, and
+CHANGELOG update need when user-visible behavior, compatibility, or workflow
+changes.
+
+## Durable Documentation Gate
+
+Before updating long-lived docs such as use cases, README, AGENTS,
+`plans.md`, `roadmap.md`, or design/development guides, verify the content:
+
+- is reusable beyond one feature
+- describes durable behavior, specification, design policy, or repository
+  operating policy
+- helps future planning or implementation
+- does not duplicate another durable document
+- is not a temporary investigation result
+- is not implementation history
+- is not review commentary
+- is not a record of a resolved issue
+
+Update the smallest necessary durable document surface.
 
 ## VS Code Compatibility Policy
 
@@ -281,7 +332,8 @@ This repository is designed to work seamlessly with multiple AI agents, each wit
 **Source of Truth** (all agents reference, never duplicate):
 
 - `AGENTS.md` - Architecture rules and agent routing (you are here)
-- `docs/specs/` - SDD specifications and use cases
+- `docs/specs/` and `docs/requirements/use-cases/` - SDD workflow,
+  feature artifacts, and durable behavior contracts
 - `README.md` - Build/test commands and quick reference
 
 **Agent-Specific Configuration** (agent instructions, not rules):
@@ -296,13 +348,13 @@ This repository is designed to work seamlessly with multiple AI agents, each wit
 
    - `.github/copilot-instructions.md` → points to this section
    - `AGENTS.md` (this routing guide) → determines task type
-   - `docs/specs/` → gets SDD context
+   - `docs/specs/` and `docs/requirements/use-cases/` → gets SDD context
    - `README.md` → gets build/test commands
 
 2. **Codex** reads:
    - `.codex/skills/*/SKILL.md` → references `AGENTS.md` routing
    - `AGENTS.md` (this routing guide) → determines task type
-   - `docs/specs/` → gets SDD context
+   - `docs/specs/` and `docs/requirements/use-cases/` → gets SDD context
    - Editor context → live analysis
 
 ### Best Practices for Multi-Agent Work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,20 +85,10 @@ the active feature must have an approved implementation slice recorded in
 right SDD artifact and stop for clarification or approval instead of making
 hidden assumptions.
 
-Document responsibilities:
-
-- Use Case: durable behavior contract.
-- `SPECS.md`: feature requirements, boundaries, compatibility, and acceptance.
-- `TASKS.md`: implementation-slice plan, approval state, validation, risks,
-  and feature exit readiness.
-- `TRACEABILITY.md`: mapping from use case or requirement through `SPECS.md`,
-  slice, and test or validation when required.
-- `docs/specs/plans.md`: branch-level active features and branch-wide
-  decisions.
-- `docs/specs/roadmap.md`: repository-level direction, sequence, remaining
-  debt, and deferred work.
-- README: user/developer overview and command reference.
-- AGENTS: agent-facing repository rules and SDD entrypoint.
+Document roles are defined only in `docs/specs/README.md`. Use that file as
+the Single Source of Truth for SDD artifact responsibilities, including
+`SPECS.md`, `TASKS.md`, `TRACEABILITY.md`, `docs/specs/plans.md`, and
+`docs/specs/roadmap.md`.
 
 ## Branch Naming
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Good first slices:
 
 SDD is the only standard process for non-trivial changes. Do not use an
 alternate implementation flow when SDD applies.
+Use `docs/specs/README.md` as the Single Source of Truth for deciding whether
+a change is trivial enough to skip SDD feature creation.
 
 Follow this lifecycle:
 
@@ -143,8 +145,7 @@ Recommended test layers:
 Production readiness checks must cover failure modes, understandable
 diagnostics or fallback behavior, JP1/AJS definition-file compatibility, large
 or malformed input risk, desktop/web behavior, README or user-doc impact, and
-CHANGELOG update need when user-visible behavior, compatibility, or workflow
-changes.
+CHANGELOG update need according to `docs/specs/README.md`.
 
 ## Durable Documentation Gate
 

--- a/PLANS.md
+++ b/PLANS.md
@@ -7,12 +7,14 @@ Current active planning topic:
 
 Use the documents as follows:
 
-- `docs/specs/plans.md`: branch status, current task, workflow rules, and
-  branch-level planning notes
+- `docs/specs/plans.md`: active feature folders, branch-wide decisions, and
+  repository sequencing that applies across features
 - `docs/specs/roadmap.md`: medium-term extraction order and deferred slices
 - `docs/specs/features/<feature>/SPECS.md`: per-feature requirements
-- `docs/specs/features/<feature>/TASKS.md`: execution checklist for the
-  current slice
+- `docs/specs/features/<feature>/TASKS.md`: implementation-slice plan,
+  approval state, validation, risks, and feature exit readiness
+- `docs/specs/features/<feature>/TRACEABILITY.md`: requirement-to-validation
+  mapping when required
 
 Keep this root file as a pointer only. When branch direction changes, update
 `docs/specs/plans.md` first, then refresh feature docs and roadmap only where

--- a/README.md
+++ b/README.md
@@ -50,18 +50,37 @@ To use this extension:
 
 ## Development
 
-This repository is incrementally adopting Specification-Driven Development
-(SDD) and cleaner application boundaries.
+This repository uses Specification-Driven Development (SDD) as the standard
+process for non-trivial changes.
 
 - SDD guidance starts in `docs/specs/README.md`.
+- Feature work starts with `sdd-create-feature`.
+- Feature implementation plans are created or revised with `sdd-plan-task`.
+- Plans are reviewed with `sdd-review-plan`.
+- Runtime code, tests, generated artifacts, and configuration are edited only
+  after Human Approval.
+- `sdd-implement-task` implements one approved implementation slice at a time.
+- Feature closure follows the Feature Definition of Done in
+  `docs/specs/README.md`.
 - Repository-level use-case contracts live in
   `docs/requirements/use-cases/`.
 - Branch-level planning is tracked in `docs/specs/plans.md`.
-- `PLANS.md` is the root index that points to the active SDD documents.
 - Codex-specific repository guidance lives in `AGENTS.md`.
 - Docs-only work should use a `docs/...` branch name and stay within the
   docs-only file set used by `.github/workflows/verify.yml`:
   `docs/**`, `README.md`, `.codex/**/*.md`, and `.github/**/*.md`.
+
+SDD artifact roles:
+
+- Use cases: durable behavior contracts.
+- `SPECS.md`: feature requirements, boundaries, and acceptance criteria.
+- `TASKS.md`: implementation-slice plan, approval state, validation, risks,
+  and feature exit readiness.
+- `TRACEABILITY.md`: use case or requirement to validation mapping when
+  required.
+- `docs/specs/plans.md`: branch-level active features and branch-wide
+  decisions.
+- `docs/specs/roadmap.md`: repository-level direction and sequencing.
 
 Recent refactoring work introduced:
 
@@ -169,6 +188,10 @@ proxy exists, for example `rtk git status --short --branch`,
 `rtk pnpm run qlty`, or `rtk pnpm run build`. Use native commands only when
 `rtk` has no suitable proxy, exact unfiltered output is required, or the
 command is interactive.
+
+Agent development rules are centralized in `AGENTS.md` and `docs/specs/`.
+README intentionally stays at overview level to avoid duplicating the SDD
+workflow.
 
 ## Telemetry
 

--- a/README.md
+++ b/README.md
@@ -53,43 +53,15 @@ To use this extension:
 This repository uses Specification-Driven Development (SDD) as the standard
 process for non-trivial changes.
 
-- SDD guidance starts in `docs/specs/README.md`.
-- Feature work starts with `sdd-create-feature`.
-- Feature implementation plans are created or revised with `sdd-plan-task`.
-- Plans are reviewed with `sdd-review-plan`.
-- Runtime code, tests, generated artifacts, and configuration are edited only
-  after Human Approval.
-- `sdd-implement-task` implements one approved implementation slice at a time.
-- Feature closure follows the Feature Definition of Done in
-  `docs/specs/README.md`.
-- Repository-level use-case contracts live in
-  `docs/requirements/use-cases/`.
-- Branch-level planning is tracked in `docs/specs/plans.md`.
-- Codex-specific repository guidance lives in `AGENTS.md`.
-- Docs-only work should use a `docs/...` branch name and stay within the
-  docs-only file set used by `.github/workflows/verify.yml`:
-  `docs/**`, `README.md`, `.codex/**/*.md`, and `.github/**/*.md`.
+- SDD workflow and document roles: `docs/specs/README.md`
+- Agent-facing repository rules and routing: `AGENTS.md`
+- Durable behavior contracts: `docs/requirements/use-cases/`
+- Copilot CLI entry point: `.github/copilot-instructions.md`
+- Codex workflows: `.codex/skills/`
 
-SDD artifact roles:
-
-- Use cases: durable behavior contracts.
-- `SPECS.md`: feature requirements, boundaries, and acceptance criteria.
-- `TASKS.md`: implementation-slice plan, approval state, validation, risks,
-  and feature exit readiness.
-- `TRACEABILITY.md`: use case or requirement to validation mapping when
-  required.
-- `docs/specs/plans.md`: branch-level active features and branch-wide
-  decisions.
-- `docs/specs/roadmap.md`: repository-level direction and sequencing.
-
-Recent refactoring work introduced:
-
-- a normalized AJS model for application-facing use cases
-- application use cases for unit list, flow graph, CSV export, and unit
-  definition building
-- a table row/view adapter so the table UI consumes application view data
-  instead of `UnitEntity` wrapper accessors
-- repeatable web-extension verification via `pnpm run test:web`
+Keep README as an overview and command reference. Detailed development rules,
+approval gates, feature artifact responsibilities, and agent routing live in
+the documents above.
 
 Browser-based extension testing uses `@vscode/test-web`, which currently
 requires Node.js 20 or later.
@@ -153,45 +125,9 @@ misses remain valid.
 
 ## For AI Agents
 
-This repository supports both **Copilot CLI** and **Codex** (VS Code Copilot).
-Agents should coordinate using a shared routing guide rather than separate
-configurations.
-
-### Quick Reference
-
-| Agent           | Primary Strength                       | Fallback Available | Configuration                     |
-| --------------- | -------------------------------------- | ------------------ | --------------------------------- |
-| **Codex**       | Live coding, SDD workflow, interactive | Yes (Copilot CLI)  | `.codex/skills/`                  |
-| **Copilot CLI** | Automation, git ops, batch work        | Yes (Codex)        | `.github/copilot-instructions.md` |
-
-**Note**: If a Primary agent reaches token limit or session loss, use the Fallback agent.
-Both agents stay coordinated through a single routing guide (see below).
-
-### Routing Guide (Single Source of Truth)
-
-For detailed task-to-agent assignment with Primary/Fallback options:
-
-- **See** `AGENTS.md` § "AI Agent Routing Guide"
-- **See** `.agent.md` for lightweight coordination index
-- All rules reference **AGENTS.md**, never duplicate
-
-### Key Files
-
-- `AGENTS.md` - Architecture rules and agent routing (authoritative)
-- `.agent.md` - Multi-agent coordination index
-- `docs/specs/` - Specification-driven development documentation
-- `.github/copilot-instructions.md` - Copilot CLI entry point
-- `.codex/skills/` - Codex-specific workflows
-
-AI agents should run CLI commands through `rtk` by default when a matching
-proxy exists, for example `rtk git status --short --branch`,
-`rtk pnpm run qlty`, or `rtk pnpm run build`. Use native commands only when
-`rtk` has no suitable proxy, exact unfiltered output is required, or the
-command is interactive.
-
-Agent development rules are centralized in `AGENTS.md` and `docs/specs/`.
-README intentionally stays at overview level to avoid duplicating the SDD
-workflow.
+Agent development rules are centralized in `AGENTS.md` and
+`docs/specs/README.md`. README intentionally stays at overview level to avoid
+duplicating the SDD workflow.
 
 ## Telemetry
 

--- a/docs/requirements/use-cases/README.md
+++ b/docs/requirements/use-cases/README.md
@@ -56,12 +56,14 @@ That belongs in `docs/specs/`.
   Repository-level behavior contract.
 - `docs/specs/features/<feature>/SPECS.md`
   Feature-local implementation requirements and boundary decisions.
-- `docs/specs/features/<feature>/PLANS.md`
-  Feature-local design and milestone notes.
 - `docs/specs/features/<feature>/TASKS.md`
-  Execution checklist for the current slice.
+  Feature implementation-slice plan, approval state, validation, risks, and
+  feature exit readiness.
+- `docs/specs/features/<feature>/TRACEABILITY.md`
+  Mapping from use case or requirement through `SPECS.md`, implementation
+  slice, and test or validation when required.
 - `docs/specs/plans.md`
-  Branch-level summary, current task, and next priorities.
+  Branch-level active features and branch-wide decisions.
 
 ## Decision Rule
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -25,9 +25,22 @@ repository.
 SDD is the standard process for non-trivial changes. Use the Codex SDD skills
 as the operational workflow:
 
-```md
-sdd-create-feature -> sdd-plan-task -> sdd-review-plan -> Human Approval -> sdd-implement-task -> Feature Exit
+```mermaid
+flowchart TD
+    A["Investigation"] --> B["Feature Creation<br/>sdd-create-feature"]
+    B --> C["Planning<br/>sdd-plan-task"]
+    C --> D["Plan Review<br/>sdd-review-plan"]
+    D --> E["Human Approval<br/>required before implementation"]
+    E --> F["Implementation<br/>sdd-implement-task"]
+    F --> G["Completion Approval"]
+    G --> H["Feature Exit Review<br/>sdd-plan-task Feature Exit Mode"]
+    H --> I["Feature Close"]
+    F -. "exception only: new slice, scope change, design decision,<br/>wider impact, or approval-boundary change" .-> C
 ```
+
+Human Approval is required before implementation starts. Replanning is an
+exception flow, not the normal path between approved implementation slices.
+Feature Exit runs only after the Feature Definition of Done is satisfied.
 
 For non-trivial changes:
 
@@ -140,21 +153,9 @@ Every agent must preserve:
 - approved scope boundaries
 - required validation
 
-Keep feature documents decision-focused:
-
-- use `docs/specs/plans.md` for active feature folders, branch-wide
-  assumptions, and repository sequencing that applies across features
-- use feature `SPECS.md` for feature-level functional requirements,
-  compatibility constraints, acceptance criteria, and non-goals
-- use feature `TASKS.md` for the implementation-slice plan, approval state,
-  validation expectations, production readiness, unresolved risks, and feature
-  exit readiness
-- use feature `TRACEABILITY.md` when required to map use cases or requirements
-  through `SPECS.md`, implementation slices, and tests or validation plans
-- move durable behavior contracts to `docs/requirements/use-cases/`
-- move repository-level sequence changes to `roadmap.md`
-- remove implementation history once it no longer affects future approval,
-  risk, traceability, or durable documentation
+Keep feature documents decision-focused and follow the Document Roles section
+below as the Single Source of Truth. Remove implementation history once it no
+longer affects future approval, risk, traceability, or durable documentation.
 
 Copilot suggestions must be checked against the approved `SPECS.md`,
 `TASKS.md`, and approved scope before adoption. Do not accept Copilot
@@ -258,23 +259,8 @@ follow-up decision.
 ## Impact Investigation Records
 
 Use the SDD artifacts by responsibility instead of storing all investigation
-notes in feature documents.
-
-- `docs/specs/plans.md`:
-  branch-level work plan: active feature folders, branch-wide assumptions, and
-  repository sequencing that applies across features. Do not rewrite it for
-  slice-level progress inside an already active feature.
-- `docs/specs/features/<feature>/SPECS.md`:
-  feature-level functional requirements, compatibility requirements,
-  acceptance criteria, and non-goals
-- `docs/specs/features/<feature>/TASKS.md`:
-  implementation-slice plan, approval state, validation expectations,
-  production readiness, unresolved risks, and feature exit readiness
-- `docs/specs/features/<feature>/TRACEABILITY.md`:
-  required mapping from use case or requirement through `SPECS.md`,
-  implementation slice, and test or validation plan
-- `docs/requirements/use-cases/`:
-  durable behavior contracts and observable scenario changes
+notes in feature documents. See Document Roles below for the authoritative
+responsibility boundaries.
 
 `TASKS.md` is not a historical work log. After a slice is completed,
 re-scoped, or dropped, reduce the record to what still affects future
@@ -453,9 +439,37 @@ When syncing, preserve decision context instead of accumulating entries:
 
 ## Document Roles
 
-- `vision.md`: product purpose and values
-- `glossary.md`: shared terms
-- `context-map.md`: boundaries and external systems
-- `architecture.md`: target layering and dependency direction
-- `roadmap.md`: preferred incremental extraction order
-- `features/_templates/`: templates for new repository-native feature docs
+This section is the Single Source of Truth for SDD document responsibilities.
+Other repository docs should link here instead of repeating these details.
+
+- `vision.md`: product purpose and values.
+- `glossary.md`: shared terms.
+- `context-map.md`: boundaries and external systems.
+- `architecture.md`: target layering and dependency direction.
+- `features/_templates/`: templates for new repository-native feature docs.
+- `docs/requirements/use-cases/`: durable behavior contracts and observable
+  scenario changes that remain meaningful when modules, adapters, or file
+  layout change.
+- `docs/specs/features/<feature>/SPECS.md`: feature-level requirements,
+  boundaries, compatibility constraints, acceptance criteria, and non-goals.
+- `docs/specs/features/<feature>/TASKS.md`: the full implementation-slice
+  plan, slice order, dependencies, approval state, validation expectations,
+  production readiness, unresolved risks, and feature exit readiness.
+- `docs/specs/features/<feature>/TRACEABILITY.md`: required mapping from use
+  case or requirement through `SPECS.md`, implementation slice, and test or
+  validation plan.
+- `docs/specs/plans.md`: current branch work management. Keep active features,
+  current priorities, unfinished work, and the next intended action here.
+  Do not keep completed slice history, implementation logs, work diaries,
+  resolved issues, or information used only after feature closure here.
+- `docs/specs/roadmap.md`: repository-wide medium- and long-term planning.
+  Keep future features, repository direction, and planned improvements here.
+  Do not keep current branch work, feature progress, slice history, or
+  implementation status here.
+- `README.md`: repository entry point, user/developer overview, setup, basic
+  commands, and links to detailed docs.
+- `AGENTS.md`: agent-facing repository rules, architecture constraints, and
+  routing entry point.
+
+`docs/specs/plans.md` and `docs/specs/roadmap.md` are not places to store
+implementation history.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -22,37 +22,33 @@ repository.
 
 ## Working Agreement
 
+SDD is the standard process for non-trivial changes. Use the Codex SDD skills
+as the operational workflow:
+
+```md
+sdd-create-feature -> sdd-plan-task -> sdd-review-plan -> Human Approval -> sdd-implement-task -> Feature Exit
+```
+
 For non-trivial changes:
 
-1. create a dedicated git branch before implementation work starts
-   and use `docs/...` only for docs-only slices
-2. prefer quality assurance, KISS, DRY/YAGNI, then SOLID in that order;
-   do not add abstractions unless they reduce real complexity
-3. update or create the relevant use-case spec in
-   `docs/requirements/use-cases/` when the behavior contract changes
-4. update or create concise feature docs under
-   `docs/specs/features/<feature>/` when feature-level functional
-   requirements or current task decisions need tracking
-5. track execution tasks in `docs/specs/features/<feature>/TASKS.md`
-   and update that file in the same commit whenever a task is completed,
-   reframed, or dropped
-   `TASKS.md` is not a complete work log; retain only the task state,
-   approval boundary, unresolved risk, and use-case back-propagation notes
-   that future maintainers need for the next decision
-6. document assumptions explicitly
-7. implement in small vertical slices
-8. refresh `docs/specs/plans.md` only when the branch starts, stops, or
-   changes an active feature; slice progress stays in the feature `TASKS.md`
-9. refresh `docs/specs/roadmap.md` in the same commit if a completed slice
-   changes repository-level ordering, remaining debt, or deferred work
-10. before `git push`, run local validation through `rtk` serially in this
-    order for code changes: `rtk pnpm run qlty`, `rtk pnpm test`,
-    `rtk pnpm run test:web`, `rtk pnpm run build`
-11. run any additional task-specific checks before finishing
-12. avoid anemic domain models: extract only cross-unit or cross-layer
-    semantics into helpers/interfaces, and keep entity identity plus
-    unit-local behavior in the entity when that behavior is part of the
-    JP1/AJS concept itself
+1. create a dedicated git branch before implementation work starts and use
+   `docs/...` only for docs-only slices
+2. start feature intake with `sdd-create-feature`
+3. create or revise the full implementation-slice plan with `sdd-plan-task`
+   in exactly one mode: Planning Mode, Replanning Mode, or Feature Exit Mode
+4. review the plan with `sdd-review-plan`
+5. obtain clear Human Approval before editing runtime code, tests, generated
+   artifacts, or configuration
+6. implement only approved slices with `sdd-implement-task`
+7. return to `sdd-plan-task` only when a new slice, scope change, design
+   decision, wider impact, approval-boundary change, or Feature Exit review is
+   required
+8. close a feature only after Feature Exit Mode confirms the Feature
+   Definition of Done
+
+Prefer quality assurance, readability, KISS, DRY/YAGNI, then SOLID in that
+order. Do not add abstractions unless they reduce real complexity. Keep diffs
+inside the approved slice scope.
 
 For docs-only changes:
 
@@ -146,25 +142,19 @@ Every agent must preserve:
 
 Keep feature documents decision-focused:
 
-- use `docs/specs/plans.md` for the branch work plan: active feature folders,
-  branch-wide assumptions, and repository sequencing that applies across
-  features
-- do not update `docs/specs/plans.md` only because a slice inside an already
-  active feature starts, finishes, or changes approval state
+- use `docs/specs/plans.md` for active feature folders, branch-wide
+  assumptions, and repository sequencing that applies across features
 - use feature `SPECS.md` for feature-level functional requirements,
   compatibility constraints, acceptance criteria, and non-goals
-- do not use feature `SPECS.md` for individual task records, slice histories,
-  approval logs, qlty metric transcripts, or implementation checklists
-- keep feature `TASKS.md` limited to the current status, active tasks, current
-  approval state, unresolved risks, and the minimum record needed to decide
-  whether a completed or active task must be reflected back into a use case
-- remove prior implementation, approval, and validation details once they no
-  longer affect a future decision, re-approval boundary, unresolved risk, or
-  use-case update
+- use feature `TASKS.md` for the implementation-slice plan, approval state,
+  validation expectations, production readiness, unresolved risks, and feature
+  exit readiness
+- use feature `TRACEABILITY.md` when required to map use cases or requirements
+  through `SPECS.md`, implementation slices, and tests or validation plans
 - move durable behavior contracts to `docs/requirements/use-cases/`
 - move repository-level sequence changes to `roadmap.md`
-- summarize validation expectations in `TASKS.md`; include past run details
-  only when a failure, warning, or risk remains actionable
+- remove implementation history once it no longer affects future approval,
+  risk, traceability, or durable documentation
 
 Copilot suggestions must be checked against the approved `SPECS.md`,
 `TASKS.md`, and approved scope before adoption. Do not accept Copilot
@@ -214,7 +204,8 @@ While approval is pending, Codex may only:
 - organize alternatives
 - present the approval request
 
-Each feature `TASKS.md` must include only the current approval evidence:
+Each feature `TASKS.md` must include approval evidence for the approved plan
+or active slice:
 
 ```md
 ## Human Approval
@@ -228,11 +219,10 @@ Each feature `TASKS.md` must include only the current approval evidence:
 current conversation`; do not copy the human approval message into `TASKS.md`.
 
 Implementation may start only when `Status: Approved`, `Approved at`, and
-`Approved scope` record the human-approved implementation boundary. Reset the
-section back to `Pending` when that approved slice is finished and no active
-implementation approval remains. If implementation reveals required changes
-outside the approved scope, stop again, update the impact record, and obtain
-additional clear approval before editing those areas.
+`Approved scope` record the human-approved implementation boundary for the
+slice. If implementation reveals required changes outside the approved scope,
+stop, use `sdd-plan-task` Replanning Mode, update the impact record, and
+obtain additional clear approval before editing those areas.
 
 Before approval, Codex must report only this implementation-gate output and
 must not claim that implementation has started or completed:
@@ -257,19 +247,10 @@ generated artifacts, or configuration.
 Implementation will not proceed until approval is given.
 ```
 
-After approval, expand the investigation into a complete reference impact
-check, list every required fix, and task the work before implementation.
-Use Serena or another semantic code navigation tool when available to verify
-affected references, call sites, transitive references, and dependency impact.
-Do not finish with only a subset of affected references updated.
-
-Implementation should then proceed in small meaningful blocks:
-
-1. implement one coherent block
-2. compile or run the closest fast check
-3. repair affected references in order
-4. run relevant unit tests
-5. after all fixes, run non-unit validation required by the change
+After approval, `sdd-implement-task` implements exactly one approved slice.
+Implementation should use staged validation: nearest fast check, related
+tests, qlty, needed web tests, and build only when required for final
+confidence.
 
 Do not leave failing checks unexplained or deferred without an explicit
 follow-up decision.
@@ -287,17 +268,17 @@ notes in feature documents.
   feature-level functional requirements, compatibility requirements,
   acceptance criteria, and non-goals
 - `docs/specs/features/<feature>/TASKS.md`:
-  current execution tasks, current approval evidence, unresolved risks, and
-  the minimum notes needed to decide whether behavior must be reflected back
-  into `docs/requirements/use-cases/`
+  implementation-slice plan, approval state, validation expectations,
+  production readiness, unresolved risks, and feature exit readiness
+- `docs/specs/features/<feature>/TRACEABILITY.md`:
+  required mapping from use case or requirement through `SPECS.md`,
+  implementation slice, and test or validation plan
 - `docs/requirements/use-cases/`:
   durable behavior contracts and observable scenario changes
 
-`TASKS.md` may temporarily hold approval-sensitive investigation details while
-the task is active. After the task is completed, re-scoped, or dropped, reduce
-the record to only what still affects future approval, risk, or use-case
-back-propagation. It is not the primary record for design decisions, impact
-analysis, or historical narrative.
+`TASKS.md` is not a historical work log. After a slice is completed,
+re-scoped, or dropped, reduce the record to what still affects future
+approval, risk, traceability, production readiness, or feature exit.
 
 When behavior scenarios exist, include the scenario impact in the same
 investigation: changed scenarios, added scenarios, removed scenarios, and
@@ -390,11 +371,54 @@ Those belong under `docs/specs/`.
 
 ## When To Remove Feature Docs
 
-Remove a `docs/specs/features/<feature>/` folder when it no longer carries an
-active feature requirement, active task decision, unresolved risk, or useful
-follow-up. Preserve completed refactor-only information in `roadmap.md`,
-`plans.md`, or use cases only when it helps future sequencing, risk
-assessment, ownership decisions, or behavior understanding.
+Remove a `docs/specs/features/<feature>/` folder only in Feature Exit Mode
+after the Feature Definition of Done passes and the human approves closure.
+Preserve information in durable docs only when it passes the Durable
+Documentation Gate.
+
+## Feature Definition Of Done
+
+A feature is complete only when:
+
+- every implementation slice is complete
+- feature requirements and acceptance criteria are satisfied
+- required validation is complete
+- non-functional quality and production readiness are preserved or justified
+- required `TRACEABILITY.md` updates are complete, or not required with a
+  clear reason
+- durable use-case, `plans.md`, and `roadmap.md` updates are complete when
+  needed
+- unresolved risks are resolved, accepted, or recorded as follow-up
+
+## Durable Documentation Gate
+
+Before updating long-lived docs, verify the content:
+
+- is reusable beyond one feature
+- describes durable behavior, specification, design policy, or repository
+  operating policy
+- helps future planning or implementation
+- does not duplicate another durable document
+- is not a temporary investigation result
+- is not implementation history
+- is not review commentary
+- is not a record of a resolved issue
+
+Update the smallest necessary durable document surface.
+
+## Production Readiness Gate
+
+For code slices, confirm:
+
+- failure modes are intentional
+- user-facing errors, diagnostics, or fallback behavior are understandable
+- existing JP1/AJS definition files remain compatible unless explicitly
+  changed by the approved scope
+- large, malformed, or edge-case inputs avoid preventable slowdowns or crashes
+- desktop and web behavior are considered
+- README or user docs are updated only when user-facing behavior changes
+- CHANGELOG update need is evaluated for user-facing behavior, compatibility,
+  or workflow changes
 
 ## Sync Cadence
 
@@ -402,9 +426,11 @@ Treat the following docs as required sync artifacts, not optional catch-up
 notes:
 
 - `docs/specs/features/<feature>/TASKS.md`
-  Update immediately when one task or follow-up is completed, re-scoped, or
-  intentionally dropped, then remove details that no longer affect approval,
-  risk, or use-case back-propagation.
+  Update when the implementation-slice plan, approval state, slice status,
+  validation, risk, or feature exit readiness changes.
+- `docs/specs/features/<feature>/TRACEABILITY.md`
+  Update when required traceability changes or when an implemented slice's
+  validation result must be reflected.
 - `docs/specs/plans.md`
   Update only when the branch starts, stops, or changes an active feature.
 - `docs/specs/roadmap.md`
@@ -412,7 +438,7 @@ notes:
   debt, or deferred work.
 
 Prefer the smallest useful cadence:
-one completed task or one resolved follow-up is enough reason to sync the
+one completed slice or one resolved follow-up is enough reason to sync the
 docs in the same commit.
 
 When syncing, preserve decision context instead of accumulating entries:
@@ -420,8 +446,8 @@ When syncing, preserve decision context instead of accumulating entries:
 - remove or rewrite completed checklist/history sections when they no longer
   help future maintainers understand the current state, remaining risk, next
   decision, or required use-case update
-- keep `TASKS.md` readable from the top so the current approval state, active
-  tasks, and next decision are immediately visible
+- keep `TASKS.md` readable from the top so the plan status, approval state,
+  active slice, and next decision are immediately visible
 - keep feature `SPECS.md` readable as functional requirements rather than as a
   task archive
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -42,6 +42,30 @@ Human Approval is required before implementation starts. Replanning is an
 exception flow, not the normal path between approved implementation slices.
 Feature Exit runs only after the Feature Definition of Done is satisfied.
 
+## Trivial Change Criteria
+
+Use this section as the Single Source of Truth for deciding whether SDD feature
+creation may be skipped.
+
+A change is trivial only when it does not change any of these:
+
+- runtime behavior
+- tests or validation expectations
+- generated artifacts
+- configuration
+- desktop, web, VS Code, JP1/AJS, or definition-file compatibility
+- durable documentation responsibilities or document roles
+
+Examples that may be trivial:
+
+- typo fixes
+- formatting-only markdown cleanup
+- comment wording that does not change behavior, policy, or responsibility
+- broken link fixes that do not change document meaning
+
+When any item above changes, or when impact is uncertain, treat the work as
+non-trivial and start with `sdd-create-feature`.
+
 For non-trivial changes:
 
 1. create a dedicated git branch before implementation work starts and use
@@ -73,6 +97,33 @@ For docs-only changes:
 
 Run validation commands through `rtk` by default. `rtk` is a cost-control and
 execution-efficiency tool; it is not a reason to skip required validation.
+
+## CHANGELOG Update Criteria
+
+Use this section as the Single Source of Truth for deciding whether a
+CHANGELOG update is required.
+
+Update `CHANGELOG.md` when a change affects externally observable extension
+behavior, including:
+
+- user-visible behavior
+- compatibility
+- commands
+- configuration
+- diagnostics
+- user workflow
+- documented extension behavior
+
+Do not update `CHANGELOG.md` for changes that are only:
+
+- internal refactoring
+- implementation cleanup
+- tests with no externally observable behavior change
+- documentation maintenance that does not change documented extension behavior
+- other changes with no externally observable behavior
+
+When uncertain, record the evaluation in the feature plan or implementation
+summary and ask for the human decision before closing the slice or feature.
 
 ## Semantic Code Navigation
 
@@ -376,6 +427,28 @@ A feature is complete only when:
   needed
 - unresolved risks are resolved, accepted, or recorded as follow-up
 
+## Feature Exit Review Output
+
+Report Feature Exit Review using this standard output:
+
+```md
+## Feature Exit Review
+
+- Feature:
+- Completed slices:
+- Acceptance status:
+- Validation:
+- Traceability:
+- Production readiness:
+- Durable documentation:
+- Remaining risks:
+- Closure recommendation: Close | Do not close | Human decision needed
+```
+
+Use `Closure recommendation: Close` only when the Feature Definition of Done is
+satisfied. Use `Human decision needed` when the evidence is complete but the
+closure decision still requires explicit approval.
+
 ## Durable Documentation Gate
 
 Before updating long-lived docs, verify the content:
@@ -403,8 +476,7 @@ For code slices, confirm:
 - large, malformed, or edge-case inputs avoid preventable slowdowns or crashes
 - desktop and web behavior are considered
 - README or user docs are updated only when user-facing behavior changes
-- CHANGELOG update need is evaluated for user-facing behavior, compatibility,
-  or workflow changes
+- CHANGELOG update need is evaluated using the CHANGELOG Update Criteria
 
 ## Sync Cadence
 

--- a/docs/specs/features/_templates/ADR.template.md
+++ b/docs/specs/features/_templates/ADR.template.md
@@ -39,7 +39,8 @@ Explain why this option was chosen.
 
 ## Related Documents
 
-- {{PLANS.md}}
-- {{SPECS.md}}
-- {{TASKS.md}}
-- {{Use Case}}
+- Branch plan: {{docs/specs/plans.md}}
+- Feature spec: {{SPECS.md}}
+- Slice plan: {{TASKS.md}}
+- Traceability: {{TRACEABILITY.md or "not required"}}
+- Use case: {{Use Case}}

--- a/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
+++ b/docs/specs/features/_templates/CODEX_IMPLEMENTATION_PROMPT.template.md
@@ -8,7 +8,6 @@ Feature:
 Read these documents first:
 
 - docs/requirements/use-cases/{{use-case-file}}.md
-- docs/specs/features/{{feature-slug}}/PLANS.md
 - docs/specs/features/{{feature-slug}}/SPECS.md
 - docs/specs/features/{{feature-slug}}/TASKS.md
 - docs/specs/features/{{feature-slug}}/ADR.md if present
@@ -24,7 +23,7 @@ Implementation rules:
    commits, implementation refactors, or incidental fixes.
 5. Stop for clear human approval before implementation.
 6. After approval, enumerate all affected references and track the complete fix.
-7. Follow TASKS.md in small safe steps.
+7. Implement exactly one approved TASKS.md slice.
 8. Do not rewrite unrelated code.
 9. Preserve existing behavior unless SPECS.md explicitly changes it.
 10. Respect DDD and Clean Architecture boundaries.
@@ -53,10 +52,13 @@ Before editing:
   branch starts, stops, or changes an active feature.
 - Record durable impact, propagation, alternatives, and boundary decisions in
   SPECS.md.
-- Record investigation, implementation, test, and follow-up tasks in TASKS.md.
+- Record implementation-slice plan, validation, risk, production readiness,
+  approval state, and feature exit readiness in TASKS.md.
+- Update TRACEABILITY.md when required.
 - Record the TASKS.md `Human Approval` section with `Status: Pending`.
-- Keep TASKS.md focused on current status and active tasks; do not accumulate
-  historical logs, prior approvals, or long validation histories there.
+- Keep TASKS.md focused on slice plan/status, approval, validation, risks, and
+  feature exit readiness; do not accumulate historical logs, prior approvals,
+  or long validation histories there.
 - Report only this approval request, then wait for approval:
 
 ```md
@@ -104,4 +106,5 @@ After editing:
 - Run available build/test commands through `rtk` by default.
 - Summarize changed files.
 - Summarize behavior compatibility.
+- Summarize production readiness and CHANGELOG impact.
 - List follow-up tasks.

--- a/docs/specs/features/_templates/CODEX_SDD_PROMPT.template.md
+++ b/docs/specs/features/_templates/CODEX_SDD_PROMPT.template.md
@@ -6,7 +6,6 @@ Follow the existing repository documentation structure:
 
 - docs/specs/roadmap.md
 - docs/requirements/use-cases/\_template.md
-- docs/specs/features/\_templates/PLANS.template.md
 - docs/specs/features/\_templates/SPECS.template.md
 - docs/specs/features/\_templates/TASKS.template.md
 - docs/specs/features/\_templates/ADR.template.md
@@ -27,11 +26,11 @@ Instructions:
 3. Create feature documents under:
    docs/specs/features/{{feature-slug}}/
 4. Generate:
-   - PLANS.md
    - SPECS.md
    - TASKS.md
    - ADR.md if an architectural decision is needed
-   - TRACEABILITY.md if requirements mapping is useful
+   - TRACEABILITY.md when required for use case / requirement / slice /
+     validation mapping
 5. Keep documents concise, repository-specific, and implementation-ready.
 6. Align with DDD and Clean Architecture.
 7. Preserve VS Code compatibility declared in `package.json` when relevant.

--- a/docs/specs/features/_templates/SPECS.template.md
+++ b/docs/specs/features/_templates/SPECS.template.md
@@ -7,7 +7,8 @@
 ## Origin
 
 - Source use case: {{docs/requirements/use-cases/uc-*.md}}
-- Related plan: {{PLANS.md}}
+- Branch plan: {{docs/specs/plans.md}}
+- Implementation-slice plan: {{TASKS.md}}
 
 ## Requirements
 

--- a/docs/specs/features/_templates/TASKS.template.md
+++ b/docs/specs/features/_templates/TASKS.template.md
@@ -13,7 +13,8 @@
 
 ## Plan Status
 
-- Status: Proposed | Review Needed | Pending Approval | Approved | In Progress | Replan Required | Complete
+- Status: Proposed | Review Needed | Pending Approval | Approved | In Progress |
+  Replan Required | Complete
 - Planning scope:
 - Review status:
 - Human approval:

--- a/docs/specs/features/_templates/TASKS.template.md
+++ b/docs/specs/features/_templates/TASKS.template.md
@@ -7,14 +7,17 @@
 - Update `docs/specs/plans.md` only when the branch starts, stops, or changes
   an active feature.
 - Update `docs/specs/roadmap.md` when repository sequencing changes.
-- Keep this file focused on current state only; do not retain historical logs,
+- Keep this file focused on the implementation-slice plan, approval state,
+  validation, risk, and feature exit readiness. Do not retain historical logs,
   prior approvals, or long validation diaries once they stop being actionable.
 
-## Current Status
+## Plan Status
 
-- Runtime status:
-- Active slice:
-- Open follow-up:
+- Status: Proposed | Review Needed | Pending Approval | Approved | In Progress | Replan Required | Complete
+- Planning scope:
+- Review status:
+- Human approval:
+- Active implementation slice:
 
 ## Human Approval
 
@@ -30,14 +33,38 @@ current conversation`; do not copy the approval message.
 Reset this section back to Pending when the approved slice is complete and no
 active implementation approval remains.
 
-## Active Tasks
+## Implementation Slices
 
-- [ ] Impact investigation completed and recorded in PLANS/SPECS/TASKS by
-      responsibility
-- [ ] Human approval recorded
-- [ ] Implementation scope matches approved scope
-- [ ] Fix targets tracked to completion
-- [ ] {{implementation task}}
+### Slice 1: {{slice name}}
+
+- Status: Proposed | Approved | In Progress | Complete | Blocked | Replan Required
+- Scope:
+- User / Domain Value:
+- Cohesive Change Group:
+- Acceptance:
+- Validation:
+- Production Readiness:
+  - Failure mode:
+  - JP1/AJS compatibility:
+  - Large or malformed input risk:
+  - Desktop/web impact:
+  - README/docs impact:
+  - CHANGELOG impact:
+- Approval Boundary:
+- Dependencies:
+- Risks:
+- Out of Scope:
+
+## Traceability
+
+- TRACEABILITY.md required: yes | no
+- Reason:
+
+## Feature Exit
+
+- Definition of Done status:
+- Durable documentation updates:
+- Open risks:
 
 ## Validation
 
@@ -47,6 +74,6 @@ active implementation approval remains.
 
 ## Notes
 
-- Keep investigation details in PLANS.md or SPECS.md when they describe scope,
-  risk, alternatives, or boundary decisions.
-- Use this file for current executable tasks and open follow-up tracking only.
+- Keep feature requirements and boundary decisions in SPECS.md.
+- Use this file for implementation-slice planning, approval state, validation,
+  risk, and feature exit readiness only.

--- a/docs/specs/features/_templates/TRACEABILITY.template.md
+++ b/docs/specs/features/_templates/TRACEABILITY.template.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-Map the use case, behavioral scenarios, feature requirements, implementation,
-tasks, and tests when that mapping is not obvious from SPECS.md and TASKS.md
-alone.
+Map use cases or requirements to feature requirements, implementation slices,
+and tests or validation plans when that mapping is required by the SDD
+workflow.
 
 ## Mapping
 
@@ -12,9 +12,9 @@ alone.
 - Scenario: SCN-{{ID}}-1
 - Requirement: FR-{{ID}}
 - Spec: {{section}}
-- Implementation: {{path}}
-- Task: {{task}}
-- Test: TEST-{{ID}}
+- SPECS section: {{section}}
+- Implementation Slice: {{slice}}
+- Test file or validation plan: {{test-or-validation}}
 
 ## Coverage
 

--- a/docs/specs/features/import-definition-via-webapi/PLANS.md
+++ b/docs/specs/features/import-definition-via-webapi/PLANS.md
@@ -188,7 +188,7 @@ hover, or unit-definition features remains a follow-up integration slice.
   product version and tested scenario
 - enough user feedback is recorded to show that the supported read-only import
   path behaves predictably outside mock and local test environments
-- release notes or user documentation no longer need to warn that the feature
+- CHANGELOG or user documentation no longer need to warn that the feature
   has limited real-environment validation or limited beta feedback
 
 ## Validation

--- a/docs/specs/features/import-definition-via-webapi/SPECS.md
+++ b/docs/specs/features/import-definition-via-webapi/SPECS.md
@@ -36,7 +36,7 @@ Add a read-only JP1/AJS WebAPI import path for server-side definition data.
 - implement request, authentication, response, and error handling according to
   the JP1/AJS3 version 13 API chapters before adding repository-local
   assumptions
-- present the feature as beta in command labels, release notes, or user-facing
+- present the feature as beta in command labels, CHANGELOG, or user-facing
   documentation until the beta exit criteria are met
 - use OpenAPI as a derived, testable contract for the subset of JP1/AJS3 WebAPI
   endpoints this extension supports; do not treat it as a replacement for the

--- a/docs/specs/plans.md
+++ b/docs/specs/plans.md
@@ -27,8 +27,9 @@ rules in `docs/specs/README.md`, not in this file.
   folder. A new feature should be opened only when a finding maps to a
   meaningful responsibility or boundary concern.
 - Feature `SPECS.md` files carry feature requirements. Feature `TASKS.md` files
-  carry only current task state and the minimum record needed to decide whether
-  behavior must be reflected back into use cases.
+  carry implementation-slice plans, approval state, validation, risk, and
+  feature exit readiness. Feature `TRACEABILITY.md` files carry
+  requirement-to-validation mapping when required.
 - Desktop and web compatibility must stay explicit whenever bootstrap, preview,
   parsing, shared adapters, or runtime behavior change.
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -3,7 +3,8 @@
 ## Principles
 
 - Preserve behavior first.
-- Refactor in small vertical slices.
+- Refactor in meaningful implementation slices that can be reviewed, tested,
+  approved, and committed independently.
 - Prefer one use case per extraction.
 - Keep parser internals away from UI-facing components.
 - Keep active feature docs concise; remove completed feature-local folders after


### PR DESCRIPTION
## Summary
- align AGENTS.md, README, docs/specs, templates, and agent docs around SDD as the standard non-trivial development workflow
- add sdd-review-plan and expand SDD skills for planning modes, traceability, feature exit review, durable documentation, production readiness, and implementation feedback
- deduplicate SDD document-role details so docs/specs/README.md is the single source of truth
- add a Mermaid approval-flow diagram and clarify plans.md / roadmap.md responsibilities

## Validation
- rtk pnpm run qlty
- rtk pnpm run lint:md
- rtk git diff --check

## Notes
- quick_validate.py was not rerun because the local environment is missing PyYAML.