### PR TITLE
release: v1.17.0

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,6 +18,10 @@ antlr/
 # github
 .github/
 
+# repository tooling
+pnpm-workspace.yaml
+scripts/
+
 # vscode
 .vscode/
 .vscode-test/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [1.17.0] - 2026-08-09
+
 - Improved viewer opening failure handling so unavailable editors and host
   panel errors show safe messages without leaking raw exceptions or leaving a
   partially mounted panel.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-ajsbutler",
   "displayName": "JP1/AJS Butler - ジョブネット可視化",
   "description": "JP1/AJS3の定義ファイルを一覧・検索・フロー図で可視化するVS Code拡張機能",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Overview

This PR prepares the v1.17.0 release. The previous published release was `v1.16.0`; this is a minor release because it adds compatible, user-facing capabilities.

- Release tag: `v1.17.0`
- Tagged commit: `dbd06f3ef196035489d4830b800ef537d17433b2`
- VSIX: `vscode-ajsbutler-1.17.0.vsix` (22 files, 1.7 MB)

## Validation

| Check | Result | Notes |
| --- | --- | --- |
| `pnpm run qlty` | Passed | No issues |
| `pnpm run lint:md` | Passed | No issues |
| `pnpm run build` | Passed | Webpack bundle-size warnings only |
| `pnpm run test` | Passed | Desktop tests exited with code 0; macOS Electron emitted a codesign warning |
| `pnpm run test:web` | Passed | Exited with code 0; the web harness emitted EPIPE / premature-close shutdown logs |
| VSIX audit | Passed | Verified version, engine, README, CHANGELOG, and desktop/web bundles |

The VSIX excludes source, docs, tests, `.codex`, `.agents`, `scripts/`, and `pnpm-workspace.yaml`.

The package was created with `pnpm exec vsce package --no-dependencies`. The default dependency scan misclassifies this repository's pnpm layout through npm, while all runtime code is webpack-bundled.

## Release Gates

- Marketplace publication: waiting for `VSCE_PAT` or Azure publisher authentication
- Publish command: `pnpm exec vsce publish --packagePath vscode-ajsbutler-1.17.0.vsix`
- Merge method: use a merge commit so the `v1.17.0` commit remains reachable from `main`; do not squash or rebase
- GitHub rulesets: unchanged; no ruleset was edited, disabled, deleted, or manually bypassed
